### PR TITLE
Revert "enable fscache while iterating every local refs"

### DIFF
--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -713,7 +713,6 @@ static int everything_local(struct fetch_pack_args *args,
 
 	save_commit_buffer = 0;
 
-	enable_fscache(1);
 	for (ref = *refs; ref; ref = ref->next) {
 		struct object *o;
 
@@ -734,7 +733,6 @@ static int everything_local(struct fetch_pack_args *args,
 				cutoff = commit->date;
 		}
 	}
-	enable_fscache(0);
 
 	if (!args->deepen) {
 		for_each_ref(mark_complete_oid, NULL);


### PR DESCRIPTION
This reverts commit 09ccec4.

Using fscache here is not right way.
It is better to specify OBJECT_INFO_QUICK flag for has_object_file instead.
This flag prevents directory list up for each refs also.

Signed-off-by: Takuto Ikuta <tikuta@chromium.org>