### PR TITLE
connect: recognize [tortoise]plink in GIT_SSH_COMMAND

### DIFF
--- a/connect.c
+++ b/connect.c
@@ -772,6 +772,7 @@ struct child_process *git_connect(int fd[2], const char *url,
 			int putty = 0, tortoiseplink = 0;
 			char *ssh_host = hostandport;
 			const char *port = NULL;
+			char *ssh_argv0 = NULL;
 			transport_check_allowed("ssh");
 			get_host_and_port(&ssh_host, &port);
 
@@ -792,10 +793,16 @@ struct child_process *git_connect(int fd[2], const char *url,
 			}
 
 			ssh = get_ssh_command();
-			if (!ssh) {
-				const char *base;
-				char *ssh_dup;
+			if (ssh) {
+				char* split_ssh;
+				const char** ssh_argv;
 
+				split_ssh = xstrdup(ssh);
+				if (split_cmdline(split_ssh, &ssh_argv) >= 1) {
+					ssh_argv0 = xstrdup(ssh_argv[0]);
+				}
+				free(split_ssh);
+			} else {
 				/*
 				 * GIT_SSH is the no-shell version of
 				 * GIT_SSH_COMMAND (and must remain so for
@@ -807,8 +814,13 @@ struct child_process *git_connect(int fd[2], const char *url,
 				if (!ssh)
 					ssh = "ssh";
 
-				ssh_dup = xstrdup(ssh);
-				base = basename(ssh_dup);
+				ssh_argv0 = xstrdup(ssh);
+			}
+
+			if (ssh_argv0) {
+				const char *base;
+
+				base = basename(ssh_argv0);
 
 				tortoiseplink = !strcasecmp(base, "tortoiseplink") ||
 					!strcasecmp(base, "tortoiseplink.exe");
@@ -816,7 +828,7 @@ struct child_process *git_connect(int fd[2], const char *url,
 					!strcasecmp(base, "plink") ||
 					!strcasecmp(base, "plink.exe");
 
-				free(ssh_dup);
+				free(ssh_argv0);
 			}
 
 			argv_array_push(&conn->args, ssh);

--- a/t/t5601-clone.sh
+++ b/t/t5601-clone.sh
@@ -386,6 +386,18 @@ test_expect_success 'tortoiseplink is like putty, with extra arguments' '
 	expect_ssh "-batch -P 123" myhost src
 '
 
+test_expect_success 'double quoted plink.exe is treated specially (as putty) in GIT_SSH_COMMAND' '
+	copy_ssh_wrapper_as "$TRASH_DIRECTORY/plink.exe" &&
+	GIT_SSH_COMMAND="\"$TRASH_DIRECTORY/plink.exe\" -v" git clone "[myhost:123]:src" ssh-bracket-clone-plink-3 &&
+	expect_ssh "-v -P 123" myhost src
+'
+
+test_expect_success 'single quoted plink.exe is treated specially (as putty) in GIT_SSH_COMMAND' '
+	copy_ssh_wrapper_as "$TRASH_DIRECTORY/plink.exe" &&
+	GIT_SSH_COMMAND="'"'"'$TRASH_DIRECTORY/plink.exe'"'"' -v" git clone "[myhost:123]:src" ssh-bracket-clone-plink-4 &&
+	expect_ssh "-v -P 123" myhost src
+'
+
 # Reset the GIT_SSH environment variable for clone tests.
 setup_ssh_wrapper
 


### PR DESCRIPTION
When users want to pass some additional arguments to [tortoise]plink via
GIT_SSH, for example, setting a private key, the user is required to either
use a shell script named plink or tortoiseplink or duplicate the logic
that's already in Git for passing the correct style of command line
arguments, which can be difficult, error prone and annoying to get right.
They could have used GIT_SSH_COMMAND but Git doesn't detect [tortoise]plink
in this environment variable, meaning that Git would pass the wrong style
of command line arguments.  For example -p instead of -P.

This patch uses the logic that was used to recognize [tortoise]plink in
GIT_SSH for the GIT_SSH_COMMAND environment variable, allowing to use
GIT_SSH_COMMAND with [tortoise]plink directly.

Signed-off-by: Segev Finer <segev208@gmail.com>