### PR TITLE
readme: added link to governance model

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 This is the source code of [Git for Windows](http://git-for-windows.github.io/),
 forked from [Git](http://git-scm.com/).
 
-If you encounter problems, you can report them as [GitHub issues](https://github.com/git-for-windows/git/issues), discuss them on Git for Windows' [Google Group](http://groups.google.com/group/git-for-windows), and [contribute bug fixes](https://github.com/git-for-windows/git/wiki/How-to-participate#fix-bugs-or-add-features-in-the-git-code-itself).
+This project is run by a [governance model](http://git-for-windows.github.io/governance-model.html). If you encounter problems, you can report them as [GitHub issues](https://github.com/git-for-windows/git/issues), discuss them on Git for Windows' [Google Group](http://groups.google.com/group/git-for-windows), and [contribute bug fixes](https://github.com/git-for-windows/git/wiki/How-to-participate#fix-bugs-or-add-features-in-the-git-code-itself).


### PR DESCRIPTION
After publishing the governance model on the [developer
page](http://git-for-windows.github.io), lets add a link on the
`README.md` too.

Signed-off-by: 마누엘 <nalla@hamal.uberspace.de>