### PR TITLE
POC: Simplify clean command's approach remove_dirs 

### DIFF
--- a/builtin/clean.c
+++ b/builtin/clean.c
@@ -171,6 +171,15 @@ static int remove_dirs(struct strbuf *path, const char *prefix, int force_flag,
 		goto out;
 	}
 
+	/* first try the simple approach, recursion may not be needed if empty dir, symlink, junction, etc. */
+	res = dry_run ? 0 : unlink(path->buf);
+	if (res == 0) {
+		printf(dry_run ?  _(msg_would_remove) : _(msg_remove), path->buf);
+		ret = res;
+		goto out;
+	}
+
+	/* failure of simple approach needs no message, begin the walk through contents of directory */
 	dir = opendir(path->buf);
 	if (!dir) {
 		/* an empty dir could be removed even if it is unreadble */


### PR DESCRIPTION
This is a proof of concept PR for discussion only, do not merge.

I'm not currently able to get tests to pass with this change.

Fixes #607 which only happens with Junction Points on Windows.   The fix discussed in the issue was to first try the simple approach of deleting a directory with unlink before launching into recursing into its directory structure.
