### PR TITLE
Jeffhostetler/memihash perf

### DIFF
--- a/cache.h
+++ b/cache.h
@@ -173,6 +173,9 @@ struct cache_entry {
 	unsigned int ce_flags;
 	unsigned int ce_namelen;
 	unsigned int index;	/* for link extension */
+	unsigned int precompute_hash_state;
+	unsigned int precompute_hash_name;
+	unsigned int precompute_hash_dir;
 	unsigned char sha1[20];
 	char name[FLEX_ARRAY]; /* more */
 };
@@ -228,6 +231,19 @@ struct cache_entry {
 #if CE_EXTENDED_FLAGS & 0x803FFFFF
 #error "CE_EXTENDED_FLAGS out of range"
 #endif
+
+/*
+ * Bit set if preload-index precomputed the hash value(s)
+ * for this cache-entry.
+ */ 
+#define CE_PRECOMPUTE_HASH_STATE__SET   (1 << 0)
+/*
+ * Bit set if precompute-index also precomputed the hash value
+ * for the parent directory.
+ */ 
+#define CE_PRECOMPUTE_HASH_STATE__DIR   (1 << 1)
+
+void precompute_istate_hashes(struct cache_entry *ce);
 
 /* Forward structure decls */
 struct pathspec;

--- a/hashmap.c
+++ b/hashmap.c
@@ -50,6 +50,23 @@ unsigned int memihash(const void *buf, size_t len)
 	return hash;
 }
 
+/*
+ * Incoporate another chunk of data into a memihash
+ * computation.
+ */ 
+unsigned int memihash2(unsigned int hash_seed, const void *buf, size_t len)
+{
+	unsigned int hash = hash_seed;
+	unsigned char *ucbuf = (unsigned char *) buf;
+	while (len--) {
+		unsigned int c = *ucbuf++;
+		if (c >= 'a' && c <= 'z')
+			c -= 'a' - 'A';
+		hash = (hash * FNV32_PRIME) ^ c;
+	}
+	return hash;
+}
+
 #define HASHMAP_INITIAL_SIZE 64
 /* grow / shrink by 2^2 */
 #define HASHMAP_RESIZE_BITS 2

--- a/name-hash.c
+++ b/name-hash.c
@@ -148,7 +148,8 @@ static void lazy_init_name_hash(struct index_state *istate)
 		return;
 	hashmap_init(&istate->name_hash, (hashmap_cmp_fn) cache_entry_cmp,
 			istate->cache_nr);
-	hashmap_init(&istate->dir_hash, (hashmap_cmp_fn) dir_entry_cmp, 0);
+	hashmap_init(&istate->dir_hash, (hashmap_cmp_fn) dir_entry_cmp,
+			istate->cache_nr);
 	for (nr = 0; nr < istate->cache_nr; nr++)
 		hash_index_entry(istate, istate->cache[nr]);
 	istate->name_hash_initialized = 1;

--- a/name-hash.c
+++ b/name-hash.c
@@ -50,6 +50,17 @@ static struct dir_entry *hash_dir_entry(struct index_state *istate,
 	 */
 	struct dir_entry *dir;
 	unsigned int hash;
+	int use_precomputed_dir_hash = 0;
+
+	if (ce->precompute_hash_state & CE_PRECOMPUTE_HASH_STATE__SET) {
+		if (!ce->precompute_hash_state & CE_PRECOMPUTE_HASH_STATE__DIR)
+			return NULL; /* item does not have a parent directory */
+		if (namelen == ce_namelen(ce)) {
+			/* dir hash only valid for outer-most call (not recursive ones) */
+			use_precomputed_dir_hash = 1;
+			hash = ce->precompute_hash_dir;
+		}
+	}
 
 	/* get length of parent directory */
 	while (namelen > 0 && !is_dir_sep(ce->name[namelen - 1]))
@@ -59,7 +70,8 @@ static struct dir_entry *hash_dir_entry(struct index_state *istate,
 	namelen--;
 
 	/* lookup existing entry for that directory */
-	hash = memihash(ce->name, namelen);
+	if (!use_precomputed_dir_hash)
+		hash = memihash(ce->name, namelen);
 	dir = find_dir_entry__hash(istate, ce->name, namelen, hash);
 	if (!dir) {
 		/* not found, create it and add to hash table */
@@ -99,10 +111,18 @@ static void remove_dir_entry(struct index_state *istate, struct cache_entry *ce)
 
 static void hash_index_entry(struct index_state *istate, struct cache_entry *ce)
 {
+	unsigned int h;
+
 	if (ce->ce_flags & CE_HASHED)
 		return;
 	ce->ce_flags |= CE_HASHED;
-	hashmap_entry_init(ce, memihash(ce->name, ce_namelen(ce)));
+
+	if (ce->precompute_hash_state & CE_PRECOMPUTE_HASH_STATE__SET)
+		h = ce->precompute_hash_name;
+	else
+		h = memihash(ce->name, ce_namelen(ce));
+
+	hashmap_entry_init(ce, h);
 	hashmap_add(&istate->name_hash, ce);
 
 	if (ignore_case)
@@ -243,4 +263,46 @@ void free_name_hash(struct index_state *istate)
 
 	hashmap_free(&istate->name_hash, 0);
 	hashmap_free(&istate->dir_hash, 1);
+}
+
+/*
+ * Precompute the hash values for this cache_entry
+ * for use in the istate.name_hash and istate.dir_hash.
+ *
+ * If the item is in the root directory, just compute the
+ * hash value (for istate.name_hash) on the full path.
+ *
+ * If the item is in a subdirectory, first compute the
+ * hash value for the immediate parent directory (for
+ * istate.dir_hash) and then the hash value for the full
+ * path by continuing the computation.
+ *
+ * Note that these hashes will be used by
+ * wt_status_collect_untracked() as it scans the worktree
+ * and maps observed paths back to the index (optionally
+ * ignoring case).  Therefore, we probably only *NEED* to
+ * precompute this for non-skip-worktree items (since
+ * status should not observe skipped items), but because
+ * lazy_init_name_hash() hashes everything, we force it
+ * here.
+ */ 
+void precompute_istate_hashes(struct cache_entry *ce)
+{
+	int namelen = ce_namelen(ce);
+
+	while (namelen > 0 && !is_dir_sep(ce->name[namelen - 1]))
+		namelen--;
+
+	if (namelen <= 0) {
+		ce->precompute_hash_name = memihash(ce->name, ce_namelen(ce));
+		ce->precompute_hash_state = CE_PRECOMPUTE_HASH_STATE__SET;
+	} else {
+		namelen--;
+		ce->precompute_hash_dir = memihash(ce->name, namelen);
+		ce->precompute_hash_name = memihash2(
+			ce->precompute_hash_dir, &ce->name[namelen],
+			ce_namelen(ce) - namelen);
+		ce->precompute_hash_state =
+			CE_PRECOMPUTE_HASH_STATE__SET | CE_PRECOMPUTE_HASH_STATE__DIR;
+	}
 }

--- a/preload-index.c
+++ b/preload-index.c
@@ -47,6 +47,8 @@ static void *preload_thread(void *_data)
 		struct cache_entry *ce = *cep++;
 		struct stat st;
 
+		precompute_istate_hashes(ce);
+
 		if (ce_stage(ce))
 			continue;
 		if (S_ISGITLINK(ce->ce_mode))


### PR DESCRIPTION
A series of performance enhancements in the memihash and name-cache area.

On Windows, calls to memihash() and maintaining the istate.name_hash and istate.dir_hash HashMaps take significant time on very large repositories.  This series of changes reduces the overall time taken for various operations by reducing the number calls to memihash(), moving some of them into multi-threaded code, and etc.
