### PR TITLE
Build Git with Stack Smashing Protector enabled

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -555,7 +555,8 @@ else
 			BASIC_LDFLAGS += -Wl,--large-address-aware
 		endif
 		CC = gcc
-		COMPAT_CFLAGS += -D__USE_MINGW_ANSI_STDIO=0 -DDETECT_MSYS_TTY
+		COMPAT_CFLAGS += -D__USE_MINGW_ANSI_STDIO=0 -DDETECT_MSYS_TTY \
+			-fstack-protector-strong
 		EXTLIBS += -lntdll
 		INSTALL = /bin/install
 		NO_R_TO_GCC_LINKER = YesPlease


### PR DESCRIPTION
Reference: http://wiki.osdev.org/Stack_Smashing_Protector

This was raised to me privately recently as a suggestion to harden Git from buffer overflows. From the link above:

> The Stack Smashing Protector (SSP) compiler feature helps detect stack buffer overrun by aborting if a secret value on the stack is changed. This serves a dual purpose in making the occurrence of such bugs visible and as exploit mitigation against return-oriented programming.

I've been looking into building the latest version of Git for Windows with this flag enabled, and am running through the test suite with these parameters:

> CFLAGS="-g -O2 -Wall -fstack-protector" make test

This injects a stack smashing protector into "functions with vulnerable objects". There's also some tougher options for GCC that can be used here `-fstack-protector-strong` and `-fstack-protector-all` but I think the first one is Good Enough™.

I'm not sure how upstream feels about this, but we can deal with that later.

Thoughts?