### PR TITLE
Quote shell path in iteractive rebase 'exec'

### DIFF
--- a/git-rebase--interactive.sh
+++ b/git-rebase--interactive.sh
@@ -610,7 +610,7 @@ do_next () {
 		read -r command rest < "$todo"
 		mark_action_done
 		printf 'Executing: %s\n' "$rest"
-		${SHELL:-@SHELL_PATH@} -c "$rest" # Actual execution
+		"${SHELL:-@SHELL_PATH@}" -c "$rest" # Actual execution
 		status=$?
 		# Run in subshell because require_clean_work_tree can die.
 		dirty=f


### PR DESCRIPTION
This fixes exec commands when there's a space in /bin/bash (e.g. default git for windows install path).

$SHELL will be something like "C:\Program Files\Git\bin\bash.exe" by default in msys.

Thoughts?