### PR TITLE
sha1: use openssl sha1 routines on mingw

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -515,7 +515,6 @@ ifneq (,$(findstring MINGW,$(uname_S)))
 	OBJECT_CREATION_USES_RENAMES = UnfortunatelyNeedsTo
 	NO_REGEX = YesPlease
 	NO_PYTHON = YesPlease
-	BLK_SHA1 = YesPlease
 	ETAGS_TARGET = ETAGS
 	NO_INET_PTON = YesPlease
 	NO_INET_NTOP = YesPlease


### PR DESCRIPTION
Use OpenSSL SHA1 routines rather than builtin block-sha routines.
This improves performance on SHA1 operations on Intel processors.

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>