### PR TITLE
RFC: system-wide config file in %PROGRAMDATA%

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -6,9 +6,8 @@ the Git commands' behavior. The `.git/config` file in each repository
 is used to store the configuration for that repository, and
 `$HOME/.gitconfig` is used to store a per-user configuration as
 fallback values for the `.git/config` file. The file `/etc/gitconfig`
-can be used to store a system-wide default configuration. On Windows,
-configuration can also be stored in `C:\ProgramData\Git\config`; This
-file will be used also by libgit2-based software.
+can be used to store a system-wide default configuration
+(`%PROGRAMDATA%\Git\gitconfig` on Windows).
 
 The configuration variables are used by both the Git plumbing
 and the porcelains. The variables are divided into sections, wherein

--- a/Documentation/git-config.txt
+++ b/Documentation/git-config.txt
@@ -117,11 +117,13 @@ See also <<FILES>>.
 
 --system::
 	For writing options: write to system-wide
-	`$(prefix)/etc/gitconfig` rather than the repository
+	`/etc/gitconfig` rather than the repository
 	`.git/config`.
 +
-For reading options: read only from system-wide `$(prefix)/etc/gitconfig`
+For reading options: read only from system-wide `/etc/gitconfig`
 rather than from all available files.
++
+On Windows, the system-wide config file is `%PROGRAMDATA%\Git\gitconfig`.
 +
 See also <<FILES>>.
 
@@ -221,11 +223,21 @@ See also <<FILES>>.
 FILES
 -----
 
-If not set explicitly with '--file', there are four files where
+If not set explicitly with '--file', there are five files where
 'git config' will search for configuration options:
 
 $(prefix)/etc/gitconfig::
-	System-wide configuration file.
+	Installation-specific configuration file, where '$(prefix)' is the
+	installation root directory specified via 'make prefix=...'. This allows
+	software distributions to provide installation-specific default values
+	(e.g. 'help.format=html' if the installation only includes html pages).
+
+/etc/gitconfig::
+	System-wide configuration file (`%PROGRAMDATA%\Git\gitconfig` on Windows).
++
+If git was built with relative `$(sysconfdir)`, this file will not be
+used, and the '--system' option refers to the installation-specific
+`$(prefix)/etc/gitconfig` instead.
 
 $XDG_CONFIG_HOME/git/config::
 	Second user-specific configuration file. If $XDG_CONFIG_HOME is not set
@@ -268,11 +280,11 @@ ENVIRONMENT
 GIT_CONFIG::
 	Take the configuration from the given file instead of .git/config.
 	Using the "--global" option forces this to ~/.gitconfig. Using the
-	"--system" option forces this to $(prefix)/etc/gitconfig.
+	"--system" option forces this to /etc/gitconfig.
 
 GIT_CONFIG_NOSYSTEM::
-	Whether to skip reading settings from the system-wide
-	$(prefix)/etc/gitconfig file. See linkgit:git[1] for details.
+	Whether to skip reading settings from the installation-specific	and
+	system-wide /etc/gitconfig files. See linkgit:git[1] for details.
 
 See also <<FILES>>.
 

--- a/Documentation/git.txt
+++ b/Documentation/git.txt
@@ -939,8 +939,8 @@ for further details.
 	on the terminal (e.g., when asking for HTTP authentication).
 
 'GIT_CONFIG_NOSYSTEM'::
-	Whether to skip reading settings from the system-wide
-	`$(prefix)/etc/gitconfig` file.  This environment variable can
+	Whether to skip reading settings from the installation-specific and
+	system-wide `/etc/gitconfig` files. This environment variable can
 	be used along with `$HOME` and `$XDG_CONFIG_HOME` to create a
 	predictable environment for a picky script, or you can set it
 	temporarily to avoid using a buggy `/etc/gitconfig` file while

--- a/Documentation/gitattributes.txt
+++ b/Documentation/gitattributes.txt
@@ -84,7 +84,7 @@ for a single user should be placed in a file specified by the
 Its default value is $XDG_CONFIG_HOME/git/attributes. If $XDG_CONFIG_HOME
 is either not set or empty, $HOME/.config/git/attributes is used instead.
 Attributes for all users on a system should be placed in the
-`$(prefix)/etc/gitattributes` file.
+`/etc/gitattributes` file (`%PROGRAMDATA%\Git\gitattributes` on Windows).
 
 Sometimes you would need to override an setting of an attribute
 for a path to `Unspecified` state.  This can be done by listing

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -330,6 +330,7 @@ endif
 ifeq ($(uname_S),Windows)
 	GIT_VERSION := $(GIT_VERSION).MSVC
 	pathsep = ;
+	sysconfdir = /etc
 	HAVE_ALLOCA_H = YesPlease
 	NO_PREAD = YesPlease
 	NEEDS_CRYPTO_WITH_SSL = YesPlease
@@ -484,6 +485,7 @@ ifeq ($(uname_S),NONSTOP_KERNEL)
 endif
 ifneq (,$(findstring MINGW,$(uname_S)))
 	pathsep = ;
+	sysconfdir = /etc
 	HAVE_ALLOCA_H = YesPlease
 	NO_PREAD = YesPlease
 	NEEDS_CRYPTO_WITH_SSL = YesPlease
@@ -532,6 +534,10 @@ ifneq (,$(findstring MINGW,$(uname_S)))
 ifneq (,$(wildcard ../THIS_IS_MSYSGIT))
 	htmldir = share/doc/git/$(firstword $(subst -, ,$(GIT_VERSION)))/html
 	prefix =
+	# prevent conversion to Windows path on MSys1 (see
+	# http://www.mingw.org/wiki/Posix_path_conversion)
+	ETC_GITCONFIG = //etc\gitconfig
+	ETC_GITATTRIBUTES = //etc\gitattributes
 	INSTALL = /bin/install
 	EXTLIBS += /mingw/lib/libz.a
 	NO_R_TO_GCC_LINKER = YesPlease


### PR DESCRIPTION
This fixes issue #154, as an alternative to @dscho's PR #104.

Notable differences:
* `git config --system` reads / writes `%PROGRAMDATA%\Git\gitconfig`
* `$(prefix)/etc/gitconfig` is read before `%PROGRAMDATA%\Git\gitconfig`
* the fallback mechanism works on all platforms, including Linux and all Windows build targets
* also works for `%PROGRAMDATA%\Git\gitattributes` (and any future config files that go to the `sysconfdir` Makefile variable)
* doesn't need SHGetFolderPath API. IIRC, delay-loading DLLs was a huge performance saver in MSys-1.dll, so I'd rather not require loading shell32.dll in the startup code of practically every git command (although I don't think we currently do delay-loading, but this may be as simple as adding a compiler switch)