### PR TITLE
Adjust README.md to reflect the new Git for Windows home

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Git for Windows
 
-This is the source code of [Git for Windows](http://msysgit.github.io/),
+This is the source code of [Git for Windows](http://git-for-windows.github.io/),
 forked from [Git](http://git-scm.com/).
 
-If you encounter problems, you can report them as [GitHub issues](https://github.com/msysgit/git/issues?direction=desc&sort=updated&state=open), discuss them on Git for Windows' [Google Group](http://groups.google.com/group/msysgit), and encourage others to work on by tipping via [![tip for next commit](http://tip4commit.com/projects/295.svg)](http://tip4commit.com/projects/295).
+If you encounter problems, you can report them as [GitHub issues](https://github.com/git-for-windows/git/issues), discuss them on Git for Windows' [Google Group](http://groups.google.com/group/git-for-windows), and [contribute bug fixes](https://github.com/git-for-windows/git/wiki/How-to-participate#fix-bugs-or-add-features-in-the-git-code-itself).


### PR DESCRIPTION
Git for Windows switched orgs, to reflect the fact that msysGit is no
longer used to develop the project, but instead the Git for Windows SDK.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
