### PR TITLE
mingw: cvs-test-fixes

### DIFF
--- a/t/t9400-git-cvsserver-server.sh
+++ b/t/t9400-git-cvsserver-server.sh
@@ -10,6 +10,14 @@ cvs CLI client via git-cvsserver server'
 
 . ./test-lib.sh
 
+if test_have_prereq MINGW
+then
+	# Avoid posix-to-windows path mangling
+	pwd () {
+		builtin pwd
+	}
+fi
+
 if ! test_have_prereq PERL; then
 	skip_all='skipping git cvsserver tests, perl not available'
 	test_done

--- a/t/t9401-git-cvsserver-crlf.sh
+++ b/t/t9401-git-cvsserver-crlf.sh
@@ -11,6 +11,14 @@ repository using cvs CLI client via git-cvsserver server'
 
 . ./test-lib.sh
 
+if test_have_prereq MINGW
+then
+	# Avoid posix-to-windows path mangling
+	pwd () {
+		builtin pwd
+	}
+fi
+
 marked_as () {
     foundEntry="$(grep "^/$2/" "$1/CVS/Entries")"
     if [ x"$foundEntry" = x"" ] ; then

--- a/t/t9402-git-cvsserver-refs.sh
+++ b/t/t9402-git-cvsserver-refs.sh
@@ -7,6 +7,14 @@ tags, branches and other git refspecs'
 
 . ./test-lib.sh
 
+if test_have_prereq MINGW
+then
+	# Avoid posix-to-windows path mangling
+	pwd () {
+		builtin pwd
+	}
+fi
+
 #########
 
 check_start_tree() {


### PR DESCRIPTION
The CVS tests expect `pwd` to return a POSIX-style directory. Let's skip
our MinGW-specific override to let `pwd` output a Windows-style directory
for that reason.