### PR TITLE
MINGW: install into /mingw/bin/ by default

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -518,7 +518,7 @@ ifneq (,$(findstring MINGW,$(uname_S)))
 	SPARSE_FLAGS = -Wno-one-bit-signed-bitfield
 ifneq (,$(wildcard ../THIS_IS_MSYSGIT))
 	htmldir = share/doc/git/$(firstword $(subst -, ,$(GIT_VERSION)))/html
-	prefix =
+	prefix = /mingw/
 	INSTALL = /bin/install
 	EXTLIBS += /mingw/lib/libz.a
 	NO_R_TO_GCC_LINKER = YesPlease


### PR DESCRIPTION
In msysGit, we collapsed all bin/ directories into one, so it made sense
to install Git into /bin/ right away.

With the new Git for Windows SDK, we want to clean that up a little and be
more standards-compliant. In particular, we will use most of MinGW as-is,
and provide Git as a proper MinGW package. So let's install the files into
the correct place.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
