### PR TITLE
git-cvsexportcommit.perl: Force crlf translation

### DIFF
--- a/git-cvsexportcommit.perl
+++ b/git-cvsexportcommit.perl
@@ -431,6 +431,7 @@ END
 sub safe_pipe_capture {
     my @output;
     if (my $pid = open my $child, '-|') {
+	binmode($child, ":crlf");
 	@output = (<$child>);
 	close $child or die join(' ',@_).": $! $?";
     } else {


### PR DESCRIPTION
This fixes a bug encountered when using cvsnt + msys + git. It seems like the output of `cvs status` had \r\n in it, and caused the command to fail. This fixes that.