### PR TITLE
mingw: treat junction points the same as symlinks

### DIFF
--- a/compat/win32.h
+++ b/compat/win32.h
@@ -9,7 +9,9 @@
 static inline int file_attr_to_st_mode (DWORD attr, DWORD tag)
 {
 	int fMode = S_IREAD;
-	if ((attr & FILE_ATTRIBUTE_REPARSE_POINT) && tag == IO_REPARSE_TAG_SYMLINK)
+	if ((attr & FILE_ATTRIBUTE_REPARSE_POINT) &&
+			(tag == IO_REPARSE_TAG_SYMLINK ||
+			 tag == IO_REPARSE_TAG_MOUNT_POINT))
 		fMode |= S_IFLNK;
 	else if (attr & FILE_ATTRIBUTE_DIRECTORY)
 		fMode |= S_IFDIR;

--- a/compat/win32/dirent.c
+++ b/compat/win32/dirent.c
@@ -17,7 +17,8 @@ static inline void finddata2dirent(struct dirent *ent, WIN32_FIND_DATAW *fdata)
 
 	/* Set file type, based on WIN32_FIND_DATA */
 	if ((fdata->dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)
-			&& fdata->dwReserved0 == IO_REPARSE_TAG_SYMLINK)
+			&& (fdata->dwReserved0 == IO_REPARSE_TAG_SYMLINK
+			 || fdata->dwReserved0 == IO_REPARSE_TAG_MOUNT_POINT))
 		ent->d_type = DT_LNK;
 	else if (fdata->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 		ent->d_type = DT_DIR;


### PR DESCRIPTION
We forgot to handle them in the same way. Pointed out by Ed Thomson.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
