### PR TITLE
mingw: Suppress warning that <commit>:.gitattributes does not exist

### DIFF
--- a/attr.c
+++ b/attr.c
@@ -375,7 +375,7 @@ static struct attr_stack *read_attr_from_file(const char *path, int macro_ok)
 	int lineno = 0;
 
 	if (!fp) {
-		if (errno != ENOENT && errno != ENOTDIR)
+		if (errno != ENOENT && errno != ENOTDIR && errno != EINVAL)
 			warn_on_inaccessible(path);
 		return NULL;
 	}


### PR DESCRIPTION
On Windows, a file name containing a colon is illegal. We should
therefore expect the corresponding errno when `fopen()` is called for a
path of the form <commit>:.gitattributes.

This fixes https://github.com/git-for-windows/git/issues/255.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>