### PR TITLE
config.c: fix writing config files on Windows network shares

### DIFF
--- a/config.c
+++ b/config.c
@@ -2153,6 +2153,9 @@ int git_config_set_multivar_in_file(const char *config_filename,
 					  contents_sz - copy_begin) <
 			    contents_sz - copy_begin)
 				goto write_err_out;
+
+		munmap(contents, contents_sz);
+		contents = NULL;
 	}
 
 	if (commit_lock_file(lock) < 0) {


### PR DESCRIPTION
This fixes #226

Caused by 3a1b3126 "config.c: fix mmap leak when writing config" in 2.4.5.

I've sent the fix upstream as well.