### PR TITLE
mingw: Treat MAX_PATH as 248, not 260

### DIFF
--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -527,6 +527,14 @@ extern const char *program_data_config(void);
 #define MAX_LONG_PATH 4096
 
 /**
+ * By default MAX_PATH is of size 260, but when used for directory creation
+ * maximum chars allowed is 248. For simplicity sake we treat every path as
+ * directory (so all file paths in range 248-259 will be expanded but they
+ * not need to be).
+ */
+#define TRUE_MAX_PATH 248
+
+/**
  * Handles paths that would exceed the MAX_PATH limit of Windows Unicode APIs.
  *
  * With expand == false, the function checks for over-long paths and fails
@@ -542,8 +550,7 @@ extern const char *program_data_config(void);
  * Parameters:
  * path: path to check and / or convert
  * len: size of path on input (number of wide chars without \0)
- * max_path: max short path length to check (usually MAX_PATH = 260, but just
- * 248 for CreateDirectoryW)
+ * max_path: max short path length to check
  * expand: false to only check the length, true to expand the path to a
  * '\\?\'-prefixed absolute path
  *
@@ -637,7 +644,7 @@ static inline int xutftowcs_path_ex(wchar_t *wcs, const char *utf,
  */
 static inline int xutftowcs_path(wchar_t *wcs, const char *utf)
 {
-	return xutftowcs_path_ex(wcs, utf, MAX_PATH, -1, MAX_PATH, 0);
+	return xutftowcs_path_ex(wcs, utf, MAX_PATH, -1, TRUE_MAX_PATH, 0);
 }
 
 /**
@@ -649,7 +656,7 @@ static inline int xutftowcs_path(wchar_t *wcs, const char *utf)
  */
 static inline int xutftowcs_long_path(wchar_t *wcs, const char *utf)
 {
-	return xutftowcs_path_ex(wcs, utf, MAX_LONG_PATH, -1, MAX_PATH,
+	return xutftowcs_path_ex(wcs, utf, MAX_LONG_PATH, -1, TRUE_MAX_PATH,
 			core_long_paths);
 }
 

--- a/t/t2029-checkout-long-paths.sh
+++ b/t/t2029-checkout-long-paths.sh
@@ -17,6 +17,13 @@ test_expect_success setup '
 	p=$p$p$p$p$p && # -> 50
 	p=$p$p$p$p$p && # -> 250
 
+	# The base path (w/o filename) should be smaller than 260, but longer
+	# than 248 to show limitation of WinAPI that for creation of directories
+	# we need to expand the path even above 248. Hence value 250.
+	bp=$(echo $(pwd)) &&
+	let "len = 250 - ${#bp}" &&
+	p=${p:0:$len} &&
+
 	path=${p}/longtestfile && # -> 263 (MAX_PATH = 260)
 
 	blob=$(echo foobar | git hash-object -w --stdin) &&


### PR DESCRIPTION
Infamous limitation of Windows is the 260 max path length that requires
us to expand path to UNC (//?/) in order to cooperate with WinAPI.
Currently, we decide NOT to expand the path if the length of whole path
(base path + relative directory + filename) would not exceed 260.
Unfortunatelly, during creation of directory (base path + relative dir)
if we go over 248 we will trigger another limitation of Windows and
cause _wmkdir to fail.

In order not to complicate logic in handle_long_path (to detect whether
we are a directory and thus we need to use a different constant) we
limit ourselves to 248, always. It should have minimal impact on
performance as usually paths are either short, or pretty long and
expansion would happen anyway.

Signed-off by: Bartosz Bielecki <bielecki.b@gmail.com>