### PR TITLE
WIP opening git gui in non ANSI path

### DIFF
--- a/git-gui/git-gui.sh
+++ b/git-gui/git-gui.sh
@@ -270,10 +270,15 @@ proc is_Windows {} {
 proc is_Cygwin {} {
 	global _iscygwin
 	if {$_iscygwin eq {}} {
-		if {$::tcl_platform(platform) eq {windows} &&
-				(![info exists ::env(MSYSTEM)] ||
-				 $::env(MSYSTEM) ne {MSYS})} {
-			set _iscygwin 1
+		# force flag to non cygwin environment, it's a heavy hack / workaround
+		set _iscygwin 0
+		# or combine the previous and the current solution somehow like this?
+		if {[is_Windows] && (![info exists ::env(MSYSTEM)] || $::env(MSYSTEM) ne {MSYS})} {
+			if {[catch {set p [exec cygpath --windir]} err]} {
+ 				set _iscygwin 0
+ 			} else {
+ 				set _iscygwin 1
+ 			}
 		} else {
 			set _iscygwin 0
 		}
@@ -1274,6 +1279,7 @@ apply_config
 # v1.7.0 introduced --show-toplevel to return the canonical work-tree
 if {[package vcompare $_git_version 1.7.0] >= 0} {
 	if { [is_Cygwin] } {
+		# codepage conversion happens here TODO?
 		catch {set _gitworktree [exec cygpath --windows [git rev-parse --show-toplevel]]}
 	} else {
 		set _gitworktree [git rev-parse --show-toplevel]


### PR DESCRIPTION
Background:
In case when the git working folder contains special characters e.g. "á" the 
git gui could not be opened since the path gets converted to ANSI, 
thus the folder is not found.
Tracing back the bug lead me to the cygwin detection, 
but this could be unrelated.

Suspicious code parts:
- proc is_Cygwin (#L270 )
 it got changed in https://github.com/git-for-windows/git/commit/88f4ba9b9547e9c341cc602883e97fda9960554b
 could this be done in a simpler way? 
 (somehow like this: http://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux)

- _gitworktree evaluation (#L1277)
 especially [exec cygpath --windows [git rev-parse --show-toplevel]]
 cygpath accepts -C to specifying the code page for path printing e.g. -C UT8 - for my tests this did not helped

Original issue: 
https://github.com/git-for-windows/git/issues/410

The commit is untested and has been made via the GitHub online editor