### PR TITLE
added issue template mirroring wiki notes

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,55 @@
+ - [ ] I was not able to find an [open](https://github.com/git-for-windows/git/issues?q=is%3Aopen)
+   or [closed](https://github.com/git-for-windows/git/issues?q=is%3Aclosed) issue
+   matching what I'm seeing
+
+### Setup
+
+ - Which version of Git for Windows are you using? 32-bit or 64-bit? Include the
+   output of `git version` as well.
+
+ _TODO_
+
+```
+$ git --version
+_TODO_
+```
+
+ - Which version of Windows are you running? 32-bit or 64-bit?
+
+ _TODO_
+
+ - What options did you set as part of the installation? Or did you choose the
+   defaults?
+
+ _TODO_
+
+ - Any other interesting things about your environment that might be related
+   to the issue you're seeing?
+
+ _TODO_
+
+### Details
+
+ - Which terminal/shell are you running Git from? e.g Bash/CMD/PowerShell/other
+
+ _TODO_
+
+ - What commands did you run to trigger this issue? If you can provide a
+   [Minimal, Complete, and Verifiable example](http://stackoverflow.com/help/mcve)
+   this will help us understand the issue.
+
+```
+TODO
+```
+ - What did you expect to occur after running these commands?
+
+ _TODO_
+
+ - What actually happened instead?
+
+ _TODO_
+
+ - If the problem was occurring with a specific repository, can you provide the
+   URL to that repository to help us with testing?
+
+ _TODO_


### PR DESCRIPTION
This adds an template to the form when you create a new issue against this repository.

Example: https://github.com/shiftkey/testing-issue-template/issues/new

It's contents mostly reflect the documented [wiki](https://github.com/git-for-windows/git/wiki/Issue-reporting-guidelines) instructions, but helps to put this more into users faces when they land here.

