### PR TITLE
[RFC]Make stash a builtin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -951,6 +951,7 @@ BUILTIN_OBJS += builtin/send-pack.o
 BUILTIN_OBJS += builtin/shortlog.o
 BUILTIN_OBJS += builtin/show-branch.o
 BUILTIN_OBJS += builtin/show-ref.o
+BUILTIN_OBJS += builtin/stash--helper.o
 BUILTIN_OBJS += builtin/stripspace.o
 BUILTIN_OBJS += builtin/submodule--helper.o
 BUILTIN_OBJS += builtin/symbolic-ref.o

--- a/builtin.h
+++ b/builtin.h
@@ -120,6 +120,7 @@ extern int cmd_send_pack(int argc, const char **argv, const char *prefix);
 extern int cmd_shortlog(int argc, const char **argv, const char *prefix);
 extern int cmd_show(int argc, const char **argv, const char *prefix);
 extern int cmd_show_branch(int argc, const char **argv, const char *prefix);
+extern int cmd_stash__helper(int argc, const char **argv, const char *prefix);
 extern int cmd_status(int argc, const char **argv, const char *prefix);
 extern int cmd_stripspace(int argc, const char **argv, const char *prefix);
 extern int cmd_submodule__helper(int argc, const char **argv, const char *prefix);

--- a/builtin/stash--helper.c
+++ b/builtin/stash--helper.c
@@ -1,0 +1,70 @@
+#include "../cache.h"
+#include "../cache-tree.h"
+#include "../diff.h"
+#include "../diffcore.h"
+#include "../revision.h"
+
+static const char builtin_stash__helper_usage[] = {
+	"Usage: git stash--helper --non-patch <i_tree>"
+};
+
+static void diff_callback(struct diff_queue_struct *q,
+					 struct diff_options *options, void *data)
+{
+	int i;
+	for (i = 0; i < q->nr; i++)
+	{
+		struct diff_filepair *p;
+		struct stat st;
+
+		p = q->queue[i];
+		if (p->one && lstat(p->one->path, &st)) {
+			warning("Could not stat %s", p->one->path);
+			continue;
+		}
+		add_to_index(&the_index, p->one->path, &st, 0);
+	}
+}
+
+int stash_non_patch(const char *i_tree,	const char *prefix)
+{
+	int result;
+	struct rev_info rev;
+	const char *wt_prefix = NULL;
+	unsigned char sha1[20];
+	const char *me = "git stash--helper";
+
+	read_index(&the_index);
+	refresh_cache(REFRESH_QUIET);
+	init_revisions(&rev, NULL);
+	add_head_to_pending(&rev);
+	rev.diffopt.output_format |= DIFF_FORMAT_CALLBACK;
+	rev.diffopt.format_callback = diff_callback;
+	rev.diffopt.format_callback_data=&result;
+	diff_setup_done(&rev.diffopt);
+	run_diff_index(&rev,0);
+	result = write_cache_as_tree(sha1, 0, wt_prefix);
+
+	switch (result) {
+	case 0:
+		printf("%s\n", sha1_to_hex(sha1));
+		break;
+	case WRITE_TREE_UNREADABLE_INDEX:
+		die("%s: error reading the index", me);
+		break;
+	case WRITE_TREE_UNMERGED_INDEX:
+		die("%s: error building trees", me);
+		break;
+	case WRITE_TREE_PREFIX_ERROR:
+		die("%s: prefix %s not found", me, wt_prefix);
+		break;
+	}
+	return result;
+}
+
+int cmd_stash__helper(int argc, const char **argv, const char *prefix)
+{
+	if (argc == 3 && !strcmp("--non-patch", argv[1]))
+		return stash_non_patch(argv[2], prefix);
+	usage(builtin_stash__helper_usage);
+}

--- a/git-stash.sh
+++ b/git-stash.sh
@@ -111,15 +111,7 @@ create_stash () {
 	then
 
 		# state of the working tree
-		w_tree=$( (
-			git read-tree --index-output="$TMPindex" -m $i_tree &&
-			GIT_INDEX_FILE="$TMPindex" &&
-			export GIT_INDEX_FILE &&
-			git diff-index --name-only -z HEAD -- >"$TMP-stagenames" &&
-			git update-index -z --add --remove --stdin <"$TMP-stagenames" &&
-			git write-tree &&
-			rm -f "$TMPindex"
-		) ) ||
+		w_tree=$(git stash--helper --non-patch $i_tree) ||
 			die "$(gettext "Cannot save the current worktree state")"
 
 	else

--- a/git.c
+++ b/git.c
@@ -493,6 +493,7 @@ static struct cmd_struct commands[] = {
 	{ "show-branch", cmd_show_branch, RUN_SETUP },
 	{ "show-ref", cmd_show_ref, RUN_SETUP },
 	{ "stage", cmd_add, RUN_SETUP | NEED_WORK_TREE },
+	{ "stash--helper", cmd_stash__helper, RUN_SETUP | NEED_WORK_TREE },
 	{ "status", cmd_status, RUN_SETUP | NEED_WORK_TREE },
 	{ "stripspace", cmd_stripspace },
 	{ "submodule--helper", cmd_submodule__helper, RUN_SETUP | SUPPORT_SUPER_PREFIX},


### PR DESCRIPTION
This is mainly about e740d9e, the other commits are regular upstream commits.

> stash--helper: implement "git stash--helper"
> 
> This patch implements a new "git stash--helper" builtin plumbing
> command that will be used to migrate "git-stash.sh" to C.
> 
> We start by implementing only the "--non-patch" option that will
> handle the core part of the non-patch stashing.

The other commits are in the pull request, because I based this on upstreams master. I want to introduce the stash--helper in another commit with a commit message simillar to 23b5f18 that contains this patch:

``` diff
diff --git a/git-stash.sh b/git-stash.sh
index c7c65e2..c0f8b12 100755
--- a/git-stash.sh
+++ b/git-stash.sh
@@ -112,15 +112,9 @@ create_stash () {
    then

        # state of the working tree
-       w_tree=$( (
-           git read-tree --index-output="$TMPindex" -m $i_tree &&
-           GIT_INDEX_FILE="$TMPindex" &&
-           export GIT_INDEX_FILE &&
-           git diff --name-only -z HEAD -- >"$TMP-stagenames" &&
-           git update-index -z --add --remove --stdin <"$TMP-stagenames" &&
-           git write-tree &&
-           rm -f "$TMPindex"
-       ) ) ||
+       w_tree=$(
+       git stash--helper --non-patch $TMPindex $TMP-stagenames $i_tree
+       ) ||
            die "$(gettext "Cannot save the current worktree state")"

    else
```
