### PR TITLE
The stat() method should not be dependent on the core.symlinks config entry

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -757,17 +757,7 @@ int mingw_stat(const char *file_name, struct stat *buf)
 	HANDLE hnd;
 	int result;
 
-	/* if symlinks are disabled, use lstat() (without following links) */
-	if (!has_symlinks) {
-		result = lstat(file_name, buf);
-		if (!result && S_ISLNK(buf->st_mode)) {
-			errno = ELOOP;
-			return -1;
-		}
-		return result;
-	}
-
-	/* otherwise just open the file and let Windows resolve the links */
+	/* open the file and let Windows resolve the links */
 	if (xutftowcs_long_path(wfile_name, file_name) < 0)
 		return -1;
 	hnd = CreateFileW(wfile_name, 0,


### PR DESCRIPTION
The contact for the stat() and lstat() function is:
> stat() stats the file pointed to by path and fills in buf.
> lstat() is identical to stat(), except that if path is a symbolic link, then the link itself is stat-ed, not the file that it refers to.

stat() should always return the statistics of the file or directory a symbolic link is pointing to. The lstat() function is used to get the stats for the symlink. Hence the check should not be there.