### PR TITLE
git-gui: correctly restore GIT_DIR after invoking commands

### DIFF
--- a/git-gui/git-gui.sh
+++ b/git-gui/git-gui.sh
@@ -2203,6 +2203,8 @@ proc do_gitk {revs {is_submodule false}} {
 
 		if {$old_GIT_DIR ne {}} {
 			set env(GIT_DIR) $old_GIT_DIR
+		} else {
+			unset env(GIT_DIR)
 		}
 		cd $pwd
 


### PR DESCRIPTION
git-gui tries to temporary set GIT_DIR for running commands
and restore it back after it started. But in case of GIT_DIR which was
not set prior to invocation it is not unset after it.

Fix it.

Signed-off-by: Max Kirillov <max@max630.net>