### PR TITLE
fetch-pack.c: enable fscache for stats under .git/objects

### DIFF
--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -713,6 +713,7 @@ static int everything_local(struct fetch_pack_args *args,
 
 	save_commit_buffer = 0;
 
+	enable_fscache(1);
 	for (ref = *refs; ref; ref = ref->next) {
 		struct object *o;
 
@@ -734,6 +735,7 @@ static int everything_local(struct fetch_pack_args *args,
 				cutoff = commit->date;
 		}
 	}
+	enable_fscache(0);
 
 	if (!args->deepen) {
 		for_each_ref(mark_complete_oid, NULL);


### PR DESCRIPTION
When I do git fetch, git call file stats under .git/objects for each
refs. This takes time when there are many refs.

By enabling fscache, git takes file stats by directory traversing and that
improved the speed of fetch-pack for repository having large number of
refs.

In my windows workstation, this improves the time of `git fetch` for
chromium repository like below. I took stats 3 times.

* With this patch
TotalSeconds: 9.9825165
TotalSeconds: 9.1862075
TotalSeconds: 10.1956256
Avg: 9.78811653333333

* Without this patch
TotalSeconds: 15.8406702
TotalSeconds: 15.6248053
TotalSeconds: 15.2085938
Avg: 15.5580231

Signed-off-by: Takuto Ikuta <tikuta@chromium.org>