### PR TITLE
DO NOT MERGE YET: make git-rebase a builtin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -884,6 +884,7 @@ BUILTIN_OBJS += builtin/prune.o
 BUILTIN_OBJS += builtin/pull.o
 BUILTIN_OBJS += builtin/push.o
 BUILTIN_OBJS += builtin/read-tree.o
+BUILTIN_OBJS += builtin/rebase--helper.o
 BUILTIN_OBJS += builtin/receive-pack.o
 BUILTIN_OBJS += builtin/reflog.o
 BUILTIN_OBJS += builtin/remote.o

--- a/Makefile
+++ b/Makefile
@@ -476,6 +476,7 @@ SCRIPT_SH += git-merge-resolve.sh
 SCRIPT_SH += git-mergetool.sh
 SCRIPT_SH += git-quiltimport.sh
 SCRIPT_SH += git-rebase.sh
+SCRIPT_SH += git-rebase--merge.sh
 SCRIPT_SH += git-remote-testgit.sh
 SCRIPT_SH += git-request-pull.sh
 SCRIPT_SH += git-stash.sh
@@ -486,7 +487,6 @@ SCRIPT_LIB += git-mergetool--lib
 SCRIPT_LIB += git-parse-remote
 SCRIPT_LIB += git-rebase--am
 SCRIPT_LIB += git-rebase--interactive
-SCRIPT_LIB += git-rebase--merge
 SCRIPT_LIB += git-sh-setup
 SCRIPT_LIB += git-sh-i18n
 

--- a/builtin.h
+++ b/builtin.h
@@ -102,6 +102,7 @@ extern int cmd_prune_packed(int argc, const char **argv, const char *prefix);
 extern int cmd_pull(int argc, const char **argv, const char *prefix);
 extern int cmd_push(int argc, const char **argv, const char *prefix);
 extern int cmd_read_tree(int argc, const char **argv, const char *prefix);
+extern int cmd_rebase__helper(int argc, const char **argv, const char *prefix);
 extern int cmd_receive_pack(int argc, const char **argv, const char *prefix);
 extern int cmd_reflog(int argc, const char **argv, const char *prefix);
 extern int cmd_remote(int argc, const char **argv, const char *prefix);

--- a/builtin/blame.c
+++ b/builtin/blame.c
@@ -2330,8 +2330,8 @@ static struct commit *fake_working_tree_commit(struct diff_options *opt,
 			if (DIFF_OPT_TST(opt, ALLOW_TEXTCONV) &&
 			    textconv_object(read_from, mode, null_sha1, 0, &buf_ptr, &buf_len))
 				strbuf_attach(&buf, buf_ptr, buf_len, buf_len + 1);
-			else if (strbuf_read_file(&buf, read_from, st.st_size) != st.st_size)
-				die_errno("cannot open or read '%s'", read_from);
+	else
+		strbuf_read_file_or_die(&buf, read_from, st.st_size);
 			break;
 		case S_IFLNK:
 			if (strbuf_readlink(&buf, read_from, st.st_size) < 0)

--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -703,9 +703,7 @@ static int prepare_to_commit(const char *index_file, const char *prefix,
 			die_errno(_("could not read log from standard input"));
 		hook_arg1 = "message";
 	} else if (logfile) {
-		if (strbuf_read_file(&sb, logfile, 0) < 0)
-			die_errno(_("could not read log file '%s'"),
-				  logfile);
+		strbuf_read_file_or_die(&sb, logfile, 0);
 		hook_arg1 = "message";
 	} else if (use_message) {
 		char *buffer;
@@ -725,16 +723,13 @@ static int prepare_to_commit(const char *index_file, const char *prefix,
 				      &sb, &ctx);
 		hook_arg1 = "message";
 	} else if (!stat(git_path_merge_msg(), &statbuf)) {
-		if (strbuf_read_file(&sb, git_path_merge_msg(), 0) < 0)
-			die_errno(_("could not read MERGE_MSG"));
+		strbuf_read_file_or_die(&sb, git_path_merge_msg(), 0);
 		hook_arg1 = "merge";
 	} else if (!stat(git_path_squash_msg(), &statbuf)) {
-		if (strbuf_read_file(&sb, git_path_squash_msg(), 0) < 0)
-			die_errno(_("could not read SQUASH_MSG"));
+		strbuf_read_file_or_die(&sb, git_path_squash_msg(), 0);
 		hook_arg1 = "squash";
 	} else if (template_file) {
-		if (strbuf_read_file(&sb, template_file, 0) < 0)
-			die_errno(_("could not read '%s'"), template_file);
+		strbuf_read_file_or_die(&sb, template_file, 0);
 		hook_arg1 = "template";
 		clean_message_contents = 0;
 	}
@@ -1699,8 +1694,7 @@ int cmd_commit(int argc, const char **argv, const char *prefix)
 		fclose(fp);
 		strbuf_release(&m);
 		if (!stat(git_path_merge_mode(), &statbuf)) {
-			if (strbuf_read_file(&sb, git_path_merge_mode(), 0) < 0)
-				die_errno(_("could not read MERGE_MODE"));
+			strbuf_read_file_or_die(&sb, git_path_merge_mode(), 0);
 			if (!strcmp(sb.buf, "no-ff"))
 				allow_fast_forward = 0;
 		}

--- a/builtin/merge.c
+++ b/builtin/merge.c
@@ -768,8 +768,7 @@ static void read_merge_msg(struct strbuf *msg)
 {
 	const char *filename = git_path_merge_msg();
 	strbuf_reset(msg);
-	if (strbuf_read_file(msg, filename, 0) < 0)
-		die_errno(_("Could not read from '%s'"), filename);
+	strbuf_read_file_or_die(msg, filename, 0);
 }
 
 static void write_merge_state(struct commit_list *);

--- a/builtin/notes.c
+++ b/builtin/notes.c
@@ -230,8 +230,8 @@ static int parse_file_arg(const struct option *opt, const char *arg, int unset)
 	if (!strcmp(arg, "-")) {
 		if (strbuf_read(&d->buf, 0, 1024) < 0)
 			die_errno(_("cannot read '%s'"), arg);
-	} else if (strbuf_read_file(&d->buf, arg, 1024) < 0)
-		die_errno(_("could not open or read '%s'"), arg);
+	} else
+		strbuf_read_file_or_die(&(d->buf), arg, 0);
 	stripspace(&d->buf, 0);
 
 	d->given = 1;

--- a/builtin/rebase--helper.c
+++ b/builtin/rebase--helper.c
@@ -1,0 +1,4 @@
+int cmd_rebase__helper(int argc, const char **argv, const char *prefix)
+{
+	return 0;
+}

--- a/builtin/tag.c
+++ b/builtin/tag.c
@@ -693,11 +693,8 @@ int cmd_tag(int argc, const char **argv, const char *prefix)
 			if (!strcmp(msgfile, "-")) {
 				if (strbuf_read(&buf, 0, 1024) < 0)
 					die_errno(_("cannot read '%s'"), msgfile);
-			} else {
-				if (strbuf_read_file(&buf, msgfile, 1024) < 0)
-					die_errno(_("could not open or read '%s'"),
-						msgfile);
-			}
+	} else
+		strbuf_read_file_or_die(&buf, msgfile, 0);
 		}
 	}
 

--- a/git-rebase--merge.sh
+++ b/git-rebase--merge.sh
@@ -5,7 +5,42 @@
 # Copyright (c) 2010 Junio C Hamano.
 #
 
-prec=4
+. git-sh-setup
+. git-sh-i18n
+set_reflog_action rebase
+require_work_tree_exists
+
+GIT_QUIET=$git_quiet 
+
+prec=4 
+
+write_basic_state () {
+	echo "$head_name" > "$state_dir"/head-name &&
+	echo "$onto" > "$state_dir"/onto &&
+	echo "$orig_head" > "$state_dir"/orig-head &&
+	echo "$GIT_QUIET" > "$state_dir"/quiet &&
+	test t = "$verbose" && : > "$state_dir"/verbose
+	test -n "$strategy" && echo "$strategy" > "$state_dir"/strategy
+	test -n "$strategy_opts" && echo "$strategy_opts" > \
+		"$state_dir"/strategy_opts
+	test -n "$allow_rerere_autoupdate" && echo "$allow_rerere_autoupdate" > \
+		"$state_dir"/allow_rerere_autoupdate
+	test -n "$gpg_sign_opt" && echo "$gpg_sign_opt" > "$state_dir"/gpg_sign_opt
+}
+
+move_to_original_branch () {
+	case "$head_name" in
+	refs/*)
+		message="rebase finished: $head_name onto $onto"
+		git update-ref -m "$message" \
+			$head_name $(git rev-parse HEAD) $orig_head &&
+		git symbolic-ref \
+			-m "rebase finished: returning to $head_name" \
+			HEAD $head_name ||
+		die "$(gettext "Could not move back to $head_name")"
+		;;
+	esac
+}
 
 read_state () {
 	onto_name=$(cat "$state_dir"/onto_name) &&

--- a/git-rebase.sh
+++ b/git-rebase.sh
@@ -186,7 +186,19 @@ run_specific_rebase () {
 		export GIT_EDITOR
 		autosquash=
 	fi
-	. git-rebase--$type
+
+	git_quiet=$GIT_QUIET
+	export GIT_PAGER GIT_QUIET
+	export action allow_rerere_autoupdate git_am_opt git_quiet  keep_empty
+	export onto orig_head rebase_root resolvemsg revisions
+	export state_dir verbose strategy strategy_opts
+	export gpg_sign_opt upstream restrict_revision head_name
+
+	if [ "$type" = merge ]; then 
+		exec git-rebase--merge 
+	else 
+		. git-rebase--$type 
+	fi
 	ret=$?
 	if test $ret -eq 0
 	then

--- a/git.c
+++ b/git.c
@@ -449,6 +449,7 @@ static struct cmd_struct commands[] = {
 	{ "pull", cmd_pull, RUN_SETUP | NEED_WORK_TREE },
 	{ "push", cmd_push, RUN_SETUP },
 	{ "read-tree", cmd_read_tree, RUN_SETUP },
+	{ "rebase--helper", cmd_rebase__helper, RUN_SETUP },
 	{ "receive-pack", cmd_receive_pack },
 	{ "reflog", cmd_reflog, RUN_SETUP },
 	{ "remote", cmd_remote, RUN_SETUP },

--- a/strbuf.c
+++ b/strbuf.c
@@ -537,6 +537,14 @@ ssize_t strbuf_read_file(struct strbuf *sb, const char *path, size_t hint)
 	return len;
 }
 
+void strbuf_read_file_or_die(struct strbuf *sb, const char *path, size_t size)
+{
+	int ret;
+	ret = strbuf_read_file(sb, path, size);
+	if (ret < 0 || (size && ret != size))
+	die_errno(_("could not open or read '%s'"), path);
+}
+
 void strbuf_add_lines(struct strbuf *out, const char *prefix,
 		      const char *buf, size_t size)
 {

--- a/strbuf.h
+++ b/strbuf.h
@@ -497,6 +497,7 @@ static inline void strbuf_complete_line(struct strbuf *sb)
 		strbuf_addch(sb, '\n');
 }
 
+extern void strbuf_read_file_or_die(struct strbuf *sb, const char *path, size_t size);
 extern int strbuf_branchname(struct strbuf *sb, const char *name);
 extern int strbuf_check_branch_ref(struct strbuf *sb, const char *name);
 

--- a/unpack-trees.h
+++ b/unpack-trees.h
@@ -86,4 +86,8 @@ int bind_merge(const struct cache_entry * const *src,
 int oneway_merge(const struct cache_entry * const *src,
 		 struct unpack_trees_options *o);
 
+struct tree;
+extern int reset_tree(struct tree *tree, int quiet,
+			int worktree, int *writeout_error);
+
 #endif


### PR DESCRIPTION
rebase: Introduce native rebase helper

Git rebase functionality currently implemented in the git-rebase.sh,
git-rebase--am.sh, git-rebase--interactive.sh and git-rebase--merge.sh.
Rewritten in C it will become faster and ready to integrate with other C code.

rebase--helper to be called from git-rebase.sh run_specific_rebase with
git-rebase-am, git-rebase-interactive, git-rebase-merge subcommands eliminating
above scripts one by one and then git-rebase.sh will be converted itself.

Signed-off-by: Evgeny Knyazev <evgeny.knyazev (at) gmail.com>