### PR TITLE
Better mmap() emulation

### DIFF
--- a/compat/win32mmap.c
+++ b/compat/win32mmap.c
@@ -2,26 +2,24 @@
 
 void *git_mmap(void *start, size_t length, int prot, int flags, int fd, off_t offset)
 {
-	HANDLE hmap;
+	HANDLE osfhandle, hmap;
 	void *temp;
-	off_t len;
-	struct stat st;
+	LARGE_INTEGER len;
 	uint64_t o = offset;
 	uint32_t l = o & 0xFFFFFFFF;
 	uint32_t h = (o >> 32) & 0xFFFFFFFF;
 
-	if (!fstat(fd, &st))
-		len = st.st_size;
-	else
+	osfhandle = (HANDLE)_get_osfhandle(fd);
+	if (!GetFileSizeEx(osfhandle, &len))
 		die("mmap: could not determine filesize");
 
-	if ((length + offset) > len)
-		length = xsize_t(len - offset);
+	if ((length + offset) > len.QuadPart)
+		length = xsize_t(len.QuadPart - offset);
 
 	if (!(flags & MAP_PRIVATE))
 		die("Invalid usage of mmap when built with USE_WIN32_MMAP");
 
-	hmap = CreateFileMapping((HANDLE)_get_osfhandle(fd), NULL,
+	hmap = CreateFileMapping(osfhandle, NULL,
 		prot == PROT_READ ? PAGE_READONLY : PAGE_WRITECOPY, 0, 0, NULL);
 
 	if (!hmap) {

--- a/compat/win32mmap.c
+++ b/compat/win32mmap.c
@@ -22,14 +22,15 @@ void *git_mmap(void *start, size_t length, int prot, int flags, int fd, off_t of
 		die("Invalid usage of mmap when built with USE_WIN32_MMAP");
 
 	hmap = CreateFileMapping((HANDLE)_get_osfhandle(fd), NULL,
-		PAGE_WRITECOPY, 0, 0, NULL);
+		prot == PROT_READ ? PAGE_READONLY : PAGE_WRITECOPY, 0, 0, NULL);
 
 	if (!hmap) {
 		errno = EINVAL;
 		return MAP_FAILED;
 	}
 
-	temp = MapViewOfFileEx(hmap, FILE_MAP_COPY, h, l, length, start);
+	temp = MapViewOfFileEx(hmap, prot == PROT_READ ?
+			FILE_MAP_READ : FILE_MAP_COPY, h, l, length, start);
 
 	if (!CloseHandle(hmap))
 		warning("unable to close file mapping handle");


### PR DESCRIPTION
Kevin David provided access to his VM where a simple `git fetch` would produce this error output:

```
fatal: mmap failed: No error
fatal: write error: Invalid argument
```

The reason was that several bits of our `mmap()` emulation left room for improvement. This Pull Request tries to close the gap.