### PR TITLE
Asciidoctor fixes

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -335,7 +335,7 @@ manpage-base-url.xsl: manpage-base-url.xsl.in
 
 user-manual.xml: user-manual.txt user-manual.conf
 	$(QUIET_ASCIIDOC)$(RM) $@.new $@ && \
-	$(TXT_TO_XML) -d article -o $@.new $< && \
+	$(TXT_TO_XML) -d book -o $@.new $< && \
 	mv $@.new $@
 
 technical/api-index.txt: technical/api-index-skel.txt \

--- a/Documentation/giteveryday.txt
+++ b/Documentation/giteveryday.txt
@@ -308,18 +308,15 @@ master or exposed as a part of a stable branch.
 <10> create a signed tag.
 <11> make sure master was not accidentally rewound beyond that
 already pushed out.  `ko` shorthand points at the Git maintainer's
-repository at kernel.org, and looks like this:
-+
-------------
-(in .git/config)
-[remote "ko"]
-	url = kernel.org:/pub/scm/git/git.git
-	fetch = refs/heads/*:refs/remotes/ko/*
-	push = refs/heads/master
-	push = refs/heads/next
-	push = +refs/heads/pu
-	push = refs/heads/maint
-------------
+repository at kernel.org, and looks like this: +
+++(in .git/config) +
+{startsb}remote "ko"{endsb} +
+{nbsp}{nbsp}{nbsp}{nbsp}url = kernel.org:/pub/scm/git/git.git +
+{nbsp}{nbsp}{nbsp}{nbsp}fetch = refs/heads/\*:refs/remotes/ko/* +
+{nbsp}{nbsp}{nbsp}{nbsp}push = refs/heads/master +
+{nbsp}{nbsp}{nbsp}{nbsp}push = refs/heads/next +
+{nbsp}{nbsp}{nbsp}{nbsp}push = +refs/heads/pu +
+{nbsp}{nbsp}{nbsp}{nbsp}push = refs/heads/maint++
 +
 <12> In the output from `git show-branch`, `master` should have
 everything `ko/master` has, and `next` should have

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -3424,7 +3424,7 @@ just missing one particular blob version.
 
 [[the-index]]
 The index
------------
+---------
 
 The index is a binary file (generally kept in `.git/index`) containing a
 sorted list of path names, each with permissions and the SHA-1 of a blob
@@ -4366,6 +4366,10 @@ itself!
 Git Glossary
 ============
 
+[[git-explained]]
+Git explained
+-------------
+
 include::glossary-content.txt[]
 
 [[git-quick-start]]
@@ -4606,6 +4610,10 @@ $ git gc
 [[todo]]
 Appendix B: Notes and todo list for this manual
 ===============================================
+
+[[todo-list]]
+Todo list
+---------
 
 This is a work in progress.
 


### PR DESCRIPTION
This PR for issue #79 prepares the documentation do be built by `asciidoctor`.

The documentation can be built by the following call.
```bash
make doc ASCIIDOC=asciidoctor ASCIIDOC_HTML=html5 ASCIIDOC_DOCBOOK=docbook45 ASCIIDOC_EXTRA="'-alitdd=&#45;&#45;'" ASCIIDOC_CONF='-I/mingw64/lib/asciidoctor-extensions -rman-inline-macro'
```

Note: use `ASCIIDOC_CONF='-I/mingw32/lib/asciidoctor-extensions -rman-inline-macro'` on `32bit`.

You need to have the [asciidoctor-extensions](https://github.com/git-for-windows/MINGW-packages/tree/master/mingw-w64-asciidoctor-extensions) package installed.