### PR TITLE
Make sure temporary file handles are not inherited by child processes

### DIFF
--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -67,6 +67,10 @@ typedef int pid_t;
 #define F_SETFD 2
 #define FD_CLOEXEC 0x1
 
+#if !defined O_CLOEXEC && defined O_NOINHERIT
+#define O_CLOEXEC	O_NOINHERIT
+#endif
+
 #ifndef EAFNOSUPPORT
 #define EAFNOSUPPORT WSAEAFNOSUPPORT
 #endif

--- a/t/t6026-merge-attr.sh
+++ b/t/t6026-merge-attr.sh
@@ -180,4 +180,19 @@ test_expect_success 'up-to-date merge without common ancestor' '
 	)
 '
 
+test_expect_success 'custom merge does not lock index' '
+	git reset --hard anchor &&
+
+	write_script sleep-one-second.sh <<-\EOF &&
+		sleep 1 &
+	EOF
+
+	printf "* merge=ours\ntext merge=sleep-one-second\n" >.gitattributes &&
+
+	git config merge.ours.driver "true" &&
+	git config merge.sleep-one-second.driver "./sleep-one-second.sh" &&
+
+	git merge master
+'
+
 test_done

--- a/tempfile.c
+++ b/tempfile.c
@@ -120,7 +120,7 @@ int create_tempfile(struct tempfile *tempfile, const char *path)
 	prepare_tempfile_object(tempfile);
 
 	strbuf_add_absolute_path(&tempfile->filename, path);
-	tempfile->fd = open(tempfile->filename.buf, O_RDWR | O_CREAT | O_EXCL, 0666);
+	tempfile->fd = open(tempfile->filename.buf, O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, 0666);
 	if (tempfile->fd < 0) {
 		strbuf_reset(&tempfile->filename);
 		return -1;


### PR DESCRIPTION
When testing a merge driver which spawns a merge server (for future merges)
I got the following error:
> Rename from 'xxx/.git/index.lock' to 'xxx/.git/index' failed. Should I try again? (y/n)

Only after I stop the merge server the lock is released.
This is caused by [windows handle inheritance](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724466%28v=vs.85%29.aspx)

Starting childs with bInheritHandles==FALSE does not work.
(For some reason the merge commit window did not pop up.)

However creating the handle with bInheritHandle==FALSE does seem to work.
Although I think this should not break anything, it would be great to get some feedback on this.

mcve:
```shell
git init

cat > mergetest.sh << EOF
#!/bin/sh
echo mergetest.sh

sleep 60 &
EOF

git config --local merge.mergetest.driver "./mergetest.sh %O %A %B %P"

echo "*.test merge=mergetest" > .gitattributes
echo first line > fake.test

git add .
git commit -m "initial"

git checkout -b other master
echo other change >> fake.test
git add fake.test
git commit -m "other"

git checkout -b this master
echo this change >> fake.test
git add fake.test
git commit -m "this"

#now try: git merge other
```