### PR TITLE
VS2017 vcxproj

### DIFF
--- a/compat/vcbuild/packages.config
+++ b/compat/vcbuild/packages.config
@@ -12,15 +12,10 @@
   <package id="libssh2.redist" version="1.4.3.3" />
 
   <package id="openssl" version="1.0.2.1" />
-  <package id="openssl.v120.windesktop.msvcstl.dyn.rt-dyn" version="1.0.2.1" />
-  <package id="openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x64" version="1.0.2.0" />
-  <package id="openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x86" version="1.0.2.1" />
   <package id="openssl.v140.windesktop.msvcstl.dyn.rt-dyn" version="1.0.2.1" />
   <package id="openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x64" version="1.0.2.1" />
-  <package id="openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x86" version="1.0.2.1" />
 
   <package id="zlib" version="1.2.8.8" />
-  <package id="zlib.v120.windesktop.msvcstl.dyn.rt-dyn" version="1.2.8.8" />
   <package id="zlib.v140.windesktop.msvcstl.dyn.rt-dyn" version="1.2.8.8" />
 
 </packages>

--- a/contrib/buildsystems/Generators/Vcxproj.pm
+++ b/contrib/buildsystems/Generators/Vcxproj.pm
@@ -163,6 +163,13 @@ sub createProject {
         } elsif ($needsCurl && $1 eq 'expat') {
 	  # libexpat is only available targeting v100 and v110
 	  $libs .= ";$rel_dir\\compat\\vcbuild\\GEN.PKGS\\$1.$2\\build\\native\\lib\\v110\\\$(Platform)\\Release\\dynamic\\utf8\\libexpat.lib";
+	} elsif ($1 eq 'zlib') {
+	  # zlib
+	  $libs .= ";$rel_dir\\compat\\vcbuild\\GEN.PKGS\\$1.v140.windesktop.msvcstl.dyn.rt-dyn.$2\\lib\\native\\v140\\windesktop\\msvcstl\\dyn\\rt-dyn\\x64\\RelWithDebInfo\\zlib.lib";
+	} elsif ($1 eq 'openssl') {
+	  # openssl
+	  $libs .= ";$rel_dir\\compat\\vcbuild\\GEN.PKGS\\$1.v140.windesktop.msvcstl.dyn.rt-dyn.x64.$2\\lib\\native\\v140\\windesktop\\msvcstl\\dyn\\rt-dyn\\x64\\release\\libeay32.lib";
+	  $libs .= ";$rel_dir\\compat\\vcbuild\\GEN.PKGS\\$1.v140.windesktop.msvcstl.dyn.rt-dyn.x64.$2\\lib\\native\\v140\\windesktop\\msvcstl\\dyn\\rt-dyn\\x64\\release\\ssleay32.lib";
 	}
         next if ($1 =~  /^(zlib$|openssl(?!.*(x64|x86)$))/);
         my $targetsFile = "$rel_dir\\compat\\vcbuild\\GEN.PKGS\\$1.$2\\build\\native\\$1.targets";


### PR DESCRIPTION
Here is a fix for building inside VS2017 using the generated SLN and VCXPROJ files in vs/master.
For some reason, the existing PERL-generated project files built fine using VS2015, but failed to
link when building with VS2017 (with unsatisfied references in zlib and then openssl).

The fix here, adds explicit .lib references to the AdditionalDependencies parameter.  I left a TODO
in the commit message describing a possibly simpler fix.

@dscho Please see if this looks right to you.  I managed to get everything to compile and link, but
I wasn't sure how you were using some of the project dependencies and error handling at the bottom
of the resulting vcxproj files, so you may want to refactor this.  However you want to handle this is
fine with me.  Thanks!