### PR TITLE
connect: Add the envvar GIT_SSH_VARIANT and ssh.variant config

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -1957,6 +1957,12 @@ Environment variable settings always override any matches.  The URLs that are
 matched against are those given directly to Git commands.  This means any URLs
 visited as a result of a redirection do not participate in matching.
 
+ssh.variant::
+	Override the autodetection of plink/tortoiseplink in the SSH command that
+	'git fetch' and 'git push' use. It can be set to either `ssh`, `plink`,
+	`putty` or `tortoiseplink`. Any other value will be treated as normal ssh.
+	This is useful in case that Git gets this wrong.
+
 i18n.commitEncoding::
 	Character encoding the commit messages are stored in; Git itself
 	does not care per se, but this information is necessary e.g. when

--- a/Documentation/git.txt
+++ b/Documentation/git.txt
@@ -1013,6 +1013,13 @@ Usually it is easier to configure any desired options through your
 personal `.ssh/config` file.  Please consult your ssh documentation
 for further details.
 
+`GIT_SSH_VARIANT`::
+	If this environment variable is set, it overrides the autodetection
+	of plink/tortoiseplink in the SSH command that 'git fetch' and 'git push'
+	use. It can be set to either `ssh`, `plink`, `putty` or `tortoiseplink`.
+	Any other value will be treated as normal ssh. This is useful in case
+	that Git gets this wrong.
+
 `GIT_ASKPASS`::
 	If this environment variable is set, then Git commands which need to
 	acquire passwords or passphrases (e.g. for HTTP or IMAP authentication)

--- a/t/t5601-clone.sh
+++ b/t/t5601-clone.sh
@@ -401,6 +401,28 @@ test_expect_success 'single quoted plink.exe in GIT_SSH_COMMAND' '
 	expect_ssh "-v -P 123" myhost src
 '
 
+test_expect_success 'GIT_SSH_VARIANT overrides plink detection' '
+	copy_ssh_wrapper_as "$TRASH_DIRECTORY/plink" &&
+	GIT_SSH_VARIANT=ssh git clone "[myhost:123]:src" ssh-bracket-clone-variant-1 &&
+	expect_ssh "-p 123" myhost src
+'
+
+test_expect_success 'ssh.variant overrides plink detection' '
+	copy_ssh_wrapper_as "$TRASH_DIRECTORY/plink" &&
+	git -c ssh.variant=ssh clone "[myhost:123]:src" ssh-bracket-clone-variant-2 &&
+	expect_ssh "-p 123" myhost src
+'
+
+test_expect_success 'GIT_SSH_VARIANT overrides plink detection to plink' '
+	GIT_SSH_VARIANT=plink git clone "[myhost:123]:src" ssh-bracket-clone-variant-3 &&
+	expect_ssh "-P 123" myhost src
+'
+
+test_expect_success 'GIT_SSH_VARIANT overrides plink detection to tortoiseplink' '
+	GIT_SSH_VARIANT=tortoiseplink git clone "[myhost:123]:src" ssh-bracket-clone-variant-4 &&
+	expect_ssh "-batch -P 123" myhost src
+'
+
 # Reset the GIT_SSH environment variable for clone tests.
 setup_ssh_wrapper
 


### PR DESCRIPTION
This environment variable and configuration value allow to override the autodetection of plink/tortoiseplink in case that Git gets it wrong.

This was requested by Junio when @dscho tried to submit 936a410653c35f7b4121e7bc19c90485a81b5d74 upstream. Since I don't think Junio was convinced to accept the patch without this, I implemented what he asked.

Once and if this gets accepted you will probably have to use some Git trickery to arrange this as a set of two patches to send upstream.