### PR TITLE
Fix typo in issue reporting template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -26,7 +26,7 @@ _TODO_
 > type "C:\Program Files\Git\etc\install-options.txt"
 > type "C:\Program Files (x86)\Git\etc\install-options.txt"
 > type "%USERPROFILE%\AppData\Local\Programs\Git\etc\install-options.txt"
-$ cat /etc/install_options.txt
+$ cat /etc/install-options.txt
 _TODO_
 ```
 


### PR DESCRIPTION
Correct a one-character typo in the issue reporting template, for a
command which bug-reporters are requested to run in order to gather
the installation options.
