### PR TITLE
[WIP] Fix initial git gui message encoding

### DIFF
--- a/git-gui/git-gui.sh
+++ b/git-gui/git-gui.sh
@@ -1599,11 +1599,13 @@ proc run_prepare_commit_msg_hook {} {
 	if {[file isfile [gitdir MERGE_MSG]]} {
 		set pcm_source "merge"
 		set fd_mm [open [gitdir MERGE_MSG] r]
+		fconfigure $fd_mm -encoding utf-8
 		puts -nonewline $fd_pcm [read $fd_mm]
 		close $fd_mm
 	} elseif {[file isfile [gitdir SQUASH_MSG]]} {
 		set pcm_source "squash"
 		set fd_sm [open [gitdir SQUASH_MSG] r]
+		fconfigure $fd_sm -encoding utf-8
 		puts -nonewline $fd_pcm [read $fd_sm]
 		close $fd_sm
 	} else {


### PR DESCRIPTION
### Commit

This fix refers https://github.com/git-for-windows/git/issues/664

After `git merge --squash` git creates .git/SQUASH_MSG (UTF-8 encoded)
which contains squashed commits. When run `git gui` it copies SQUASH_MSG
to PREPARE_COMMIT_MSG, but without honoring UTF-8. This leads to encoding
problems on `git gui` commit prompt.

The same applies on git cherry-pick conflict, where MERGE_MSG is created
and then is copied to PREPARE_COMMIT_MSG.

In both cases PREPARE_COMMIT_MSG must be configured to store data in UTF-8.

Signed-off-by: yaras <yaras6@gmail.com>

### Worklist

- [x] Apply patch and rebuild
- [x] Manual test for `cherry-pick`
- [x] Manual test for `squash`
- [ ] Contact @patthoyts and announce this patch
- [ ] Check whether it is possible to write tests for `git-gui` and if so, write some tests