### PR TITLE
DO NOT MERGE YET: make git-rebase a builtin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -884,6 +884,7 @@ BUILTIN_OBJS += builtin/prune.o
 BUILTIN_OBJS += builtin/pull.o
 BUILTIN_OBJS += builtin/push.o
 BUILTIN_OBJS += builtin/read-tree.o
+BUILTIN_OBJS += builtin/rebase--helper.o
 BUILTIN_OBJS += builtin/receive-pack.o
 BUILTIN_OBJS += builtin/reflog.o
 BUILTIN_OBJS += builtin/remote.o

--- a/builtin.h
+++ b/builtin.h
@@ -102,6 +102,7 @@ extern int cmd_prune_packed(int argc, const char **argv, const char *prefix);
 extern int cmd_pull(int argc, const char **argv, const char *prefix);
 extern int cmd_push(int argc, const char **argv, const char *prefix);
 extern int cmd_read_tree(int argc, const char **argv, const char *prefix);
+extern int cmd_rebase__helper(int argc, const char **argv, const char *prefix);
 extern int cmd_receive_pack(int argc, const char **argv, const char *prefix);
 extern int cmd_reflog(int argc, const char **argv, const char *prefix);
 extern int cmd_remote(int argc, const char **argv, const char *prefix);

--- a/builtin/rebase--helper.c
+++ b/builtin/rebase--helper.c
@@ -1,0 +1,4 @@
+int cmd_rebase__helper(int argc, const char **argv, const char *prefix)
+{
+	return 0;
+}

--- a/git.c
+++ b/git.c
@@ -449,6 +449,7 @@ static struct cmd_struct commands[] = {
 	{ "pull", cmd_pull, RUN_SETUP | NEED_WORK_TREE },
 	{ "push", cmd_push, RUN_SETUP },
 	{ "read-tree", cmd_read_tree, RUN_SETUP },
+	{ "rebase--helper", cmd_rebase__helper, RUN_SETUP },
 	{ "receive-pack", cmd_receive_pack },
 	{ "reflog", cmd_reflog, RUN_SETUP },
 	{ "remote", cmd_remote, RUN_SETUP },


### PR DESCRIPTION
rebase: Introduce native rebase helper

Git rebase functionality currently implemented in the git-rebase.sh,
git-rebase--am.sh, git-rebase--interactive.sh and git-rebase--merge.sh.
Rewritten in C it will become faster and ready to integrate with other C code.

rebase--helper to be called from git-rebase.sh run_specific_rebase with
git-rebase-am, git-rebase-interactive, git-rebase-merge subcommands eliminating
above scripts one by one and then git-rebase.sh will be converted itself.

Signed-off-by: Evgeny Knyazev <evgeny.knyazev@gmail.com>