### PR TITLE
Add ability to work as /usr/bin/git on MSYS2

### DIFF
--- a/exec_cmd.c
+++ b/exec_cmd.c
@@ -15,8 +15,10 @@ char *system_path(const char *path)
 #endif
 	struct strbuf d = STRBUF_INIT;
 
+#ifndef __MINGW32__
 	if (is_absolute_path(path))
 		return xstrdup(path);
+#endif
 
 #ifdef RUNTIME_PREFIX
 	assert(argv0_path);
@@ -31,7 +33,19 @@ char *system_path(const char *path)
 				"but prefix computation failed.  "
 				"Using static fallback '%s'.\n", prefix);
 	}
+#ifdef __MINGW32__
+#ifdef __MINGW64__
+#define PKGPREFIX "mingw64"
+#else
+#define PKGPREFIX "mingw32"
 #endif
+	char *slash = strrchr(prefix, '\\');
+	if (slash && !strcmp(slash, "\\usr")) {
+	    char *nprefix = strip_path_suffix(prefix, "usr");
+	    strbuf_addf(&d, "%s/"PKGPREFIX"/%s", nprefix, path);
+	} else
+#endif /* !__MINGW32__ */
+#endif /* !RUNTIME_PREFIX */
 
 	strbuf_addf(&d, "%s/%s", prefix, path);
 	return strbuf_detach(&d, NULL);


### PR DESCRIPTION
This allows for a user to link /mingwXX/bin/git to /usr/bin/git and use it
as their MSYS2 install's git.  This change is needed so that lookups using
system_path work correctly in this case.

Note that if the user does this, they will also need to modify
/mingwXX/etc/gitconfig so that http.sslCAInfo points to
/mingwXX/ssl/certs/ca-bundle.crt or similar.

This is the change that in the discussion for git-for-windows/MINGW-packages#11 you said would be better applied to the git sources.