### PR TITLE
Prepare for more thorough testing when building in MinGW

### DIFF
--- a/t/t0027-auto-crlf.sh
+++ b/t/t0027-auto-crlf.sh
@@ -4,9 +4,9 @@ test_description='CRLF conversion all combinations'
 
 . ./test-lib.sh
 
-if ! test_have_prereq EXPENSIVE
+if ! test_have_prereq EXPENSIVE && ! test_have_prereq MINGW
 then
-	skip_all="EXPENSIVE not set"
+	skip_all="Neither EXPENSIVE nor MINGW set"
 	test_done
 fi
 


### PR DESCRIPTION
On Windows, we need to care a little bit more about certain things like line endings. Therefore it makes sense to run some tests by default that would otherwise require the `EXPENSIVE` flag. This topic branch does that and also incorporates more regression tests relevant for Windows.
