### PR TITLE
t0027: Disable test on MINGW

### DIFF
--- a/t/t0021-conversion.sh
+++ b/t/t0021-conversion.sh
@@ -190,7 +190,7 @@ test_expect_success 'required filter clean failure' '
 	test_must_fail git add test.fc
 '
 
-test_expect_success EXPENSIVE 'filter large file' '
+test_expect_success EXPENSIVE,!MINGW 'filter large file' '
 	git config filter.largefile.smudge cat &&
 	git config filter.largefile.clean cat &&
 	for i in $(test_seq 1 2048); do printf "%1048576d" 1; done >2GB &&


### PR DESCRIPTION
We can't mmap 2GB of RAM on our 32bit platform, so
just disable the test.

This is a preparation for enabling EXPENSIVE.
