### PR TITLE
fixup! Silence GCC's "cast of pointer to integer of a different size" warning

### DIFF
--- a/compat/regex/regcomp.c
+++ b/compat/regex/regcomp.c
@@ -18,6 +18,8 @@
    Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
    02110-1301 USA.  */
 
+#include <stdint.h>
+
 static reg_errcode_t re_compile_internal (regex_t *preg, const char * pattern,
 					  size_t length, reg_syntax_t syntax);
 static void re_compile_fastmap_iter (regex_t *bufp,


### PR DESCRIPTION
[5621f24 broke the MSYS1 build](https://dscho.cloudapp.net/job/gfw-msys1-build-git/40/console) due to a missing typedef for `intptr_t`, so fix it again by including the required MSYS1 header file. Although not required for MSYS2, that header exists there, too, and unconditionally including it should have no negative impact.