### PR TITLE
Make alternates work on UNC paths

### DIFF
--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -396,6 +396,7 @@ HANDLE winansi_get_osfhandle(int fd);
  */
 
 #define has_dos_drive_prefix(path) (isalpha(*(path)) && (path)[1] == ':')
+#define has_unc_prefix(path) (*(path) == '\\' && (path)[1] == '\\')
 #define is_dir_sep(c) ((c) == '/' || (c) == '\\')
 static inline char *mingw_find_last_dir_sep(const char *path)
 {

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -337,6 +337,14 @@ static inline int git_has_dos_drive_prefix(const char *path)
 #define has_dos_drive_prefix git_has_dos_drive_prefix
 #endif
 
+#ifndef has_unc_prefix
+static inline int git_has_unc_prefix(const char *path)
+{
+	return 0;
+}
+#define has_unc_prefix git_has_unc_prefix
+#endif
+
 #ifndef is_dir_sep
 static inline int git_is_dir_sep(int c)
 {

--- a/path.c
+++ b/path.c
@@ -666,7 +666,7 @@ int normalize_path_copy_len(char *dst, const char *src, int *prefix_len)
 {
 	char *dst0;
 
-	if (has_dos_drive_prefix(src)) {
+	if (has_unc_prefix(src) || has_dos_drive_prefix(src)) {
 		*dst++ = *src++;
 		*dst++ = *src++;
 	}


### PR DESCRIPTION
It has been reported that `git.exe` won't be able to access alternates when they are specified as UNC paths. Let's make that work.