### PR TITLE
add note about %PROGRAMDATA%\Git\config to git-config.txt

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -7,7 +7,7 @@ is used to store the configuration for that repository, and
 `$HOME/.gitconfig` is used to store a per-user configuration as
 fallback values for the `.git/config` file. The file `/etc/gitconfig`
 can be used to store a system-wide default configuration. On Windows,
-configuration can also be stored in `C:\ProgramData\Git\config`; This
+configuration can also be stored in `%PROGRAMDATA%\Git\config`; This
 file will be used also by libgit2-based software.
 
 The configuration variables are used by both the Git plumbing

--- a/Documentation/git-config.txt
+++ b/Documentation/git-config.txt
@@ -247,9 +247,10 @@ $GIT_DIR/config::
 	Repository specific configuration file.
 
 On Windows, as there is no central `/etc/` directory, there is yet another
-config file, intended to contain settings for *all* Git-related software
-running on the machine. Consequently, this config file takes an even lower
-precedence than the `$(prefix)/etc/gitconfig` file.
+config file (located at `%PROGRAMDATA%\Git\config`), intended to contain
+settings for *all* Git-related software running on the machine. Consequently,
+this config file takes an even lower precedence than the
+`$(prefix)/etc/gitconfig` file.
 
 If no further options are given, all reading options will read all of these
 files that are available. If the global or the system-wide configuration


### PR DESCRIPTION
Spent a while hunting this down the other day, it would be helpful to have the information in `git help config` as well.