### PR TITLE
Add support for %PROGRAMDATA%\Git\config

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -6,7 +6,9 @@ the Git commands' behavior. The `.git/config` file in each repository
 is used to store the configuration for that repository, and
 `$HOME/.gitconfig` is used to store a per-user configuration as
 fallback values for the `.git/config` file. The file `/etc/gitconfig`
-can be used to store a system-wide default configuration.
+can be used to store a system-wide default configuration. On Windows,
+configuration can also be stored in `C:\ProgramData\Git\config`; This
+file will be used also by libgit2-based software.
 
 The configuration variables are used by both the Git plumbing
 and the porcelains. The variables are divided into sections, wherein

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2378,3 +2378,12 @@ void mingw_startup()
 	/* init length of current directory for handle_long_path */
 	current_directory_len = GetCurrentDirectoryW(0, NULL);
 }
+
+const char *windows_wide_config(void)
+{
+	static struct strbuf windows_wide = STRBUF_INIT;
+	if (!windows_wide.len)
+		strbuf_addf(&windows_wide,
+			"%s\\Git\\config", getenv("PROGRAMDATA"));
+	return windows_wide.buf;
+}

--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -392,6 +392,8 @@ static inline char *mingw_find_last_dir_sep(const char *path)
 int mingw_offset_1st_component(const char *path);
 #define offset_1st_component mingw_offset_1st_component
 #define PATH_SEP ';'
+extern const char *windows_wide_config(void);
+#define git_super_config windows_wide_config
 #ifndef __MINGW64_VERSION_MAJOR
 #define PRIuMAX "I64u"
 #define PRId64 "I64d"

--- a/config.c
+++ b/config.c
@@ -1204,10 +1204,17 @@ int git_config_system(void)
 int git_config_early(config_fn_t fn, void *data, const char *repo_config)
 {
 	int ret = 0, found = 0;
+	const char *super_config = git_super_config();
 	char *xdg_config = NULL;
 	char *user_config = NULL;
 
 	home_config_paths(&user_config, &xdg_config, "config");
+
+	if (super_config && git_config_system() &&
+			!access(super_config, R_OK)) {
+		ret += git_config_from_file(fn, super_config, data);
+		found += 1;
+	}
 
 	if (git_config_system() && !access_or_die(git_etc_gitconfig(), R_OK, 0)) {
 		ret += git_config_from_file(fn, git_etc_gitconfig(),

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -307,6 +307,10 @@ static inline char *git_find_last_dir_sep(const char *path)
 #define find_last_dir_sep git_find_last_dir_sep
 #endif
 
+#ifndef git_super_gitconfig
+#define git_super_gitconfig NULL
+#endif
+
 #if defined(__HP_cc) && (__HP_cc >= 61000)
 #define NORETURN __attribute__((noreturn))
 #define NORETURN_PTR


### PR DESCRIPTION
As discussed in https://github.com/libgit2/libgit2/pull/3040, the Windows-based Git projects (both Git for Windows and libgit2) would like to share configuration. It was determined that the best (and most "Windows") way is to have the system-wide configuration in `%PROGRAMDATA%\Git\config`.

This requires three changes in Git for Windows:
- we need to read from that location first, before looking in `etc/gitconfig` and the rest
- we need to update the documentation to state that new behavior
- we need to teach the installer to copy over existing `etc/gitconfig` from Git for Windows 1.x setups