### PR TITLE
git_terminal_prompt fixes and Unicode support

### DIFF
--- a/compat/terminal.c
+++ b/compat/terminal.c
@@ -110,6 +110,7 @@ static char *shell_prompt(const char *prompt, int echo)
 	child.argv = read_input;
 	child.in = -1;
 	child.out = -1;
+	child.silent_exec_failure = 1;
 
 	if (start_command(&child))
 		return NULL;
@@ -153,11 +154,14 @@ char *git_terminal_prompt(const char *prompt, int echo)
 	static struct strbuf buf = STRBUF_INIT;
 	int r;
 	FILE *input_fh, *output_fh;
-#ifdef GIT_WINDOWS_NATIVE
-	const char *term = getenv("TERM");
 
-	if (term && starts_with(term, "xterm"))
-		return shell_prompt(prompt, echo);
+#ifdef GIT_WINDOWS_NATIVE
+
+	/* try shell_prompt first, fall back to CONIN/OUT if bash is missing */
+	char *result = shell_prompt(prompt, echo);
+	if (result || errno != ENOENT)
+		return result;
+
 #endif
 
 	input_fh = fopen(INPUT_PATH, "r" FORCE_TEXT);

--- a/compat/terminal.c
+++ b/compat/terminal.c
@@ -98,7 +98,7 @@ static char *xterm_prompt(const char *prompt, int echo)
 {
 	const char *read_input[] = {
 		"sh", "-c",
-		"cat >/dev/tty && read line </dev/tty && echo \"$line\"",
+		"cat >/dev/tty && read -r line </dev/tty && echo \"$line\"",
 		NULL
 	};
 	const char *echo_off[] = { "sh", "-c", "stty -echo </dev/tty", NULL };

--- a/compat/terminal.c
+++ b/compat/terminal.c
@@ -129,7 +129,7 @@ static char *xterm_prompt(const char *prompt, int echo)
 	}
 	close(child.in);
 
-	strbuf_setlen(&buffer, 0);
+	strbuf_reset(&buffer);
 	len = strbuf_read(&buffer, child.out, 1024);
 	close(child.out);
 	if (len < 0) {

--- a/compat/terminal.c
+++ b/compat/terminal.c
@@ -124,14 +124,12 @@ static char *xterm_prompt(const char *prompt, int echo)
 	if (write_in_full(child.in, prompt, prompt_len) != prompt_len) {
 		error("Could not write to xterm");
 		close(child.in);
-		close(child.out);
 		goto ret;
 	}
 	close(child.in);
 
 	strbuf_reset(&buffer);
 	len = strbuf_read(&buffer, child.out, 1024);
-	close(child.out);
 	if (len < 0) {
 		error("Could not read from xterm");
 		goto ret;
@@ -141,6 +139,7 @@ static char *xterm_prompt(const char *prompt, int echo)
 	strbuf_strip_suffix(&buffer, "\r");
 
 ret:
+	close(child.out);
 	if (!code)
 		finish_command(&child);
 

--- a/compat/terminal.c
+++ b/compat/terminal.c
@@ -137,10 +137,8 @@ static char *xterm_prompt(const char *prompt, int echo)
 		goto ret;
 	}
 
-	if (len && buffer.buf[len - 1] == '\n')
-		strbuf_setlen(&buffer, len - 1);
-	if (len && buffer.buf[len - 1] == '\r')
-		strbuf_setlen(&buffer, len - 1);
+	strbuf_strip_suffix(&buffer, "\n");
+	strbuf_strip_suffix(&buffer, "\r");
 
 ret:
 	if (!code)


### PR DESCRIPTION
Followup to #74 mintty issues / @dscho's d56d2f8

* Fixes a few minor issues with `git_terminal_prompt` (see individual fixup commits)
* Use `read -s` instead of `stty echo` (for fewer processes and MSys1 compatibility)
* ~~Drop CONIN$ / CONOUT$ in favor of the shell based solution (for Unicode support)~~ see discussion
* ~~Drop unnecessary `SetConsoleCP()` from git-wrapper~~ see PR #142

Tested with git-bash, git-cmd, bash in native console, and MSys1 bash (with compat/terminal.c backported to msysgit/git/master).