### PR TITLE
squash! Port header fixes from MSys2

### DIFF
--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -99,8 +99,10 @@ static inline int symlink(const char *oldpath, const char *newpath)
 { errno = ENOSYS; return -1; }
 static inline int fchmod(int fildes, mode_t mode)
 { errno = ENOSYS; return -1; }
+#ifndef __MINGW64_VERSION_MAJOR
 static inline pid_t fork(void)
 { errno = ENOSYS; return -1; }
+#endif
 static inline unsigned int alarm(unsigned int seconds)
 { return 0; }
 static inline int fsync(int fd)
@@ -390,8 +392,10 @@ static inline char *mingw_find_last_dir_sep(const char *path)
 int mingw_offset_1st_component(const char *path);
 #define offset_1st_component mingw_offset_1st_component
 #define PATH_SEP ';'
+#ifndef __MINGW64_VERSION_MAJOR
 #define PRIuMAX "I64u"
 #define PRId64 "I64d"
+#endif
 
 void mingw_open_html(const char *path);
 #define open_html mingw_open_html


### PR DESCRIPTION
Replace the commit message with this one:

Assorted header fixes to support MSys2-based MinGW build

The excellent MSys2 project brings a substantially updated MinGW
environment including newer GCC versions and new headers. To support
compiling Git, let's special-case the new MinGW (tell-tale: the
_MINGW_MAJOR_MINOR constant is defined).

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>