### PR TITLE
mingw: Fix the MSYS1 build

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2162,9 +2162,11 @@ int symlink(const char *target, const char *link)
 	return 0;
 }
 
+#ifndef _WINNT_H
 /*
- * The REPARSE_DATA_BUFFER structure is only defined in the Windows DDK (in
- * Ntifs.h), so we have to define it ourselves.
+ * The REPARSE_DATA_BUFFER structure is defined in the Windows DDK (in
+ * ntifs.h) and in MSYS1's winnt.h (which defines _WINNT_H). So define
+ * it ourselves if we are on MSYS2 (whose winnt.h defines _WINNT_).
  */
 typedef struct _REPARSE_DATA_BUFFER {
 	DWORD  ReparseTag;
@@ -2191,6 +2193,7 @@ typedef struct _REPARSE_DATA_BUFFER {
 		} GenericReparseBuffer;
 	} DUMMYUNIONNAME;
 } REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
+#endif
 
 int readlink(const char *path, char *buf, size_t bufsiz)
 {


### PR DESCRIPTION
In contrast to MSYS2, MSYS1 not only defines REPARSE_DATA_BUFFER in
"ntifs.h" but also in "winnt.h". Luckily, we can distinguish between
MSYS1's and MSYS2's "winnt.h" by looking at the include-guards:
While MSYS1 defines "_WINNT_H", MSYS2 defines "_WINNT_".

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>