### PR TITLE
git-wrapper: support git.exe to be in a spaced dir

### DIFF
--- a/compat/win32/git-wrapper.c
+++ b/compat/win32/git-wrapper.c
@@ -133,7 +133,7 @@ static LPWSTR fixup_commandline(LPWSTR exepath, LPWSTR *exep, int *wait,
 		(wcslen(cmdline) + prefix_args_len + 1 + MAX_PATH));
 	if (prefix_args) {
 		if (is_git_command)
-			_swprintf(cmd, L"%s\\%s %.*s", exepath, L"git.exe",
+			_swprintf(cmd, L"\"%s\\%s\" %.*s", exepath, L"git.exe",
 					prefix_args_len, prefix_args);
 		else
 			_swprintf(cmd, L"%.*s", prefix_args_len, prefix_args);


### PR DESCRIPTION
When *Git for Windows* is installed into a directory that has spaces in
it, e.g. `C:\Program Files\Git`, the `git-wrapper` appends this directory
unquoted when fixing up the command line. To resolve this, just quote the
provided `execpath`.

This commit *should* fix https://github.com/git-for-windows/git/issues/51.
@kevin-david Maybe you could give it a try?

Signed-off-by: nalla <nalla@hamal.uberspace.de>