### PR TITLE
dir.c: regression fix for add_excludes with fscache

### DIFF
--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -9,11 +9,6 @@ static struct hashmap map;
 static CRITICAL_SECTION mutex;
 static struct trace_key trace_fscache = TRACE_KEY_INIT(FSCACHE);
 
-int fscache_is_enabled(void)
-{
-	return enabled;
-}
-
 /*
  * An entry in the file system cache. Used for both entire directory listings
  * and file entries.
@@ -257,7 +252,7 @@ static void fscache_clear(void)
 /*
  * Checks if the cache is enabled for the given path.
  */
-static inline int fscache_enabled(const char *path)
+int fscache_enabled(const char *path)
 {
 	return enabled > 0 && !is_absolute_path(path);
 }

--- a/compat/win32/fscache.h
+++ b/compat/win32/fscache.h
@@ -4,8 +4,8 @@
 int fscache_enable(int enable);
 #define enable_fscache(x) fscache_enable(x)
 
-int fscache_is_enabled(void);
-#define is_fscache_enabled() (fscache_is_enabled())
+int fscache_enabled(const char *path);
+#define is_fscache_enabled(path) fscache_enabled(path)
 
 DIR *fscache_opendir(const char *dir);
 int fscache_lstat(const char *file_name, struct stat *buf);

--- a/dir.c
+++ b/dir.c
@@ -758,6 +758,29 @@ static int add_excludes(const char *fname, const char *base, int baselen,
 	size_t size = 0;
 	char *buf, *entry;
 
+	/*
+	 * A performance optimization for status.
+	 *
+	 * During a status scan, git looks in each directory for a .gitignore
+	 * file before scanning the directory.  Since .gitignore files are not
+	 * that common, we can waste a lot of time looking for files that are
+	 * not there.  Fortunately, the fscache already knows if the directory
+	 * contains a .gitignore file, since it has already read the directory
+	 * and it already has the stat-data.
+	 *
+	 * If the fscache is enabled, use the fscache-lstat() interlude to see
+	 * if the file exists (in the fscache hash maps) before trying to open()
+	 * it.
+	 *
+	 * This causes problem when the .gitignore file is a symlink, because
+	 * we call lstat() rather than stat() on the symlnk and the resulting
+	 * stat-data is for the symlink itself rather than the target file.
+	 * We CANNOT use stat() here because the fscache DOES NOT install an
+	 * interlude for stat() and mingw_stat() always calls "open-fstat-close"
+	 * on the file and defeats the purpose of the optimization here.  Since
+	 * symlinks are even more rare than .gitignore files, we force a fstat()
+	 * after our open() to get stat-data for the target file.
+	 */
 	if (is_fscache_enabled(fname)) {
 		if (lstat(fname, &st) < 0) {
 			fd = -1;
@@ -765,6 +788,8 @@ static int add_excludes(const char *fname, const char *base, int baselen,
 			fd = open(fname, O_RDONLY);
 			if (fd < 0)
 				warn_on_fopen_errors(fname);
+			if (S_ISLNK(st.st_mode))
+				fstat(fd, &st);
 		}
 	} else {
 		fd = open(fname, O_RDONLY);

--- a/dir.c
+++ b/dir.c
@@ -758,7 +758,7 @@ static int add_excludes(const char *fname, const char *base, int baselen,
 	size_t size = 0;
 	char *buf, *entry;
 
-	if (is_fscache_enabled()) {
+	if (is_fscache_enabled(fname)) {
 		if (lstat(fname, &st) < 0) {
 			fd = -1;
 		} else {

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -1256,7 +1256,7 @@ static inline int is_missing_file_error(int errno_)
 #endif
 
 #ifndef is_fscache_enabled
-#define is_fscache_enabled() (0)
+#define is_fscache_enabled(path) (0)
 #endif
 
 extern int cmd_main(int, const char **);


### PR DESCRIPTION
Fix regression described in:
https://github.com/git-for-windows/git/issues/1392
which was introduced in:
https://github.com/git-for-windows/git/commit/b2353379bba414e6c00dde913497cc9c827366f2

When the user has a .gitignore file that is a symlink, the fscache
optimization introduced above caused the stat-data from the symlink,
rather that of the target file, to be returned.  Later when the ignore
file was read, the buffer length did not match the stat.st_size field
and we called die("cannot use <path> as an exclude file")

Added code to replace the stat-data when the path is a symlink.  This
preserves the effect of the performance gains for the normal case where
it is not a symlink.

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>
