### PR TITLE
Fixed masking username with asterisks when reading credentials

### DIFF
--- a/credential.c
+++ b/credential.c
@@ -132,7 +132,7 @@ static void credential_getpass(struct credential *c)
 {
 	if (!c->username)
 		c->username = credential_ask_one("Username", c,
-						 PROMPT_ASKPASS|PROMPT_ECHO);
+						 PROMPT_ECHO);
 	if (!c->password)
 		c->password = credential_ask_one("Password", c,
 						 PROMPT_ASKPASS);


### PR DESCRIPTION
Fixes: https://github.com/git-for-windows/git/issues/675

When reading username PROMPT_ASKPASS is unnecessary.

Signed-off-by: yaras <yaras6@gmail.com>

---

After my change, username is asked in command prompt (without asterisks) and user password in _Open SSH prompt_ (with asterisks).

What you think about such solution?