### PR TITLE
Block paths which might be misinterpreted as alternate file streams

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2444,6 +2444,21 @@ int mingw_skip_dos_drive_prefix(char **path)
 	return ret;
 }
 
+int mingw_known_invalid(const char *path)
+{
+    // Colon is admissible as part of absolute path (e.g. "C:\file.txt")
+    // but otherwise invalid. Explicit checking done to prevent
+    // unintentional writing to alternate data stream path, e.g.
+    // "some\path\file:streamname"
+    if (path) {
+        path += has_dos_drive_prefix(path);
+        for (; *path; ++path)
+            if (*path == ':')
+                return 1;
+    }
+    return 0;
+}
+
 int mingw_offset_1st_component(const char *path)
 {
 	char *pos = (char *)path;

--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -423,6 +423,8 @@ HANDLE winansi_get_osfhandle(int fd);
 	(isalpha(*(path)) && (path)[1] == ':' ? 2 : 0)
 int mingw_skip_dos_drive_prefix(char **path);
 #define skip_dos_drive_prefix mingw_skip_dos_drive_prefix
+int mingw_known_invalid(const char *path);
+#define known_invalid mingw_known_invalid
 #define has_unc_prefix(path) (*(path) == '\\' && (path)[1] == '\\' ? 2 : 0)
 #define is_dir_sep(c) ((c) == '/' || (c) == '\\')
 static inline char *mingw_find_last_dir_sep(const char *path)

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -347,6 +347,14 @@ static inline int git_skip_dos_drive_prefix(char **path)
 #define skip_dos_drive_prefix git_skip_dos_drive_prefix
 #endif
 
+#ifndef known_invalid
+static inline int git_known_invalid(const char *path)
+{
+	return 0;
+}
+#define known_invalid git_known_invalid
+#endif
+
 #ifndef has_unc_prefix
 static inline int git_has_unc_prefix(const char *path)
 {

--- a/read-cache.c
+++ b/read-cache.c
@@ -809,6 +809,9 @@ int verify_path(const char *path)
 	if (has_dos_drive_prefix(path))
 		return 0;
 
+	if (known_invalid(path))
+		return 0;
+
 	goto inside;
 	for (;;) {
 		if (!c)
@@ -821,10 +824,9 @@ inside:
 				return 0;
 			c = *path++;
 			if ((c == '.' && !verify_dotfile(path)) ||
-			    is_dir_sep(c) || c == ':' || c == '\0')
+			    is_dir_sep(c) || c == '\0')
 				return 0;
-		} else if (c == ':')
-			return 0;
+		}
 		c = *path++;
 	}
 }

--- a/read-cache.c
+++ b/read-cache.c
@@ -821,9 +821,10 @@ inside:
 				return 0;
 			c = *path++;
 			if ((c == '.' && !verify_dotfile(path)) ||
-			    is_dir_sep(c) || c == '\0')
+			    is_dir_sep(c) || c == ':' || c == '\0')
 				return 0;
-		}
+		} else if (c == ':')
+			return 0;
 		c = *path++;
 	}
 }


### PR DESCRIPTION
ref https://github.com/git-for-windows/git/issues/679

Windows disallows the colon `:` character in file names. However many
win32 file APIs allow path specifications of the form `<file path>:<stuff>`
when reading or writing files. These are interpreted as pointing to
the _alternate data stream_ named `<stuff>` within the `<file path>` file.

Documentation on alternate data streams:
https://msdn.microsoft.com/en-us/library/windows/desktop/aa364404(v=vs.85).aspx

Git for Windows, ignorant of file streams, will incorrectly map a Unix
file named like `foo:bar` into the `bar` alternate stream of a file
`foo`. This results in an unexpected file `foo` with size 0 in the working
tree, and (depending on core.fscache setting), the expected "foo:bar" file
being flagged as deleted (or maybe not).

It would be preferrable if Git for Windows detected such files and issued
errors, similar to how it does for various other invalid path situations.
This would help reduce pain and make things less confusing for those
working in a mixed Unix/Windows team.

This change adds a check for ':' so that we never accidentally unpack a file
into an alternate stream by accident. Any file path with a ':' is considered
invalid, which is perfectly sensible for the purposes of git.

If such a file is indeed detected and blocked, users can instruct git to
totally ignore it via `git update-index --assume-unchanged`, just like
they need to today for other invalid path situations.

NB - a determined Windows user can still confuse the system in certain ways
by explicitly creating alternate streams, but that requires exceptional
user effort and is judged to be not worth pursuing at this time.

Signed-off-by: Lincoln Atkinson lincoln.atkinson@hotmail.com
