### PR TITLE
Embed a manifest into git.exe

### DIFF
--- a/compat/win32/git.manifest
+++ b/compat/win32/git.manifest
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+        <assemblyIdentity type="win32" name="Git" version="0.0.0.1" />
+        <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+                <security>
+                        <requestedPrivileges>
+                                <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+                        </requestedPrivileges>
+                </security>
+        </trustInfo>
+</assembly>

--- a/git.rc
+++ b/git.rc
@@ -20,3 +20,5 @@ BEGIN
     VALUE "Translation", 0x409, 1200
   END
 END
+
+1 RT_MANIFEST "compat/win32/git.manifest"


### PR DESCRIPTION
Just like it is done in https://github.com/git-for-windows/MSYS2-packages/blob/master/git/git-1.9.0-manifest-msys2.patch, we should embed the manifest by default (instead of using external `.manifest` files, as we used to).

That linked patch should be simplified a little bit, e.g. by adding `$(RESOURCE_OBJS)` to `$(GITLIBS)` to avoid touching so many lines at once.