### PR TITLE
Add reporting of build platform

### DIFF
--- a/help.c
+++ b/help.c
@@ -423,6 +423,8 @@ const char *help_unknown_cmd(const char *cmd)
 
 int cmd_version(int argc, const char **argv, const char *prefix)
 {
+	static char build_platform[] = GIT_BUILD_PLATFORM;
+
 	/*
 	 * The format of this string should be kept stable for compatibility
 	 * with external projects that rely on the output of "git version".
@@ -431,6 +433,7 @@ int cmd_version(int argc, const char **argv, const char *prefix)
 	while (*++argv) {
 		if (!strcmp(*argv, "--build-options")) {
 			printf("sizeof-long: %d\n", (int)sizeof(long));
+			printf("machine: %s\n", build_platform);
 			/* NEEDSWORK: also save and output GIT-BUILD_OPTIONS? */
 		}
 	}

--- a/help.h
+++ b/help.h
@@ -33,3 +33,16 @@ extern void list_commands(unsigned int colopts, struct cmdnames *main_cmds, stru
  */
 extern void help_unknown_ref(const char *ref, const char *cmd, const char *error);
 #endif /* HELP_H */
+
+/*
+ * identify build platform
+ */
+#ifndef GIT_BUILD_PLATFORM
+	#if defined __x86__ || defined __i386__ || defined __i586__ || defined __i686__
+		#define GIT_BUILD_PLATFORM "x86";
+	#elif defined __x86_64__
+		#define GIT_BUILD_PLATFORM "x86_64";
+	#else
+		#define GIT_BUILD_PLATFORM "unknown";
+	#endif
+#endif


### PR DESCRIPTION
@dscho This is my attempt to add build platform information to the output of `git version --build-options` for [Issue #846](https://github.com/git-for-windows/git/issues/846). For now it only understands x86 and x86_64, but I plan to extend the process to include other platforms as well (so that this hopefully won't end up being a Git for Windows specific item).

At present all of the 32-bit variants are collapsed into *x86*, which made sense to me at the time but may or may not be the most desirable approach. For example:

```
$ uname -m
i686

$ git version --build-options
git version 2.9.3.windows.2.826.gd486be9
sizeof-long: 4
machine: x86
```