### PR TITLE
ISSUE_TEMPLATE for #846

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,24 +4,31 @@
 
 ### Setup
 
- - Which version of Git for Windows are you using? 32-bit or 64-bit? Include the
-   output of `git version` as well.
-
- _TODO_
+ - Which version of Git for Windows are you using? Is it 32-bit or 64-bit?
 
 ```
-$ git --version
+$ git --version --build-options
 _TODO_
 ```
 
- - Which version of Windows are you running? 32-bit or 64-bit?
+ - Which version of Windows are you running? Vista, 7, 8, 10? Is it 32-bit or 64-bit?
 
- _TODO_
+```
+$ cmd.exe /c ver
+_TODO_
+```
 
  - What options did you set as part of the installation? Or did you choose the
    defaults?
 
- _TODO_
+```
+# One of the following:
+> type "C:\Program Files\Git\etc\install-options.txt"
+> type "C:\Program Files (x86)\Git\etc\install-options.txt"
+> type "%USERPROFILE%\AppData\Local\Programs\Git\etc\install-options.txt"
+$ cat /etc/install_options.txt
+_TODO_
+```
 
  - Any other interesting things about your environment that might be related
    to the issue you're seeing?


### PR DESCRIPTION
MICRO ISSUE TRACKER: portability problems in suggested commands
- [x] `cmd /c ver` does not work in Git Bash because `cmd` is not in PATH
- [x] `cat /etc/install-options.txt` does not work in CMD because `/etc` isn't a real thing on Windows.

```
commit 3c8601c3b512ad97d0e420cef5b34b28425dae38
Author: Clive Chan <cc@clive.io>
Date:   Fri Aug 12 13:46:25 2016 -0400

    Add detail to ISSUE_TEMPLATE setup questions

    With the addition of the architecture (x86/x86_64) to git --version
    --build-options, it's good to add that to the Git version question.

    On the Windows version question, prompted for "Vista, 7, 8, 10? to
    indicate exactly what we're talking about. Also added `cmd /c ver as a
    command to run to get the Windows version, but it's not portable yet so
    that needs fixing before merging.

    On the installation options question, added `cat /etc/install-options.txt`
    to provide more information. This also is not portable and also needs to
    be fixed.

    Relevant Links:
    This is part of https://github.com/git-for-windows/git/pull/847.
    The git --version --build-options change discussion is at
    https://github.com/git-for-windows/git/issues/846

    Signed-off-by: Clive Chan <cc@clive.io>
```