### PR TITLE
winansi.c: Fix colourization on Cygwin pseudo terminals.

### DIFF
--- a/compat/winansi.c
+++ b/compat/winansi.c
@@ -551,8 +551,10 @@ static void detect_msys_tty(int fd)
 	name = nameinfo->Name.Buffer;
 	name[nameinfo->Name.Length] = 0;
 
-	/* check if this could be a msys pty pipe ('msys-XXXX-ptyN-XX') */
-	if (!wcsstr(name, L"msys-") || !wcsstr(name, L"-pty"))
+	/* check if this could be a msys pty pipe ('msys-XXXX-ptyN-XX')
+	   or a cygwin pty pipe ('cygwin-XXXX-ptyN-XX') */
+	if ((!wcsstr(name, L"msys-") && !wcsstr(name, L"cygwin-")) ||
+			!wcsstr(name, L"-pty"))
 		return;
 
 	/* init ioinfo size if we haven't done so */


### PR DESCRIPTION
Git only colours the output and uses pagination if isatty() returns 1.  MSys and Cygwin emulate pseudo terminals via named pipes, meaning that isatty() returns 0.

Commit 3adef8de5513390459e1caa999e7774adb89a44d fixed this for MSys terminals, but not Cygwin.

The named pipes that Cygwin and Msys use are very similar.  MSys PTY pipes are called 'msys-*-pty*' and Cygwin uses 'cygwin-*-pty*'.  This commit modifies the existing check to allow both MSys and Cygwin PTY pipes to be identified as TTYs.

Note that Pagination is still broken on Cygwin.  less.exe is spawned (as seen in Process Explorer and using GIT_TRACE=1), but the output is not being piped into it.

This partially fixes https://github.com/git-for-windows/git/issues/267