### PR TITLE
mingw: Define git-wrapper variables in the scope of the build targets

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -524,8 +524,6 @@ ifneq (,$(findstring MINGW,$(uname_S)))
 	NATIVE_CRLF = YesPlease
 	X = .exe
 	SPARSE_FLAGS = -Wno-one-bit-signed-bitfield
-	OTHER_PROGRAMS += git-wrapper$(X)
-	BUILT_IN_WRAPPER = git-wrapper$(X)
 ifneq (,$(wildcard ../THIS_IS_MSYSGIT))
 	htmldir = share/doc/git/$(firstword $(subst -, ,$(GIT_VERSION)))/html
 	prefix =
@@ -563,6 +561,8 @@ else
 	else
 		NO_CURL = YesPlease
 	endif
+	OTHER_PROGRAMS += git-wrapper$(X)
+	BUILT_IN_WRAPPER = git-wrapper$(X)
 
 git-wrapper$(X): compat/win32/git-wrapper.o git.res
 	$(QUIET_LINK)$(CC) -Wall -s -o $@ $^ -lshell32 -lshlwapi


### PR DESCRIPTION
This fixes the MSYS1-based build which otherwise would have the variables
but not the build targets.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>