### PR TITLE
Fix for issue #607 [git clean removes content of symlinks]

### DIFF
--- a/compat/win32.h
+++ b/compat/win32.h
@@ -9,7 +9,8 @@
 static inline int file_attr_to_st_mode (DWORD attr, DWORD tag)
 {
 	int fMode = S_IREAD;
-	if ((attr & FILE_ATTRIBUTE_REPARSE_POINT) && tag == IO_REPARSE_TAG_SYMLINK)
+	if ((attr & FILE_ATTRIBUTE_REPARSE_POINT) && 
+		(tag == IO_REPARSE_TAG_SYMLINK || tag == IO_REPARSE_TAG_MOUNT_POINT))
 		fMode |= S_IFLNK;
 	else if (attr & FILE_ATTRIBUTE_DIRECTORY)
 		fMode |= S_IFDIR;

--- a/compat/win32/dirent.c
+++ b/compat/win32/dirent.c
@@ -16,8 +16,9 @@ static inline void finddata2dirent(struct dirent *ent, WIN32_FIND_DATAW *fdata)
 	xwcstoutf(ent->d_name, fdata->cFileName, MAX_PATH * 3);
 
 	/* Set file type, based on WIN32_FIND_DATA */
-	if ((fdata->dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)
-			&& fdata->dwReserved0 == IO_REPARSE_TAG_SYMLINK)
+	if ((fdata->dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) && 
+		(fdata->dwReserved0 == IO_REPARSE_TAG_SYMLINK || 
+		 fdata->dwReserved0 == IO_REPARSE_TAG_MOUNT_POINT))
 		ent->d_type = DT_LNK;
 	else if (fdata->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 		ent->d_type = DT_DIR;


### PR DESCRIPTION
The problem this PR solves has been reported in issue #607.

There was already existing code in the readlink function of mingw.c that correctly handled mount points (AKA 'junctions') see line 2813 of mingw.c:
```
/* get target path for symlinks or mount points (aka 'junctions') */
       switch (b->ReparseTag) {
       case IO_REPARSE_TAG_SYMLINK:
              wbuf = (WCHAR*) (((char*) b->SymbolicLinkReparseBuffer.PathBuffer)
                           + b->SymbolicLinkReparseBuffer.SubstituteNameOffset);
              *(WCHAR*) (((char*) wbuf)
                           + b->SymbolicLinkReparseBuffer.SubstituteNameLength) = 0;
              break;
       case IO_REPARSE_TAG_MOUNT_POINT:
              wbuf = (WCHAR*) (((char*) b->MountPointReparseBuffer.PathBuffer)
                           + b->MountPointReparseBuffer.SubstituteNameOffset);
              *(WCHAR*) (((char*) wbuf)
                           + b->MountPointReparseBuffer.SubstituteNameLength) = 0;
              break;
       default:
              errno = EINVAL;
              return -1;
       }
```
It was therefore rather straight-forward to replicate that check into the two other locations where links are handled. 

It should also be noted that junctions (mount points) work like symbolic links (they are soft).  That is, if you rename the target directory (junctions only work for directories) the link doesn't update - i.e. it points to a path that has vanished. This is exactly like symbolic links.  If this was a hard link the link would automatically update because hard links point to the underlying file data (inode), they don't point to a path.

Let's say you agree that this should be fixed then it's still valid to to reject the patch if the fix isn't correctly implemented. For instance, how do we know that the check for junction (mount point) that is being used in this pull request is correct? To support that claim I offer this: https://msdn.microsoft.com/en-us/library/aa363940.aspx.  I can also point back to the code in mingw.c that already exists in Git for Windows and I cited above.

Testing
--------
*Use a standard Windows command prompt for the following (except the Git commands)*
1. Make directories in temp to act as link targets, i.e. `mkdir %temp%\junction-target` and `mkdir %temp%\symlink-target%`
2. Put files into both directories, e.g. `echo Testing >%temp%\junction-target\test.txt` and `echo Testing >%temp%\symlink-target\test.txt`.
3. Change current directory into the root of a git repo (you can use your git for windows repo for this)
4. Make a directory name test-links, i.e. `mkdir test-links`.
5. Change current directory to test-links, i.e. `cd test-links`.
6. Create a junction soft link, i.e. `mklink /j junction %temp%\junction-target`
7. Create a symbolic soft link, i.e. `mklink /d symlink %temp%\symlink-target` (you need admin privileges to perform this operation so run an elevated command prompt)
8. Perform a directory listing to see that everything looks as expected, `dir`
9. Now switch to your Git command line console.  Inside the test-links folder execute `git clean -xdfn`
10. If you are running Git prior to this patch you will notice that junction is listed as a directory (notice the trailing slash) while symlink is listed as a file/link (no trailing slash).  If you are running with this patch you will notice that both are treated the same.
11. Now execute `git clean -xdf`.
12. If you are using git prior to this patch you will notice that the contents of %temp%\junction-target have been deleted but the contents of %temp%\symlink-target are intact. If you are running git with this patch you will notice that both target folders in %temp% have been left intact. 