### PR TITLE
CTRL-C event kills the application

### DIFF
--- a/compat/win32/git-wrapper.c
+++ b/compat/win32/git-wrapper.c
@@ -14,6 +14,15 @@
 #include <stdio.h>
 #include <wchar.h>
 
+/*
+Control Handler Function
+All events are disabled!
+*/
+BOOL WINAPI CtrlHandler( DWORD fdwCtrlType ) 
+{
+  return TRUE;
+}
+
 static WCHAR msystem_bin[64];
 
 static void print_error(LPCWSTR prefix, DWORD error_number)
@@ -547,8 +556,11 @@ int main(void)
 				working_directory, /* use parent's */
 				&si, &pi);
 		if (br) {
-			if (wait)
+			if (wait) {
+				/* The only way to exit this program is the launched command end. */
+				SetConsoleCtrlHandler(CtrlHandler, TRUE);
 				WaitForSingleObject(pi.hProcess, INFINITE);
+			}
 			if (!GetExitCodeProcess(pi.hProcess, (DWORD *)&r))
 				print_error(L"error reading exit code",
 					GetLastError());


### PR DESCRIPTION
git-cmd.exe has a bad behavior when it receives CTRL-C event. A command line shell must handle the events.
For example, CTRL-C should be used to terminate the current command and not to terminate the shell himself.

When git-cmd.exe is launched, git-cmd.exe launches a child process (for example cmd.exe).
git-cmd.exe monitors the child process. When the child process exits, git-cmd.exe exits too.

When the user presses CTRL-C, the Windows console receives Windows messages for WM_KEYDOWN/WM_KEYUP.
Then the TranslateMessage function generates a CTRL-C event.

The CTRL-C event is handled by the Control Handler Function.
When a CTRL_BREAK_EVENT, CTRL_LOGOFF_EVENT, or CTRL_SHUTDOWN_EVENT signal is received, the control handler returns FALSE. Doing this causes the signal to be passed to the next control handler function. If no other control handlers have been registered or none of the registered handlers returns TRUE, the default handler will be used, resulting in the process being terminated.

cmd.exe Control Handler function terminates the current command and returns FALSE.
git-cmd.exe has no Control Handler Function registered. So git-cmd.exe is terminated.

When git-cmd.exe is used with programs like ConsoleZ, ConsoleZ injects a dll in git-cmd.exe and monitors this process.
When the user presses CTRL-C, git-cmd is terminated and so the ConsoleZ's tab is closed.

To fix this behavior, we can simply register a Control Handler function that returns TRUE (for all events). In this case the only way to exit this program is the launched command end.

Signed-off-by: Christophe Bucher Developer <christophe.bucher@laposte.net>