### PR TITLE
Use msysGit's `git-wrapper` instead of the builtins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1672,11 +1672,17 @@ version.sp version.s version.o: EXTRA_CPPFLAGS = \
 	'-DGIT_VERSION="$(GIT_VERSION)"' \
 	'-DGIT_USER_AGENT=$(GIT_USER_AGENT_CQ_SQ)'
 
+ifeq (,$(BUILT_IN_WRAPPER))
 $(BUILT_INS): git$X
 	$(QUIET_BUILT_IN)$(RM) $@ && \
 	ln $< $@ 2>/dev/null || \
 	ln -s $< $@ 2>/dev/null || \
 	cp $< $@
+else
+$(BUILT_INS): $(BUILT_IN_WRAPPER)
+	$(QUIET_BUILT_IN)$(RM) $@ && \
+	cp $< $@
+endif
 
 common-cmds.h: ./generate-cmdlist.sh command-list.txt
 
@@ -2239,6 +2245,24 @@ profile-install: profile
 profile-fast-install: profile-fast
 	$(MAKE) install
 
+ifeq (,$(BUILT_IN_WRAPPER))
+LN_OR_CP_BUILT_IN_BINDIR = \
+	test -z "$(NO_INSTALL_HARDLINKS)" && \
+	ln "$$bindir/git$X" "$$bindir/$$p" 2>/dev/null || \
+	ln -s "git$X" "$$bindir/$$p" 2>/dev/null || \
+	cp "$$bindir/git$X" "$$bindir/$$p" || exit;
+LN_OR_CP_BUILT_IN_EXECDIR = \
+	test -z "$(NO_INSTALL_HARDLINKS)" && \
+	ln "$$exectir/git$X" "$$exectir/$$p" 2>/dev/null || \
+	ln -s "git$X" "$$exectir/$$p" 2>/dev/null || \
+	cp "$$exectir/git$X" "$$exectir/$$p" || exit;
+else
+LN_OR_CP_BUILT_IN_BINDIR = \
+	cp "$(BUILT_IN_WRAPPER)" "$$bindir/$$p" || exit;
+LN_OR_CP_BUILT_IN_EXECDIR = \
+	cp "$(BUILT_IN_WRAPPER)" "$$execdir/$$p" || exit;
+endif
+
 install: all
 	$(INSTALL) -d -m 755 '$(DESTDIR_SQ)$(bindir_SQ)'
 	$(INSTALL) -d -m 755 '$(DESTDIR_SQ)$(gitexec_instdir_SQ)'
@@ -2277,17 +2301,11 @@ endif
 	} && \
 	for p in $(filter $(install_bindir_programs),$(BUILT_INS)); do \
 		$(RM) "$$bindir/$$p" && \
-		test -z "$(NO_INSTALL_HARDLINKS)" && \
-		ln "$$bindir/git$X" "$$bindir/$$p" 2>/dev/null || \
-		ln -s "git$X" "$$bindir/$$p" 2>/dev/null || \
-		cp "$$bindir/git$X" "$$bindir/$$p" || exit; \
+		$(LN_OR_CP_BUILT_IN_BINDIR) \
 	done && \
 	for p in $(BUILT_INS); do \
 		$(RM) "$$execdir/$$p" && \
-		test -z "$(NO_INSTALL_HARDLINKS)" && \
-		ln "$$execdir/git$X" "$$execdir/$$p" 2>/dev/null || \
-		ln -s "git$X" "$$execdir/$$p" 2>/dev/null || \
-		cp "$$execdir/git$X" "$$execdir/$$p" || exit; \
+		$(LN_OR_CP_BUILT_IN_EXECDIR) \
 	done && \
 	remote_curl_aliases="$(REMOTE_CURL_ALIASES)" && \
 	for p in $$remote_curl_aliases; do \

--- a/compat/win32/git-wrapper.c
+++ b/compat/win32/git-wrapper.c
@@ -1,0 +1,199 @@
+/*
+ * git-wrapper - replace cmd\git.cmd with an executable
+ *
+ * Copyright (C) 2012 Pat Thoyts <patthoyts@users.sourceforge.net>
+ */
+
+#define STRICT
+#define WIN32_LEAN_AND_MEAN
+#define UNICODE
+#define _UNICODE
+#include <windows.h>
+#include <shlwapi.h>
+#include <shellapi.h>
+#include <stdio.h>
+
+static void
+PrintError(LPCWSTR wszPrefix, DWORD dwError)
+{
+    LPWSTR lpsz = NULL;
+    DWORD cch = 0;
+
+    cch = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER
+                         | FORMAT_MESSAGE_FROM_SYSTEM
+                         | FORMAT_MESSAGE_IGNORE_INSERTS,
+                         NULL, dwError, LANG_NEUTRAL,
+                         (LPTSTR)&lpsz, 0, NULL);
+    if (cch < 1) {
+        cch = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER
+                             | FORMAT_MESSAGE_FROM_STRING
+                             | FORMAT_MESSAGE_ARGUMENT_ARRAY,
+                             L"Code 0x%1!08x!",
+                             0, LANG_NEUTRAL, (LPTSTR)&lpsz, 0,
+                             (va_list*)&dwError);
+    }
+    fwprintf(stderr, L"%s: %s", wszPrefix, lpsz);
+    LocalFree((HLOCAL)lpsz);
+}
+
+int
+main(void)
+{
+    int r = 1, wait = 1;
+    WCHAR exepath[MAX_PATH], exe[MAX_PATH];
+    LPWSTR cmd = NULL, path2 = NULL, exep = exe;
+    UINT codepage = 0;
+    int len;
+
+    /* get the installation location */
+    GetModuleFileName(NULL, exepath, MAX_PATH);
+    PathRemoveFileSpec(exepath);
+    PathRemoveFileSpec(exepath);
+
+    /* set the default exe module */
+    wcscpy(exe, exepath);
+    PathAppend(exe, L"bin\\git.exe");
+
+    /* if not set, set TERM to msys */
+    if (GetEnvironmentVariable(L"TERM", NULL, 0) == 0) {
+        SetEnvironmentVariable(L"TERM", L"msys");
+    }
+
+    /* if not set, set PLINK_PROTOCOL to ssh */
+    if (GetEnvironmentVariable(L"PLINK_PROTOCOL", NULL, 0) == 0) {
+        SetEnvironmentVariable(L"PLINK_PROTOCOL", L"ssh");
+    }
+
+    /* set HOME to %HOMEDRIVE%%HOMEPATH% or %USERPROFILE%
+     * With roaming profiles: HOMEPATH is the roaming location and
+     * USERPROFILE is the local location
+     */
+    if (GetEnvironmentVariable(L"HOME", NULL, 0) == 0) {
+        LPWSTR e = NULL;
+        len = GetEnvironmentVariable(L"HOMEPATH", NULL, 0);
+        if (len == 0) {
+            len = GetEnvironmentVariable(L"USERPROFILE", NULL, 0);
+            if (len != 0) {
+                e = (LPWSTR)malloc(len * sizeof(WCHAR));
+                GetEnvironmentVariable(L"USERPROFILE", e, len);
+                SetEnvironmentVariable(L"HOME", e);
+                free(e);
+            }
+        } else {
+            int n;
+            len += GetEnvironmentVariable(L"HOMEDRIVE", NULL, 0);
+            e = (LPWSTR)malloc(sizeof(WCHAR) * (len + 2));
+            n = GetEnvironmentVariable(L"HOMEDRIVE", e, len);
+            GetEnvironmentVariable(L"HOMEPATH", &e[n], len-n);
+            SetEnvironmentVariable(L"HOME", e);
+            free(e);
+        }
+    }
+
+    /* extend the PATH */
+    len = GetEnvironmentVariable(L"PATH", NULL, 0);
+    len = sizeof(WCHAR) * (len + 2 * MAX_PATH);
+    path2 = (LPWSTR)malloc(len);
+    wcscpy(path2, exepath);
+    PathAppend(path2, L"bin;");
+    /* should do this only if it exists */
+    wcscat(path2, exepath);
+    PathAppend(path2, L"mingw\\bin;");
+    GetEnvironmentVariable(L"PATH", &path2[wcslen(path2)],
+                           (len/sizeof(WCHAR))-wcslen(path2));
+    SetEnvironmentVariable(L"PATH", path2);
+    free(path2);
+
+
+    /* fix up the command line to call git.exe
+     * We have to be very careful about quoting here so we just
+     * trim off the first argument and replace it leaving the rest
+     * untouched.
+     */
+    {
+        int wargc = 0, gui = 0;
+        LPWSTR cmdline = NULL;
+        LPWSTR *wargv = NULL, p = NULL;
+        cmdline = GetCommandLine();
+        wargv = CommandLineToArgvW(cmdline, &wargc);
+        cmd = (LPWSTR)malloc(sizeof(WCHAR) * (wcslen(cmdline) + MAX_PATH));
+        if (wargc > 1 && wcsicmp(L"gui", wargv[1]) == 0) {
+            wait = 0;
+            if (wargc > 2 && wcsicmp(L"citool", wargv[2]) == 0) {
+                wait = 1;
+                wcscpy(cmd, L"git.exe");
+            } else {
+                WCHAR script[MAX_PATH];
+                gui = 1;
+                wcscpy(script, exepath);
+                PathAppend(script, L"libexec\\git-core\\git-gui");
+                PathQuoteSpaces(script);
+                wcscpy(cmd, L"wish.exe ");
+                wcscat(cmd, script);
+                wcscat(cmd, L" --");
+                exep = NULL; /* find the module from the commandline */
+            }
+        } else {
+            wcscpy(cmd, L"git.exe");
+        }
+        /* find the first space after the initial parameter then append all */
+        p = wcschr(&cmdline[wcslen(wargv[0])], L' ');
+        if (p && *p) {
+            /* for git gui subcommands, remove the 'gui' word */
+            if (gui) {
+                while (*p == L' ') ++p;
+                p = wcschr(p, L' ');
+            }
+            if (p && *p)
+                wcscat(cmd, p);
+        }
+        LocalFree(wargv);
+    }
+
+    /* set the console to ANSI/GUI codepage */
+    codepage = GetConsoleCP();
+    SetConsoleCP(GetACP());
+
+    {
+        STARTUPINFO si;
+        PROCESS_INFORMATION pi;
+        BOOL br = FALSE;
+        ZeroMemory(&pi, sizeof(PROCESS_INFORMATION));
+        ZeroMemory(&si, sizeof(STARTUPINFO));
+        si.cb = sizeof(STARTUPINFO);
+        br = CreateProcess(exep,/* module: null means use command line */
+                           cmd,  /* modified command line */
+                           NULL, /* process handle inheritance */
+                           NULL, /* thread handle inheritance */
+                           TRUE, /* handles inheritable? */
+                           CREATE_UNICODE_ENVIRONMENT,
+                           NULL, /* environment: use parent */
+                           NULL, /* starting directory: use parent */
+                           &si, &pi);
+        if (br) {
+            if (wait)
+                WaitForSingleObject(pi.hProcess, INFINITE);
+            if (!GetExitCodeProcess(pi.hProcess, (DWORD *)&r))
+                PrintError(L"error reading exit code", GetLastError());
+            CloseHandle(pi.hProcess);
+        } else {
+            PrintError(L"error launching git", GetLastError());
+            r = 1;
+        }
+    }
+
+    free(cmd);
+
+    /* reset the console codepage */
+    SetConsoleCP(codepage);
+    ExitProcess(r);
+}
+
+/*
+ * Local variables:
+ * mode: c
+ * indent-tabs-mode: nil
+ * c-basic-offset: 4
+ * tab-width: 4
+ * End:
+ */

--- a/compat/win32/git-wrapper.c
+++ b/compat/win32/git-wrapper.c
@@ -20,17 +20,17 @@ PrintError(LPCWSTR wszPrefix, DWORD dwError)
     DWORD cch = 0;
 
     cch = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER
-                         | FORMAT_MESSAGE_FROM_SYSTEM
-                         | FORMAT_MESSAGE_IGNORE_INSERTS,
-                         NULL, dwError, LANG_NEUTRAL,
-                         (LPTSTR)&lpsz, 0, NULL);
+			 | FORMAT_MESSAGE_FROM_SYSTEM
+			 | FORMAT_MESSAGE_IGNORE_INSERTS,
+			 NULL, dwError, LANG_NEUTRAL,
+			 (LPTSTR)&lpsz, 0, NULL);
     if (cch < 1) {
-        cch = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER
-                             | FORMAT_MESSAGE_FROM_STRING
-                             | FORMAT_MESSAGE_ARGUMENT_ARRAY,
-                             L"Code 0x%1!08x!",
-                             0, LANG_NEUTRAL, (LPTSTR)&lpsz, 0,
-                             (va_list*)&dwError);
+	cch = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER
+			     | FORMAT_MESSAGE_FROM_STRING
+			     | FORMAT_MESSAGE_ARGUMENT_ARRAY,
+			     L"Code 0x%1!08x!",
+			     0, LANG_NEUTRAL, (LPTSTR)&lpsz, 0,
+			     (va_list*)&dwError);
     }
     fwprintf(stderr, L"%s: %s", wszPrefix, lpsz);
     LocalFree((HLOCAL)lpsz);
@@ -56,12 +56,12 @@ main(void)
 
     /* if not set, set TERM to msys */
     if (GetEnvironmentVariable(L"TERM", NULL, 0) == 0) {
-        SetEnvironmentVariable(L"TERM", L"msys");
+	SetEnvironmentVariable(L"TERM", L"msys");
     }
 
     /* if not set, set PLINK_PROTOCOL to ssh */
     if (GetEnvironmentVariable(L"PLINK_PROTOCOL", NULL, 0) == 0) {
-        SetEnvironmentVariable(L"PLINK_PROTOCOL", L"ssh");
+	SetEnvironmentVariable(L"PLINK_PROTOCOL", L"ssh");
     }
 
     /* set HOME to %HOMEDRIVE%%HOMEPATH% or %USERPROFILE%
@@ -69,25 +69,25 @@ main(void)
      * USERPROFILE is the local location
      */
     if (GetEnvironmentVariable(L"HOME", NULL, 0) == 0) {
-        LPWSTR e = NULL;
-        len = GetEnvironmentVariable(L"HOMEPATH", NULL, 0);
-        if (len == 0) {
-            len = GetEnvironmentVariable(L"USERPROFILE", NULL, 0);
-            if (len != 0) {
-                e = (LPWSTR)malloc(len * sizeof(WCHAR));
-                GetEnvironmentVariable(L"USERPROFILE", e, len);
-                SetEnvironmentVariable(L"HOME", e);
-                free(e);
-            }
-        } else {
-            int n;
-            len += GetEnvironmentVariable(L"HOMEDRIVE", NULL, 0);
-            e = (LPWSTR)malloc(sizeof(WCHAR) * (len + 2));
-            n = GetEnvironmentVariable(L"HOMEDRIVE", e, len);
-            GetEnvironmentVariable(L"HOMEPATH", &e[n], len-n);
-            SetEnvironmentVariable(L"HOME", e);
-            free(e);
-        }
+	LPWSTR e = NULL;
+	len = GetEnvironmentVariable(L"HOMEPATH", NULL, 0);
+	if (len == 0) {
+	    len = GetEnvironmentVariable(L"USERPROFILE", NULL, 0);
+	    if (len != 0) {
+		e = (LPWSTR)malloc(len * sizeof(WCHAR));
+		GetEnvironmentVariable(L"USERPROFILE", e, len);
+		SetEnvironmentVariable(L"HOME", e);
+		free(e);
+	    }
+	} else {
+	    int n;
+	    len += GetEnvironmentVariable(L"HOMEDRIVE", NULL, 0);
+	    e = (LPWSTR)malloc(sizeof(WCHAR) * (len + 2));
+	    n = GetEnvironmentVariable(L"HOMEDRIVE", e, len);
+	    GetEnvironmentVariable(L"HOMEPATH", &e[n], len-n);
+	    SetEnvironmentVariable(L"HOME", e);
+	    free(e);
+	}
     }
 
     /* extend the PATH */
@@ -100,7 +100,7 @@ main(void)
     wcscat(path2, exepath);
     PathAppend(path2, L"mingw\\bin;");
     GetEnvironmentVariable(L"PATH", &path2[wcslen(path2)],
-                           (len/sizeof(WCHAR))-wcslen(path2));
+			   (len/sizeof(WCHAR))-wcslen(path2));
     SetEnvironmentVariable(L"PATH", path2);
     free(path2);
 
@@ -111,43 +111,43 @@ main(void)
      * untouched.
      */
     {
-        int wargc = 0, gui = 0;
-        LPWSTR cmdline = NULL;
-        LPWSTR *wargv = NULL, p = NULL;
-        cmdline = GetCommandLine();
-        wargv = CommandLineToArgvW(cmdline, &wargc);
-        cmd = (LPWSTR)malloc(sizeof(WCHAR) * (wcslen(cmdline) + MAX_PATH));
-        if (wargc > 1 && wcsicmp(L"gui", wargv[1]) == 0) {
-            wait = 0;
-            if (wargc > 2 && wcsicmp(L"citool", wargv[2]) == 0) {
-                wait = 1;
-                wcscpy(cmd, L"git.exe");
-            } else {
-                WCHAR script[MAX_PATH];
-                gui = 1;
-                wcscpy(script, exepath);
-                PathAppend(script, L"libexec\\git-core\\git-gui");
-                PathQuoteSpaces(script);
-                wcscpy(cmd, L"wish.exe ");
-                wcscat(cmd, script);
-                wcscat(cmd, L" --");
-                exep = NULL; /* find the module from the commandline */
-            }
-        } else {
-            wcscpy(cmd, L"git.exe");
-        }
-        /* find the first space after the initial parameter then append all */
-        p = wcschr(&cmdline[wcslen(wargv[0])], L' ');
-        if (p && *p) {
-            /* for git gui subcommands, remove the 'gui' word */
-            if (gui) {
-                while (*p == L' ') ++p;
-                p = wcschr(p, L' ');
-            }
-            if (p && *p)
-                wcscat(cmd, p);
-        }
-        LocalFree(wargv);
+	int wargc = 0, gui = 0;
+	LPWSTR cmdline = NULL;
+	LPWSTR *wargv = NULL, p = NULL;
+	cmdline = GetCommandLine();
+	wargv = CommandLineToArgvW(cmdline, &wargc);
+	cmd = (LPWSTR)malloc(sizeof(WCHAR) * (wcslen(cmdline) + MAX_PATH));
+	if (wargc > 1 && wcsicmp(L"gui", wargv[1]) == 0) {
+	    wait = 0;
+	    if (wargc > 2 && wcsicmp(L"citool", wargv[2]) == 0) {
+		wait = 1;
+		wcscpy(cmd, L"git.exe");
+	    } else {
+		WCHAR script[MAX_PATH];
+		gui = 1;
+		wcscpy(script, exepath);
+		PathAppend(script, L"libexec\\git-core\\git-gui");
+		PathQuoteSpaces(script);
+		wcscpy(cmd, L"wish.exe ");
+		wcscat(cmd, script);
+		wcscat(cmd, L" --");
+		exep = NULL; /* find the module from the commandline */
+	    }
+	} else {
+	    wcscpy(cmd, L"git.exe");
+	}
+	/* find the first space after the initial parameter then append all */
+	p = wcschr(&cmdline[wcslen(wargv[0])], L' ');
+	if (p && *p) {
+	    /* for git gui subcommands, remove the 'gui' word */
+	    if (gui) {
+		while (*p == L' ') ++p;
+		p = wcschr(p, L' ');
+	    }
+	    if (p && *p)
+		wcscat(cmd, p);
+	}
+	LocalFree(wargv);
     }
 
     /* set the console to ANSI/GUI codepage */
@@ -155,31 +155,31 @@ main(void)
     SetConsoleCP(GetACP());
 
     {
-        STARTUPINFO si;
-        PROCESS_INFORMATION pi;
-        BOOL br = FALSE;
-        ZeroMemory(&pi, sizeof(PROCESS_INFORMATION));
-        ZeroMemory(&si, sizeof(STARTUPINFO));
-        si.cb = sizeof(STARTUPINFO);
-        br = CreateProcess(exep,/* module: null means use command line */
-                           cmd,  /* modified command line */
-                           NULL, /* process handle inheritance */
-                           NULL, /* thread handle inheritance */
-                           TRUE, /* handles inheritable? */
-                           CREATE_UNICODE_ENVIRONMENT,
-                           NULL, /* environment: use parent */
-                           NULL, /* starting directory: use parent */
-                           &si, &pi);
-        if (br) {
-            if (wait)
-                WaitForSingleObject(pi.hProcess, INFINITE);
-            if (!GetExitCodeProcess(pi.hProcess, (DWORD *)&r))
-                PrintError(L"error reading exit code", GetLastError());
-            CloseHandle(pi.hProcess);
-        } else {
-            PrintError(L"error launching git", GetLastError());
-            r = 1;
-        }
+	STARTUPINFO si;
+	PROCESS_INFORMATION pi;
+	BOOL br = FALSE;
+	ZeroMemory(&pi, sizeof(PROCESS_INFORMATION));
+	ZeroMemory(&si, sizeof(STARTUPINFO));
+	si.cb = sizeof(STARTUPINFO);
+	br = CreateProcess(exep,/* module: null means use command line */
+			   cmd,  /* modified command line */
+			   NULL, /* process handle inheritance */
+			   NULL, /* thread handle inheritance */
+			   TRUE, /* handles inheritable? */
+			   CREATE_UNICODE_ENVIRONMENT,
+			   NULL, /* environment: use parent */
+			   NULL, /* starting directory: use parent */
+			   &si, &pi);
+	if (br) {
+	    if (wait)
+		WaitForSingleObject(pi.hProcess, INFINITE);
+	    if (!GetExitCodeProcess(pi.hProcess, (DWORD *)&r))
+		PrintError(L"error reading exit code", GetLastError());
+	    CloseHandle(pi.hProcess);
+	} else {
+	    PrintError(L"error launching git", GetLastError());
+	    r = 1;
+	}
     }
 
     free(cmd);

--- a/compat/win32/git-wrapper.c
+++ b/compat/win32/git-wrapper.c
@@ -13,187 +13,182 @@
 #include <shellapi.h>
 #include <stdio.h>
 
-static void
-PrintError(LPCWSTR wszPrefix, DWORD dwError)
+static void print_error(LPCWSTR prefix, DWORD error_number)
 {
-    LPWSTR lpsz = NULL;
-    DWORD cch = 0;
+	LPWSTR buffer = NULL;
+	DWORD count = 0;
 
-    cch = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER
-			 | FORMAT_MESSAGE_FROM_SYSTEM
-			 | FORMAT_MESSAGE_IGNORE_INSERTS,
-			 NULL, dwError, LANG_NEUTRAL,
-			 (LPTSTR)&lpsz, 0, NULL);
-    if (cch < 1) {
-	cch = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER
-			     | FORMAT_MESSAGE_FROM_STRING
-			     | FORMAT_MESSAGE_ARGUMENT_ARRAY,
-			     L"Code 0x%1!08x!",
-			     0, LANG_NEUTRAL, (LPTSTR)&lpsz, 0,
-			     (va_list*)&dwError);
-    }
-    fwprintf(stderr, L"%s: %s", wszPrefix, lpsz);
-    LocalFree((HLOCAL)lpsz);
+	count = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER
+			| FORMAT_MESSAGE_FROM_SYSTEM
+			| FORMAT_MESSAGE_IGNORE_INSERTS,
+			NULL, error_number, LANG_NEUTRAL,
+			(LPTSTR)&buffer, 0, NULL);
+	if (count < 1)
+		count = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER
+				| FORMAT_MESSAGE_FROM_STRING
+				| FORMAT_MESSAGE_ARGUMENT_ARRAY,
+				L"Code 0x%1!08x!",
+				0, LANG_NEUTRAL, (LPTSTR)&buffer, 0,
+				(va_list*)&error_number);
+	fwprintf(stderr, L"%s: %s", prefix, buffer);
+	LocalFree((HLOCAL)buffer);
 }
 
-int
-main(void)
+int main(void)
 {
-    int r = 1, wait = 1;
-    WCHAR exepath[MAX_PATH], exe[MAX_PATH];
-    LPWSTR cmd = NULL, path2 = NULL, exep = exe;
-    UINT codepage = 0;
-    int len;
+	int r = 1, wait = 1;
+	WCHAR exepath[MAX_PATH], exe[MAX_PATH];
+	LPWSTR cmd = NULL, path2 = NULL, exep = exe;
+	UINT codepage = 0;
+	int len;
 
-    /* get the installation location */
-    GetModuleFileName(NULL, exepath, MAX_PATH);
-    PathRemoveFileSpec(exepath);
-    PathRemoveFileSpec(exepath);
+	/* get the installation location */
+	GetModuleFileName(NULL, exepath, MAX_PATH);
+	PathRemoveFileSpec(exepath);
+	PathRemoveFileSpec(exepath);
 
-    /* set the default exe module */
-    wcscpy(exe, exepath);
-    PathAppend(exe, L"bin\\git.exe");
+	/* set the default exe module */
+	wcscpy(exe, exepath);
+	PathAppend(exe, L"bin\\git.exe");
 
-    /* if not set, set TERM to msys */
-    if (GetEnvironmentVariable(L"TERM", NULL, 0) == 0) {
-	SetEnvironmentVariable(L"TERM", L"msys");
-    }
+	/* if not set, set TERM to msys */
+	if (!GetEnvironmentVariable(L"TERM", NULL, 0))
+		SetEnvironmentVariable(L"TERM", L"msys");
 
-    /* if not set, set PLINK_PROTOCOL to ssh */
-    if (GetEnvironmentVariable(L"PLINK_PROTOCOL", NULL, 0) == 0) {
-	SetEnvironmentVariable(L"PLINK_PROTOCOL", L"ssh");
-    }
+	/* if not set, set PLINK_PROTOCOL to ssh */
+	if (!GetEnvironmentVariable(L"PLINK_PROTOCOL", NULL, 0))
+		SetEnvironmentVariable(L"PLINK_PROTOCOL", L"ssh");
 
-    /* set HOME to %HOMEDRIVE%%HOMEPATH% or %USERPROFILE%
-     * With roaming profiles: HOMEPATH is the roaming location and
-     * USERPROFILE is the local location
-     */
-    if (GetEnvironmentVariable(L"HOME", NULL, 0) == 0) {
-	LPWSTR e = NULL;
-	len = GetEnvironmentVariable(L"HOMEPATH", NULL, 0);
-	if (len == 0) {
-	    len = GetEnvironmentVariable(L"USERPROFILE", NULL, 0);
-	    if (len != 0) {
-		e = (LPWSTR)malloc(len * sizeof(WCHAR));
-		GetEnvironmentVariable(L"USERPROFILE", e, len);
-		SetEnvironmentVariable(L"HOME", e);
-		free(e);
-	    }
-	} else {
-	    int n;
-	    len += GetEnvironmentVariable(L"HOMEDRIVE", NULL, 0);
-	    e = (LPWSTR)malloc(sizeof(WCHAR) * (len + 2));
-	    n = GetEnvironmentVariable(L"HOMEDRIVE", e, len);
-	    GetEnvironmentVariable(L"HOMEPATH", &e[n], len-n);
-	    SetEnvironmentVariable(L"HOME", e);
-	    free(e);
+	/* set HOME to %HOMEDRIVE%%HOMEPATH% or %USERPROFILE%
+	 * With roaming profiles: HOMEPATH is the roaming location and
+	 * USERPROFILE is the local location
+	 */
+	if (!GetEnvironmentVariable(L"HOME", NULL, 0)) {
+		LPWSTR e = NULL;
+		len = GetEnvironmentVariable(L"HOMEPATH", NULL, 0);
+		if (len == 0) {
+			len = GetEnvironmentVariable(L"USERPROFILE", NULL, 0);
+			if (len != 0) {
+				e = (LPWSTR)malloc(len * sizeof(WCHAR));
+				GetEnvironmentVariable(L"USERPROFILE", e, len);
+				SetEnvironmentVariable(L"HOME", e);
+				free(e);
+			}
+		}
+		else {
+			int n;
+			len += GetEnvironmentVariable(L"HOMEDRIVE", NULL, 0);
+			e = (LPWSTR)malloc(sizeof(WCHAR) * (len + 2));
+			n = GetEnvironmentVariable(L"HOMEDRIVE", e, len);
+			GetEnvironmentVariable(L"HOMEPATH", &e[n], len-n);
+			SetEnvironmentVariable(L"HOME", e);
+			free(e);
+		}
 	}
-    }
 
-    /* extend the PATH */
-    len = GetEnvironmentVariable(L"PATH", NULL, 0);
-    len = sizeof(WCHAR) * (len + 2 * MAX_PATH);
-    path2 = (LPWSTR)malloc(len);
-    wcscpy(path2, exepath);
-    PathAppend(path2, L"bin;");
-    /* should do this only if it exists */
-    wcscat(path2, exepath);
-    PathAppend(path2, L"mingw\\bin;");
-    GetEnvironmentVariable(L"PATH", &path2[wcslen(path2)],
-			   (len/sizeof(WCHAR))-wcslen(path2));
-    SetEnvironmentVariable(L"PATH", path2);
-    free(path2);
+	/* extend the PATH */
+	len = GetEnvironmentVariable(L"PATH", NULL, 0);
+	len = sizeof(WCHAR) * (len + 2 * MAX_PATH);
+	path2 = (LPWSTR)malloc(len);
+	wcscpy(path2, exepath);
+	PathAppend(path2, L"bin;");
+	/* should do this only if it exists */
+	wcscat(path2, exepath);
+	PathAppend(path2, L"mingw\\bin;");
+	GetEnvironmentVariable(L"PATH", &path2[wcslen(path2)],
+			(len/sizeof(WCHAR))-wcslen(path2));
+	SetEnvironmentVariable(L"PATH", path2);
+	free(path2);
 
 
-    /* fix up the command line to call git.exe
-     * We have to be very careful about quoting here so we just
-     * trim off the first argument and replace it leaving the rest
-     * untouched.
-     */
-    {
-	int wargc = 0, gui = 0;
-	LPWSTR cmdline = NULL;
-	LPWSTR *wargv = NULL, p = NULL;
-	cmdline = GetCommandLine();
-	wargv = CommandLineToArgvW(cmdline, &wargc);
-	cmd = (LPWSTR)malloc(sizeof(WCHAR) * (wcslen(cmdline) + MAX_PATH));
-	if (wargc > 1 && wcsicmp(L"gui", wargv[1]) == 0) {
-	    wait = 0;
-	    if (wargc > 2 && wcsicmp(L"citool", wargv[2]) == 0) {
-		wait = 1;
-		wcscpy(cmd, L"git.exe");
-	    } else {
-		WCHAR script[MAX_PATH];
-		gui = 1;
-		wcscpy(script, exepath);
-		PathAppend(script, L"libexec\\git-core\\git-gui");
-		PathQuoteSpaces(script);
-		wcscpy(cmd, L"wish.exe ");
-		wcscat(cmd, script);
-		wcscat(cmd, L" --");
-		exep = NULL; /* find the module from the commandline */
-	    }
-	} else {
-	    wcscpy(cmd, L"git.exe");
+	/* fix up the command line to call git.exe
+	 * We have to be very careful about quoting here so we just
+	 * trim off the first argument and replace it leaving the rest
+	 * untouched.
+	 */
+	{
+		int wargc = 0, gui = 0;
+		LPWSTR cmdline = NULL;
+		LPWSTR *wargv = NULL, p = NULL;
+		cmdline = GetCommandLine();
+		wargv = CommandLineToArgvW(cmdline, &wargc);
+		cmd = (LPWSTR)malloc(sizeof(WCHAR) *
+			(wcslen(cmdline) + MAX_PATH));
+		if (wargc > 1 && wcsicmp(L"gui", wargv[1]) == 0) {
+			wait = 0;
+			if (wargc > 2 && wcsicmp(L"citool", wargv[2]) == 0) {
+				wait = 1;
+				wcscpy(cmd, L"git.exe");
+			}
+			else {
+				WCHAR script[MAX_PATH];
+				gui = 1;
+				wcscpy(script, exepath);
+				PathAppend(script,
+					L"libexec\\git-core\\git-gui");
+				PathQuoteSpaces(script);
+				wcscpy(cmd, L"wish.exe ");
+				wcscat(cmd, script);
+				wcscat(cmd, L" --");
+				/* find the module from the commandline */
+				exep = NULL;
+			}
+		}
+		else
+			wcscpy(cmd, L"git.exe");
+
+		/* append all after first space after the initial parameter */
+		p = wcschr(&cmdline[wcslen(wargv[0])], L' ');
+		if (p && *p) {
+			/* for git gui subcommands, remove the 'gui' word */
+			if (gui) {
+				while (*p == L' ') ++p;
+				p = wcschr(p, L' ');
+			}
+			if (p && *p)
+				wcscat(cmd, p);
+		}
+		LocalFree(wargv);
 	}
-	/* find the first space after the initial parameter then append all */
-	p = wcschr(&cmdline[wcslen(wargv[0])], L' ');
-	if (p && *p) {
-	    /* for git gui subcommands, remove the 'gui' word */
-	    if (gui) {
-		while (*p == L' ') ++p;
-		p = wcschr(p, L' ');
-	    }
-	    if (p && *p)
-		wcscat(cmd, p);
+
+	/* set the console to ANSI/GUI codepage */
+	codepage = GetConsoleCP();
+	SetConsoleCP(GetACP());
+
+	{
+		STARTUPINFO si;
+		PROCESS_INFORMATION pi;
+		BOOL br = FALSE;
+		ZeroMemory(&pi, sizeof(PROCESS_INFORMATION));
+		ZeroMemory(&si, sizeof(STARTUPINFO));
+		si.cb = sizeof(STARTUPINFO);
+		br = CreateProcess(/* module: null means use command line */
+				exep,
+				cmd,  /* modified command line */
+				NULL, /* process handle inheritance */
+				NULL, /* thread handle inheritance */
+				TRUE, /* handles inheritable? */
+				CREATE_UNICODE_ENVIRONMENT,
+				NULL, /* environment: use parent */
+				NULL, /* starting directory: use parent */
+				&si, &pi);
+		if (br) {
+			if (wait)
+				WaitForSingleObject(pi.hProcess, INFINITE);
+			if (!GetExitCodeProcess(pi.hProcess, (DWORD *)&r))
+				print_error(L"error reading exit code",
+					GetLastError());
+			CloseHandle(pi.hProcess);
+		}
+		else {
+			print_error(L"error launching git", GetLastError());
+			r = 1;
+		}
 	}
-	LocalFree(wargv);
-    }
 
-    /* set the console to ANSI/GUI codepage */
-    codepage = GetConsoleCP();
-    SetConsoleCP(GetACP());
+	free(cmd);
 
-    {
-	STARTUPINFO si;
-	PROCESS_INFORMATION pi;
-	BOOL br = FALSE;
-	ZeroMemory(&pi, sizeof(PROCESS_INFORMATION));
-	ZeroMemory(&si, sizeof(STARTUPINFO));
-	si.cb = sizeof(STARTUPINFO);
-	br = CreateProcess(exep,/* module: null means use command line */
-			   cmd,  /* modified command line */
-			   NULL, /* process handle inheritance */
-			   NULL, /* thread handle inheritance */
-			   TRUE, /* handles inheritable? */
-			   CREATE_UNICODE_ENVIRONMENT,
-			   NULL, /* environment: use parent */
-			   NULL, /* starting directory: use parent */
-			   &si, &pi);
-	if (br) {
-	    if (wait)
-		WaitForSingleObject(pi.hProcess, INFINITE);
-	    if (!GetExitCodeProcess(pi.hProcess, (DWORD *)&r))
-		PrintError(L"error reading exit code", GetLastError());
-	    CloseHandle(pi.hProcess);
-	} else {
-	    PrintError(L"error launching git", GetLastError());
-	    r = 1;
-	}
-    }
-
-    free(cmd);
-
-    /* reset the console codepage */
-    SetConsoleCP(codepage);
-    ExitProcess(r);
+	/* reset the console codepage */
+	SetConsoleCP(codepage);
+	ExitProcess(r);
 }
-
-/*
- * Local variables:
- * mode: c
- * indent-tabs-mode: nil
- * c-basic-offset: 4
- * tab-width: 4
- * End:
- */

--- a/compat/win32/git-wrapper.c
+++ b/compat/win32/git-wrapper.c
@@ -96,7 +96,8 @@ static void setup_environment(LPWSTR exepath)
  * trim off the first argument and replace it leaving the rest
  * untouched.
  */
-static LPWSTR fixup_commandline(LPWSTR exepath, LPWSTR *exep, int *wait)
+static LPWSTR fixup_commandline(LPWSTR exepath, LPWSTR *exep, int *wait,
+	LPWSTR builtin, int builtin_len)
 {
 	int wargc = 0, gui = 0;
 	LPWSTR cmd = NULL, cmdline = NULL;
@@ -105,7 +106,7 @@ static LPWSTR fixup_commandline(LPWSTR exepath, LPWSTR *exep, int *wait)
 	cmdline = GetCommandLine();
 	wargv = CommandLineToArgvW(cmdline, &wargc);
 	cmd = (LPWSTR)malloc(sizeof(WCHAR) *
-		(wcslen(cmdline) + MAX_PATH));
+		(wcslen(cmdline) + builtin_len + 1 + MAX_PATH));
 	if (wargc > 1 && wcsicmp(L"gui", wargv[1]) == 0) {
 		*wait = 0;
 		if (wargc > 2 && wcsicmp(L"citool", wargv[2]) == 0) {
@@ -126,6 +127,9 @@ static LPWSTR fixup_commandline(LPWSTR exepath, LPWSTR *exep, int *wait)
 			*exep = NULL;
 		}
 	}
+	else if (builtin)
+		_swprintf(cmd, L"%s\\%s %.*s",
+			exepath, L"git.exe", builtin_len, builtin);
 	else
 		wcscpy(cmd, L"git.exe");
 
@@ -147,17 +151,44 @@ static LPWSTR fixup_commandline(LPWSTR exepath, LPWSTR *exep, int *wait)
 
 int main(void)
 {
-	int r = 1, wait = 1;
+	int r = 1, wait = 1, builtin_len = -1;
 	WCHAR exepath[MAX_PATH], exe[MAX_PATH];
-	LPWSTR cmd = NULL, exep = exe, basename;
+	LPWSTR cmd = NULL, exep = exe, builtin = NULL, basename;
 	UINT codepage = 0;
 
 	/* get the installation location */
 	GetModuleFileName(NULL, exepath, MAX_PATH);
-	PathRemoveFileSpec(exepath);
-	PathRemoveFileSpec(exepath);
-	setup_environment(exepath);
-	cmd = fixup_commandline(exepath, &exep, &wait);
+	if (!PathRemoveFileSpec(exepath)) {
+		fwprintf(stderr, L"Invalid executable path: %s\n", exepath);
+		ExitProcess(1);
+	}
+	basename = exepath + wcslen(exepath) + 1;
+	if (!wcsncmp(basename, L"git-", 4)) {
+		/* Call a builtin */
+		builtin = basename + 4;
+		builtin_len = wcslen(builtin);
+		if (!wcscmp(builtin + builtin_len - 4, L".exe"))
+			builtin_len -= 4;
+
+		/* set the default exe module */
+		wcscpy(exe, exepath);
+		PathAppend(exe, L"git.exe");
+	}
+	else if (!wcscmp(basename, L"git.exe")) {
+		if (!PathRemoveFileSpec(exepath)) {
+			fwprintf(stderr,
+				L"Invalid executable path: %s\n", exepath);
+			ExitProcess(1);
+		}
+
+		/* set the default exe module */
+		wcscpy(exe, exepath);
+		PathAppend(exe, L"bin\\git.exe");
+	}
+
+	if (!builtin)
+		setup_environment(exepath);
+	cmd = fixup_commandline(exepath, &exep, &wait, builtin, builtin_len);
 
 	/* set the console to ANSI/GUI codepage */
 	codepage = GetConsoleCP();

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -525,6 +525,7 @@ ifneq (,$(findstring MINGW,$(uname_S)))
 	X = .exe
 	SPARSE_FLAGS = -Wno-one-bit-signed-bitfield
 	OTHER_PROGRAMS += git-wrapper$(X)
+	BUILT_IN_WRAPPER = git-wrapper$(X)
 ifneq (,$(wildcard ../THIS_IS_MSYSGIT))
 	htmldir = share/doc/git/$(firstword $(subst -, ,$(GIT_VERSION)))/html
 	prefix =

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -564,7 +564,7 @@ else
 		NO_CURL = YesPlease
 	endif
 
-git-wrapper$(X): compat/win32/git-wrapper.o
+git-wrapper$(X): compat/win32/git-wrapper.o git.res
 	$(QUIET_LINK)$(CC) -Wall -s -o $@ $^ -lshell32 -lshlwapi
 
 compat/win32/git-wrapper.o: %.o: %.c

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -524,6 +524,7 @@ ifneq (,$(findstring MINGW,$(uname_S)))
 	NATIVE_CRLF = YesPlease
 	X = .exe
 	SPARSE_FLAGS = -Wno-one-bit-signed-bitfield
+	OTHER_PROGRAMS += git-wrapper$(X)
 ifneq (,$(wildcard ../THIS_IS_MSYSGIT))
 	htmldir = share/doc/git/$(firstword $(subst -, ,$(GIT_VERSION)))/html
 	prefix =
@@ -561,6 +562,13 @@ else
 	else
 		NO_CURL = YesPlease
 	endif
+
+git-wrapper$(X): compat/win32/git-wrapper.o
+	$(QUIET_LINK)$(CC) -Wall -s -o $@ $^ -lshell32 -lshlwapi
+
+compat/win32/git-wrapper.o: %.o: %.c
+	$(QUIET_CC)$(CC) -o $*.o -c -Wall -Wwrite-strings $<
+
 endif
 endif
 ifeq ($(uname_S),QNX)


### PR DESCRIPTION
We cannot rely on hardlinks to keep disk usage low when installing the builtins into `libexec/`. Therefore, we need something very small we can use instead for backwards-compatibility.

The [Git wrapper established in msysGit](https://github.com/msysgit/msysgit/tree/master/src/git-wrapper) is ideal for that: it is already an executable users can call instead of Git (its original purpose is to call Git from `cmd.exe` without the need to call a script setting up the environment correctly). We can easily extend it to serve another purpose, too.