### PR TITLE
`git bundle create <bundle>` leaks handle the revlist is empty.

### DIFF
--- a/bundle.c
+++ b/bundle.c
@@ -447,10 +447,11 @@ int create_bundle(struct bundle_header *header, const char *path,
 	object_array_remove_duplicates(&revs.pending);
 
 	ref_count = write_bundle_refs(bundle_fd, &revs);
-	if (!ref_count)
-		die(_("Refusing to create empty bundle."));
-	else if (ref_count < 0)
+	if (ref_count <= 0)  {
+		if (!ref_count)
+			error(_("Refusing to create empty bundle."));
 		goto err;
+	}
 
 	/* write pack */
 	if (write_pack_data(bundle_fd, &revs)) {

--- a/t/tgfw790-git-bundle.sh
+++ b/t/tgfw790-git-bundle.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+test_description='
+  test git-bundle under git for Windows
+
+    When we select an empty set of commit (like git bundle create foobar.bundle master..master),
+    we should not have problem with the foobar.bundle.lock being locked (especially on Windows).
+'
+
+. ./test-lib.sh
+
+test_expect_failure 'try to create a bundle with empty ref count' '
+	git bundle create foobar.bundle master..master
+'
+
+test_done


### PR DESCRIPTION
issue #790: git bundle create does not close handle to *.lock file

This problem happens when an user tries to create an empty bundle, using the
following command:  `git bundle create <bundle> <revlist>` and when <revlist>
resolve to an empty list (for example, like `master..master`), `git bundle` fails
and warn the user about how it don't want to create empty bundle.

In that case, git tries to delete the `<bundle>.lock` file, and since there's still
an open file handle, fails to do so and ask the user if it should retry (which will
fail again).

The lock can still be deleted manually by the user (and it is required if the user
want to create a bundle after revising his rev-list).

Signed-off-by: Gaël Lhez <gael.lhez@gmail.com>