### PR TITLE
Enable support for perl regular expressions (LIBPCRE)

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -525,6 +525,7 @@ ifneq (,$(wildcard ../THIS_IS_MSYSGIT))
 	INTERNAL_QSORT = YesPlease
 	HAVE_LIBCHARSET_H = YesPlease
 	NO_GETTEXT = YesPlease
+	USE_LIBPCRE= YesPlease
 else
 	NO_CURL = YesPlease
 endif


### PR DESCRIPTION
This enables us to compile git against libpcre.
And this makes thing like

```
git grep -P "\bpcre\b" HEAD
```

possible.
