### PR TITLE
Makefile: clean EXE PDBs when MSVC=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2583,6 +2583,9 @@ endif
 	$(RM) GIT-SCRIPT-DEFINES GIT-PERL-DEFINES GIT-PYTHON-VARS
 ifdef MSVC
 	$(RM) $(patsubst %.o,%.o.pdb,$(OBJECTS))
+	$(RM) $(patsubst %.exe,%.pdb,$(OTHER_PROGRAMS))
+	$(RM) $(patsubst %.exe,%.pdb,$(PROGRAMS))
+	$(RM) $(patsubst %.exe,%.pdb,$(TEST_PROGRAMS))
 endif
 
 .PHONY: all install profile-clean clean strip


### PR DESCRIPTION
Teach main Makefile to also delete the PDB files for the
various EXE files during "make MSVC=1 clean".

Previously, we only deleted the PDB files associated with
individual .o files.

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>