### PR TITLE
git-wrapper: support MSys2

### DIFF
--- a/compat/win32/git-wrapper.c
+++ b/compat/win32/git-wrapper.c
@@ -173,6 +173,189 @@ static LPWSTR fixup_commandline(LPWSTR exepath, LPWSTR *exep, int *wait,
 	return cmd;
 }
 
+#ifdef MAGIC_RESOURCE
+
+static int wsuffixcmp(LPWSTR text, LPWSTR suffix)
+{
+	int text_len = wcslen(text), suffix_len = wcslen(suffix);
+
+	if (text_len < suffix_len)
+		return -1;
+
+	return wcscmp(text + (text_len - suffix_len), suffix);
+}
+
+static int edit_resources(LPWSTR exe_path,
+	LPWSTR *commands, int command_count)
+{
+	WORD language = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT);
+	HANDLE handle;
+	int i;
+
+	if (command_count > 16) {
+		fwprintf(stderr, L"Cannot handle more than 16 commands\n");
+		return -1;
+	}
+
+	if (wsuffixcmp(exe_path, L".exe")) {
+		fwprintf(stderr, L"Not an .exe file: '%s'", exe_path);
+		return -1;
+	}
+	if (_waccess(exe_path, 0) == -1) {
+		fwprintf(stderr, L"File not found: '%s'", exe_path);
+		return -1;
+	}
+
+	handle = BeginUpdateResource(exe_path, FALSE);
+	if (!handle) {
+		fwprintf(stderr,
+			L"Could not update resources of '%s'", exe_path);
+		return -1;
+	}
+
+	if (command_count >= 0) {
+		LPWSTR buffer, p;
+		int alloc = 16; /* 16 words with string lengths, for sure... */
+
+		for (i = 0; i < command_count; i++) {
+			int len = wcslen(commands[i]);
+			if (len > 0xffff) {
+				fwprintf(stderr, L"Too long command: %s\n",
+					commands[i]);
+				return -1;
+			}
+			alloc += len;
+		}
+
+		p = buffer = calloc(alloc, sizeof(WCHAR));
+
+		for (i = 0; i < command_count; i++)
+			p += swprintf(p, alloc - (p - buffer), L"%c%s",
+				(WCHAR) wcslen(commands[i]), commands[i]);
+
+		UpdateResource(handle, RT_STRING, MAKEINTRESOURCE(1),
+			language, buffer, sizeof(WCHAR) * alloc);
+	}
+
+	if (EndUpdateResource(handle, FALSE))
+		return 0;
+
+	fwprintf(stderr, L"Error %d updating resources\n",
+		(int) GetLastError());
+	return -1;
+}
+
+static int configure_via_resource(LPWSTR basename, LPWSTR exepath, LPWSTR exep,
+	LPWSTR *prefix_args, int *prefix_args_len,
+	int *is_git_command, int *start_in_home)
+{
+	int id = 0, wargc;
+	LPWSTR *wargv;
+
+#define BUFSIZE 65536
+	static WCHAR buf[BUFSIZE];
+	int len;
+
+	if (!wcscmp(basename, L"edit-res.exe")) {
+		LPWSTR cmdline = GetCommandLine();
+
+		wargv = CommandLineToArgvW(cmdline, &wargc);
+
+		if (wargv[1]) {
+			if (wargc > 1 && !wcscmp(wargv[1], L"command"))
+				exit(edit_resources(wargv[2],
+					wargv + 3, wargc - 3));
+		}
+		fwprintf(stderr,
+			L"Usage: %s command <exe> <args>...\n",
+			basename);
+		exit(1);
+	}
+
+	SetEnvironmentVariable(L"EXEPATH", exepath);
+	for (id = 0; ; id++) {
+		len = LoadString(NULL, id, buf, BUFSIZE);
+
+		if (!len) {
+			fwprintf(stderr, L"Need a valid command-line; "
+				L"Copy %s to edit-res.exe and call\n"
+				L"\n\tedit-res.exe command %s "
+				L"\"<command-line>\"\n",
+				basename, basename);
+			exit(1);
+		}
+
+		if (len >= BUFSIZE) {
+			fwprintf(stderr,
+				L"Could not read resource (too large)\n");
+			exit(1);
+		}
+
+		buf[len] = L'\0';
+
+		for (;;) {
+			LPWSTR atat = wcsstr(buf, L"@@"), atat2;
+			WCHAR save;
+			int env_len, delta;
+
+			if (!atat)
+				break;
+
+			atat2 = wcsstr(atat + 2, L"@@");
+			if (!atat2)
+				break;
+
+			*atat2 = L'\0';
+			env_len = GetEnvironmentVariable(atat + 2, NULL, 0);
+			delta = env_len - 1 - (atat2 + 2 - atat);
+			if (len + delta >= BUFSIZE) {
+				fwprintf(stderr,
+					L"Substituting '%s' results in too "
+					L"large a command-line\n", atat + 2);
+				exit(1);
+			}
+			if (delta)
+				memmove(atat2 + 2 + delta, atat2 + 2,
+					sizeof(WCHAR) * (len + 1
+						- (atat2 + 2 - buf)));
+			len += delta;
+			save = atat[env_len - 1];
+			GetEnvironmentVariable(atat + 2, atat, env_len);
+			atat[env_len - 1] = save;
+		}
+
+		/* parse first argument */
+		wargv = CommandLineToArgvW(buf, &wargc);
+		if (wargc < 1) {
+			fwprintf(stderr, L"Invalid command-line: '%s'\n", buf);
+			exit(1);
+		}
+		if (*wargv[0] == L'\\' ||
+				(isalpha(*wargv[0]) && wargv[0][1] == L':'))
+			wcscpy(exep, wargv[0]);
+		else {
+			wcscpy(exep, exepath);
+			PathAppend(exep, wargv[0]);
+		}
+
+		if (_waccess(exep, 0) != -1)
+			break;
+		fwprintf(stderr,
+			L"Skipping command-line '%s'\n('%s' not found)\n",
+			buf, exep);
+	}
+
+	*prefix_args = buf;
+	*prefix_args_len = wcslen(buf);
+
+	*is_git_command = 0;
+	*start_in_home = 1;
+
+	return 1;
+}
+
+#endif
+
 int main(void)
 {
 	int r = 1, wait = 1, prefix_args_len = -1, needs_env_setup = 1,
@@ -192,6 +375,14 @@ int main(void)
 		ExitProcess(1);
 	}
 	basename = exepath + wcslen(exepath) + 1;
+#ifdef MAGIC_RESOURCE
+	if (configure_via_resource(basename, exepath, exep,
+			&prefix_args, &prefix_args_len,
+			&is_git_command, &start_in_home)) {
+		/* do nothing */
+	}
+	else
+#endif
 	if (!wcsncmp(basename, L"git-", 4)) {
 		needs_env_setup = 0;
 


### PR DESCRIPTION
The original purpose of the Git wrapper is to run from inside Git for
Windows' /cmd/ directory, to allow setting up some environment variables
before Git is allowed to take over.

Due to differences in the file system layout, MSys2 requires some
changes for that to work.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>