### PR TITLE
mingw: delete call to ShellExecute for opening help.

### DIFF
--- a/builtin/help.c
+++ b/builtin/help.c
@@ -379,17 +379,10 @@ static void get_html_page_path(struct strbuf *page_path, const char *page)
 	free(to_free);
 }
 
-/*
- * If open_html is not defined in a platform-specific way (see for
- * example compat/mingw.h), we use the script web--browse to display
- * HTML.
- */
-#ifndef open_html
 static void open_html(const char *path)
 {
 	execl_git_cmd("web--browse", "-c", "help.browser", path, (char *)NULL);
 }
-#endif
 
 static void show_html_page(const char *git_cmd)
 {

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2185,40 +2185,6 @@ int mingw_raise(int sig)
 }
 
 
-static const char *make_backslash_path(const char *path)
-{
-	static char buf[PATH_MAX + 1];
-	char *c;
-
-	if (strlcpy(buf, path, PATH_MAX) >= PATH_MAX)
-		die("Too long path: %.*s", 60, path);
-
-	for (c = buf; *c; c++) {
-		if (*c == '/')
-			*c = '\\';
-	}
-	return buf;
-}
-
-void mingw_open_html(const char *unixpath)
-{
-	const char *htmlpath = make_backslash_path(unixpath);
-	int r;
-	DECLARE_PROC_ADDR(shell32.dll, HINSTANCE, ShellExecuteA,
-			HWND, LPCSTR, LPCSTR, LPCSTR, LPCSTR, INT);
-
-	if (!INIT_PROC_ADDR(ShellExecuteA))
-		die("cannot load shell32.dll");
-
-	printf("Launching default browser to display HTML ...\n");
-	r = HCAST(int, ShellExecuteA(NULL, "open", htmlpath,
-				NULL, "\\", SW_SHOWNORMAL));
-	/* see the MSDN documentation referring to the result codes here */
-	if (r <= 32) {
-		die("failed to launch browser for %.*s", MAX_PATH, unixpath);
-	}
-}
-
 int link(const char *oldpath, const char *newpath)
 {
 	DECLARE_PROC_ADDR(kernel32.dll, BOOL, CreateHardLinkW,

--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -459,9 +459,6 @@ extern char *mingw_query_user_email(void);
 #include <inttypes.h>
 #endif
 
-void mingw_open_html(const char *path);
-#define open_html mingw_open_html
-
 /**
  * Max length of long paths (exceeding MAX_PATH). The actual maximum supported
  * by NTFS is 32,767 (* sizeof(wchar_t)), but we choose an arbitrary smaller


### PR DESCRIPTION
The Windows flavor of git calls ShellExecute to view web pages.  This call
launches the default handler for .html files.  The user is not able to
configure an alternative despite git having full support for doing so on
Windows.

The original request for this change dates back to 12-May-2014, and [refers
to dropping commit 4804aab][1] from the msysgit repository.  This is exactly
what this commit does.

[1]: https://github.com/msysgit/msysgit/issues/139