### PR TITLE
Fix mergetool p4merge

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -3118,7 +3118,7 @@ static void run_diff_cmd(const char *pgm,
 		fprintf(o->file, "* Unmerged path %s\n", name);
 }
 
-static void diff_fill_sha1_info(struct diff_filespec *one)
+void diff_fill_sha1_info(struct diff_filespec *one)
 {
 	if (DIFF_FILE_VALID(one)) {
 		if (!one->sha1_valid) {

--- a/diffcore.h
+++ b/diffcore.h
@@ -60,6 +60,7 @@ extern void fill_filespec(struct diff_filespec *, const unsigned char *,
 extern int diff_populate_filespec(struct diff_filespec *, unsigned int);
 extern void diff_free_filespec_data(struct diff_filespec *);
 extern void diff_free_filespec_blob(struct diff_filespec *);
+extern void diff_fill_sha1_info(struct diff_filespec *);
 extern int diff_filespec_is_binary(struct diff_filespec *);
 
 struct diff_filepair {

--- a/git-sh-setup.sh
+++ b/git-sh-setup.sh
@@ -289,7 +289,7 @@ clear_local_git_env() {
 # remove lines from $1 that are not in $2, leaving only common lines.
 create_virtual_base() {
 	sz0=$(wc -c <"$1")
-	@@DIFF@@ -u -La/"$1" -Lb/"$1" "$1" "$2" | git apply --no-add
+	git diff --no-index -La/"$1" -Lb/"$1" "$1" "$2" | git apply --no-add
 	sz1=$(wc -c <"$1")
 
 	# If we do not have enough common material, it is not

--- a/mergetools/p4merge
+++ b/mergetools/p4merge
@@ -24,7 +24,7 @@ merge_cmd () {
 	if ! $base_present
 	then
 		cp -- "$LOCAL" "$BASE"
-		create_virtual_base "$BASE" "$REMOTE"
+		create_virtual_base "${BASE#./}" "${REMOTE#./}"
 	fi
 	"$merge_tool_path" "$BASE" "$REMOTE" "$LOCAL" "$MERGED"
 	check_unchanged

--- a/t/t4059-diff-label.sh
+++ b/t/t4059-diff-label.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+test_description='diff --no-index -L'
+
+. ./test-lib.sh
+
+test_expect_success 'setup' '
+	mkdir -p non/git &&
+	echo 1 >non/git/a &&
+	echo 2 >non/git/b
+'
+
+test_expect_success 'git diff --no-index -Lx -Ly' '
+  test_expect_code 1 git diff --no-index -Lx -Ly non/git/a non/git/b > actual 
+  grep -- "--- x" actual &&
+  grep "+++ y" actual
+'
+
+test_expect_success 'git diff --no-index -Lx' '
+  test_expect_code 1 git diff --no-index -Lx non/git/a non/git/b > actual 
+  grep -- "--- x" actual &&
+  grep "+++ non/git/b" actual
+'
+
+test_done


### PR DESCRIPTION
The merge tool p4merge fails in certain cases when there is no base version for a 3-way merge. In this case `create_virtual_base` is called to create a base file which contains only the common content of the files to be merged. This base file is presented in p4merge.

With this script https://gist.github.com/calle2010/b4910e9b8f0dbbf58fb6 I can replicate the issues in a repository with core.autocrlf=true.

There are two issues:
1. Since commit c536c07 git-apply fails with _invalid path_ if the path starts with a dot.
2. If the files have CRLF line endings these will be included in the output of `diff`. This leads to error messages about trailing whitespace in git-apply.

Even though the patch resolves the issues I have some doubts about this patch:
- Is the parameter expansion with # allowed in a Git bash script?
- `create_virtual_base` seems to be used by mergetools/p4merge and git-merge-one-file.sh only. The latter is described as an sample script in the documentation of [git-merge-index](https://github.com/git/git/blob/398dd4bd039680ba98497fbedffa415a43583c16/Documentation/git-merge-index.txt#L47-L48). So I hope I'm not in the risk of breaking anything very central here.
