### PR TITLE
Fix git svn problem when truncating a file failed due to file blocking (issue msysgit#309)

### DIFF
--- a/perl/Git.pm
+++ b/perl/Git.pm
@@ -1322,6 +1322,22 @@ Truncates and resets the position of the C<FILEHANDLE>.
 
 sub temp_reset {
 	my ($self, $temp_fd) = _maybe_self(@_);
+	my $i = 0;
+	for(; $i < 9; $i++) {
+		try {
+			_temp_reset($temp_fd);
+			return;
+		} catch Error::Simple with {
+			carp "temp_reset failed on ", $temp_fd, ". Will try again.";
+			sleep(10);
+		}
+	}
+	_temp_reset($temp_fd);
+}
+
+
+sub _temp_reset {
+	my ($self, $temp_fd) = _maybe_self(@_);
 
 	truncate $temp_fd, 0
 		or throw Error::Simple("couldn't truncate file");


### PR DESCRIPTION
Symptom: error message "couldn't truncate file at /usr/lib/perl5/site_perl/Git.pm line 1322."
when running "git svn clone" command.

Fix: delay retry the operation a few times.

Reproducibility:

- I had this issue happening consistently (but at different stages of
progress) when cloning a large codebase before these changes.
- Same issue has been reported by others:
  - https://github.com/msysgit/git/issues/309
  - http://stackoverflow.com/questions/25353316/error-with-git-svn-clone

Testing: after the changes,

1- I was able to clone the same large SVN codebase 3 times with
no errors.
2- During the clone operation, several lines similar to
"temp_reset failed on GLOB(0xa7a52f4). Will try again. at /usr/lib/perl5/site_perl/Error.pm line 335"
are logged followed by no errors, indicating that the retry
logic is effective.

Hypothesis: another process is accessing the temp file (ex: virus scan,
indexing) at the same time as the temp_reset operation, and a large
clone operation is turning an unlikely event into a consistent one. The
delayed retry is sufficient for making this again improbable event.