### PR TITLE
fixup! name-hash: precompute hash values during preload-index

### DIFF
--- a/read-cache.c
+++ b/read-cache.c
@@ -616,6 +616,7 @@ static struct cache_entry *create_alias_ce(struct index_state *istate,
 	new = xcalloc(1, cache_entry_size(len));
 	memcpy(new->name, alias->name, len);
 	copy_cache_entry(new, ce);
+	new->precompute_hash_state = 0;
 	save_or_free_index_entry(istate, ce);
 	return new;
 }


### PR DESCRIPTION
Clear the precompute flag in create_alias_ce().
It might be possible to use the precompute_ fields from the
alias in the new one, but its not worth the bother.

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>