### PR TITLE
The readlink() function should be independent of core.symlinks

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2322,12 +2322,6 @@ int readlink(const char *path, char *buf, size_t bufsiz)
 	char tmpbuf[MAX_LONG_PATH];
 	int len;
 
-	/* fail if symlinks are disabled */
-	if (!has_symlinks) {
-		errno = ENOSYS;
-		return -1;
-	}
-
 	if (xutftowcs_long_path(wpath, path) < 0)
 		return -1;
 


### PR DESCRIPTION
This patch was motivated by a bug that was discovered: when calling git pack-refs --all in a working directory created via git-new-workdir, it will blow away the existing .git\packed-refs symlink that points to the source directory and replace packed-refs with a regular file with duplicate refs in it.  This patch fixes this.


Fix: readlink() not returning target symlink when it is desired

Core api command readlink() was depending on a git configuration specific setting of has_symlinks to decide whether it should attempt to return the target of a symlink.  It should be up to the caller to check whether symlink are enabled not up to the api command readlink().  If a caller wants to get a symlink target, then it should get it regardless of whether symlinks are configured in git.

This item is related to:
git-for-windows/git#220
and
git-for-windows/git#186
and
git-for-windows/git#225
