### PR TITLE
enable fscache while iterating every local refs

### DIFF
--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -713,6 +713,7 @@ static int everything_local(struct fetch_pack_args *args,
 
 	save_commit_buffer = 0;
 
+	enable_fscache(1);
 	for (ref = *refs; ref; ref = ref->next) {
 		struct object *o;
 
@@ -733,6 +734,7 @@ static int everything_local(struct fetch_pack_args *args,
 				cutoff = commit->date;
 		}
 	}
+	enable_fscache(0);
 
 	if (!args->deepen) {
 		for_each_ref(mark_complete_oid, NULL);


### PR DESCRIPTION
When I do git fetch, git reads entries in .git/objects/pack for every refs in local repository.

By enabling fscache, directory list up in .git/objects/pack for each refs is cached.
Without fscache, such behavior causes long running time when we do git fetch in local repository having many refs.

This patch improves execution time in such case, especially in very large repository like chromium.
In my windows workstation, this patch improves git fetch time from more than 3 minutes to less than 20 seconds for chromium repository.

Signed-off-by: Takuto Ikuta <tikuta@chromium.org>