### PR TITLE
git-wrapper: don't set the console input code page

### DIFF
--- a/compat/win32/git-wrapper.c
+++ b/compat/win32/git-wrapper.c
@@ -321,7 +321,6 @@ int main(void)
 	WCHAR exepath[MAX_PATH], exe[MAX_PATH];
 	LPWSTR cmd = NULL, exep = exe, prefix_args = NULL, basename;
 	LPWSTR working_directory = NULL;
-	UINT codepage = 0;
 
 	/* Determine MSys2-based Git path. */
 	swprintf(msystem_bin, sizeof(msystem_bin),
@@ -437,10 +436,6 @@ int main(void)
 		}
 	}
 
-	/* set the console to ANSI/GUI codepage */
-	codepage = GetConsoleCP();
-	SetConsoleCP(GetACP());
-
 	{
 		STARTUPINFO si;
 		PROCESS_INFORMATION pi;
@@ -499,7 +494,5 @@ int main(void)
 
 	free(cmd);
 
-	/* reset the console codepage */
-	SetConsoleCP(codepage);
 	ExitProcess(r);
 }


### PR DESCRIPTION
Separated from PR #141