### PR TITLE
mingw: use CreateHardLink directly

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2698,12 +2698,7 @@ int mingw_raise(int sig)
 
 int link(const char *oldpath, const char *newpath)
 {
-	DECLARE_PROC_ADDR(kernel32.dll, BOOL, CreateHardLinkW,
-			LPCWSTR, LPCWSTR, LPSECURITY_ATTRIBUTES);
 	wchar_t woldpath[MAX_LONG_PATH], wnewpath[MAX_LONG_PATH];
-
-	if (!INIT_PROC_ADDR(CreateHardLinkW))
-		return -1;
 
 	if (xutftowcs_long_path(woldpath, oldpath) < 0 ||
 	    xutftowcs_long_path(wnewpath, newpath) < 0)


### PR DESCRIPTION
It was observed that the current implementation of of get_proc_addr()
fails to load the kernel32.dll with code ERROR_INVALID_PARAMETER.
Probably the reason is that kernel32.dll is already loaded. The
behavior was seen at Windows SP1, both 32bit and 64bit. Probably it
would behave same way in some or all other Windows versions.

This breaks all usages of "clone --local", including the automatic
tests where they call it.

The function CreateHardLink is available in all supported Windows
versions (since Windows XP), so there is no more need to resolve it
in runtime.