### PR TITLE
Teach msys2-runtime to hand the tty through to Git

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -6,6 +6,8 @@
 #include "../run-command.h"
 #include "../cache.h"
 
+#undef isatty
+
 static const int delay[] = { 0, 1, 10, 20, 40 };
 unsigned int _CRT_fmode = _O_BINARY;
 
@@ -2286,4 +2288,39 @@ void mingw_startup()
 
 	/* init length of current directory for handle_long_path */
 	current_directory_len = GetCurrentDirectoryW(0, NULL);
+}
+
+int mingw_isatty(int fd) {
+	static DWORD id[] = {
+		STD_INPUT_HANDLE,
+		STD_OUTPUT_HANDLE,
+		STD_ERROR_HANDLE
+	};
+	static unsigned initialized;
+	static int is_tty[ARRAY_SIZE(id)];
+
+	if (fd < 0 || fd >= ARRAY_SIZE(is_tty))
+		return isatty(fd);
+
+	if (isatty(fd))
+		return 1;
+
+	if (!initialized) {
+		const char *env = getenv("MSYS_TTY_HANDLES");
+
+		if (env) {
+			int i;
+			char buffer[64];
+
+			for (i = 0; i < ARRAY_SIZE(is_tty); i++) {
+				sprintf(buffer, " %ld ", (unsigned long)
+					GetStdHandle(id[i]));
+				is_tty[i] = !!strstr(env, buffer);
+			}
+		}
+
+		initialized = 1;
+	}
+
+	return is_tty[fd];
 }

--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -367,6 +367,9 @@ sig_handler_t mingw_signal(int sig, sig_handler_t handler);
 int mingw_raise(int sig);
 #define raise mingw_raise
 
+int mingw_isatty(int fd);
+#define isatty mingw_isatty
+
 /*
  * ANSI emulation wrappers
  */

--- a/compat/winansi.c
+++ b/compat/winansi.c
@@ -7,6 +7,8 @@
 #include <wingdi.h>
 #include <winreg.h>
 
+#undef isatty
+
 /*
  ANSI codes used by git: m, K
 


### PR DESCRIPTION
When we were using `winpty`, the `git log` command called the pager correctly. However, without using `winpty` this is not the case. Most likely, there is a way to teach the `msys2-runtime` to special-case `git.exe` and pass the tty through so that Git knows that it is running inside a console.

Note: this is only an issue when not running in `cmd.exe`. However, we want to switch to a nicer terminal in the upcoming Git for Windows release.