### PR TITLE
add: use preload-index and fscache for performance

### DIFF
--- a/builtin/add.c
+++ b/builtin/add.c
@@ -376,9 +376,6 @@ int cmd_add(int argc, const char **argv, const char *prefix)
 		return 0;
 	}
 
-	if (read_cache() < 0)
-		die(_("index file corrupt"));
-
 	/*
 	 * Check the "pathspec '%s' did not match any files" block
 	 * below before enabling new magic.
@@ -388,6 +385,10 @@ int cmd_add(int argc, const char **argv, const char *prefix)
 		       PATHSPEC_SYMLINK_LEADING_PATH |
 		       PATHSPEC_STRIP_SUBMODULE_SLASH_EXPENSIVE,
 		       prefix, argv);
+
+	enable_fscache(1);
+	if (read_cache_preload(&pathspec) < 0)
+		die(_("index file corrupt"));
 
 	if (add_new_files) {
 		int baselen;


### PR DESCRIPTION
Teach "add" to use preload-index and fscache features
to improve performance on very large repositories.

During an "add", a call is made to run_diff_files()
which calls check_remove() for each index-entry.  This
calls lstat().  On Windows, the fscache code intercepts
the lstat() calls and builds a private cache using the
FindFirst/FindNext routines, which are much faster.

Somewhat independent of this, is the preload-index code
which distributes some of the start-up costs across
multiple threads.

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>