### PR TITLE
mingw: parse `config.mak.uname` when building `doc`

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -123,6 +123,7 @@ ifndef PERL_PATH
 	PERL_PATH = /usr/bin/perl
 endif
 
+include ../config.mak.uname
 -include ../config.mak.autogen
 -include ../config.mak
 


### PR DESCRIPTION
The file `config.mak.uname` is getting parsed by the `Makefile` in the
root git folder. Thus resulting in a `git --html-path` in the
`/mingw%BITNESS%` directory. This modification is missing when building
and installing the `doc`. So the `doc` is getting installed in the default
path at `$prefix/share/doc/git-doc`. So lets parse the `config.mak.uname`
when building the `doc` too.

Signed-off-by: nalla <nalla@hamal.uberspace.de>