### PR TITLE
poll: Use GetTickCount64 to avoid wraparound issues

### DIFF
--- a/compat/poll/poll.c
+++ b/compat/poll/poll.c
@@ -446,7 +446,8 @@ poll (struct pollfd *pfd, nfds_t nfd, int timeout)
   static HANDLE hEvent;
   WSANETWORKEVENTS ev;
   HANDLE h, handle_array[FD_SETSIZE + 2];
-  DWORD ret, wait_timeout, nhandles, start = 0, elapsed, orig_timeout = 0;
+  DWORD ret, wait_timeout, nhandles, elapsed, orig_timeout = 0;
+  ULONGLONG start = 0;
   fd_set rfds, wfds, xfds;
   BOOL poll_again;
   MSG msg;
@@ -611,7 +612,7 @@ restart:
 
   if (!rc && orig_timeout && timeout != INFTIM)
     {
-      elapsed = GetTickCount64() - start;
+      elapsed = (DWORD)(GetTickCount64() - start);
       timeout = elapsed >= orig_timeout ? 0 : orig_timeout - elapsed;
     }
 

--- a/compat/poll/poll.c
+++ b/compat/poll/poll.c
@@ -462,7 +462,7 @@ poll (struct pollfd *pfd, nfds_t nfd, int timeout)
   if (timeout != INFTIM)
     {
       orig_timeout = timeout;
-      start = GetTickCount();
+      start = GetTickCount64();
     }
 
   if (!hEvent)
@@ -611,7 +611,7 @@ restart:
 
   if (!rc && orig_timeout && timeout != INFTIM)
     {
-      elapsed = GetTickCount() - start;
+      elapsed = GetTickCount64() - start;
       timeout = elapsed >= orig_timeout ? 0 : orig_timeout - elapsed;
     }
 


### PR DESCRIPTION
From Visual Studio 2015 Code Analysis: Warning C28159 Consider using
'GetTickCount64' instead of 'GetTickCount'. Reason: GetTickCount
overflows roughly every 49 days. Code that does not take that into
account can loop indefinitely.  GetTickCount64 operates on 64 bit
values and does not have that problem