### PR TITLE
Add 'full-log' option to diff.submodule

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -128,10 +128,18 @@ static int parse_dirstat_params(struct diff_options *options, const char *params
 
 static int parse_submodule_params(struct diff_options *options, const char *value)
 {
-	if (!strcmp(value, "log"))
+	if (!strcmp(value, "log")) {
 		DIFF_OPT_SET(options, SUBMODULE_LOG);
-	else if (!strcmp(value, "short"))
+		DIFF_OPT_CLR(options, SUBMODULE_FULL_LOG);
+	}
+	else if (!strcmp(value, "full-log")) {
+		DIFF_OPT_SET(options, SUBMODULE_FULL_LOG);
 		DIFF_OPT_CLR(options, SUBMODULE_LOG);
+	}
+	else if (!strcmp(value, "short")) {
+		DIFF_OPT_CLR(options, SUBMODULE_LOG);
+		DIFF_OPT_CLR(options, SUBMODULE_FULL_LOG);
+	}
 	else
 		return -1;
 	return 0;
@@ -2240,7 +2248,7 @@ static void builtin_diff(const char *name_a,
 	struct strbuf header = STRBUF_INIT;
 	const char *line_prefix = diff_line_prefix(o);
 
-	if (DIFF_OPT_TST(o, SUBMODULE_LOG) &&
+	if ((DIFF_OPT_TST(o, SUBMODULE_LOG) || DIFF_OPT_TST(o, SUBMODULE_FULL_LOG)) &&
 			(!one->mode || S_ISGITLINK(one->mode)) &&
 			(!two->mode || S_ISGITLINK(two->mode))) {
 		const char *del = diff_get_color_opt(o, DIFF_FILE_OLD);
@@ -2248,7 +2256,7 @@ static void builtin_diff(const char *name_a,
 		show_submodule_summary(o->file, one->path ? one->path : two->path,
 				line_prefix,
 				one->sha1, two->sha1, two->dirty_submodule,
-				meta, del, add, reset);
+				meta, del, add, reset, DIFF_OPT_TST(o, SUBMODULE_FULL_LOG));
 		return;
 	}
 

--- a/diff.h
+++ b/diff.h
@@ -90,6 +90,7 @@ typedef struct strbuf *(*diff_prefix_fn_t)(struct diff_options *opt, void *data)
 #define DIFF_OPT_DIRSTAT_BY_LINE     (1 << 28)
 #define DIFF_OPT_FUNCCONTEXT         (1 << 29)
 #define DIFF_OPT_PICKAXE_IGNORE_CASE (1 << 30)
+#define DIFF_OPT_SUBMODULE_FULL_LOG  (1 << 31)
 
 #define DIFF_OPT_TST(opts, flag)    ((opts)->flags & DIFF_OPT_##flag)
 #define DIFF_OPT_TOUCHED(opts, flag)    ((opts)->touched_flags & DIFF_OPT_##flag)

--- a/submodule.c
+++ b/submodule.c
@@ -290,14 +290,14 @@ void handle_ignore_submodules_arg(struct diff_options *diffopt,
 
 static int prepare_submodule_summary(struct rev_info *rev, const char *path,
 		struct commit *left, struct commit *right,
-		int *fast_forward, int *fast_backward)
+		int *fast_forward, int *fast_backward, unsigned full_log)
 {
 	struct commit_list *merge_bases, *list;
 
 	init_revisions(rev, NULL);
 	setup_revisions(0, NULL, rev, NULL);
 	rev->left_right = 1;
-	rev->first_parent_only = 1;
+	rev->first_parent_only = full_log ? 0 : 1;
 	left->object.flags |= SYMMETRIC_LEFT;
 	add_pending_object(rev, &left->object, path);
 	add_pending_object(rev, &right->object, path);
@@ -363,7 +363,8 @@ void show_submodule_summary(FILE *f, const char *path,
 		const char *line_prefix,
 		unsigned char one[20], unsigned char two[20],
 		unsigned dirty_submodule, const char *meta,
-		const char *del, const char *add, const char *reset)
+		const char *del, const char *add, const char *reset,
+		unsigned full_log)
 {
 	struct rev_info rev;
 	struct commit *left = NULL, *right = NULL;
@@ -381,7 +382,7 @@ void show_submodule_summary(FILE *f, const char *path,
 		 !(right = lookup_commit_reference(two)))
 		message = "(commits not present)";
 	else if (prepare_submodule_summary(&rev, path, left, right,
-					   &fast_forward, &fast_backward))
+					   &fast_forward, &fast_backward, full_log))
 		message = "(revision walker failed)";
 
 	if (dirty_submodule & DIRTY_SUBMODULE_UNTRACKED)

--- a/submodule.h
+++ b/submodule.h
@@ -26,7 +26,8 @@ void show_submodule_summary(FILE *f, const char *path,
 		const char *line_prefix,
 		unsigned char one[20], unsigned char two[20],
 		unsigned dirty_submodule, const char *meta,
-		const char *del, const char *add, const char *reset);
+		const char *del, const char *add, const char *reset,
+		unsigned full_log);
 void set_config_fetch_recurse_submodules(int value);
 void check_for_new_submodule_commits(unsigned char new_sha1[20]);
 int fetch_populated_submodules(const struct argv_array *options,


### PR DESCRIPTION
Like the 'log' option to `diff --submodule`, 'full-log' provides logs without the `--first-parent` option.

Note that a few things have not been completed:

* No unit tests. I am not familiar with the shell scripts used to implement the tests. I am not sure how to add a test for this.
* No documentation updates. Can anyone tell me how I can update documentation and where it should be updated?

I am making this change here instead of upstream since I do not have a linux OS to test direct changes to git on. If this can get approved here, I hope it can be cherry picked upstream to the official git repository.