### PR TITLE
fetch-pack: specify OBJECT_INFO_QUICK to remove duplicate prepare_pac…

### DIFF
--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -716,7 +716,8 @@ static int everything_local(struct fetch_pack_args *args,
 	for (ref = *refs; ref; ref = ref->next) {
 		struct object *o;
 
-		if (!has_object_file(&ref->old_oid))
+		if (!has_object_file_with_flags(&ref->old_oid,
+						OBJECT_INFO_QUICK))
 			continue;
 
 		o = parse_object(&ref->old_oid);


### PR DESCRIPTION
…ked_git call

When I run git fetch, git tries to find object for each local and remote refs.
Without specifying OBJECT_INFO_QUICK, has_object_file list up entries in pack directory for each calls.

This patch makes git fetch fast for the repositories having large number of refs,
especially for windows because it's directory list up api is much slower than linux.

Signed-off-by: Takuto Ikuta <tikuta@chromium.org>