### PR TITLE
reset.c: enable fscache

### DIFF
--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -52,6 +52,7 @@ static int reset_index(const struct object_id *oid, int reset_type, int quiet)
 	struct tree *tree;
 	struct unpack_trees_options opts;
 	int ret = -1;
+	int unpack_result;
 
 	memset(&opts, 0, sizeof(opts));
 	opts.head_idx = 1;
@@ -91,7 +92,11 @@ static int reset_index(const struct object_id *oid, int reset_type, int quiet)
 	}
 	nr++;
 
-	if (unpack_trees(nr, desc, &opts))
+	enable_fscache(1);
+	unpack_result = unpack_trees(nr, desc, &opts);
+	enable_fscache(0);
+
+	if (unpack_result)
 		goto out;
 
 	if (reset_type == MIXED || reset_type == HARD) {


### PR DESCRIPTION
In git reset --hard, unpack-trees() is called with oneway_merge().
oneway_merge calls lstat for each files in a repository.
It is bottleneck of git reset --hard, especially in large repository.

This patch improves time by using fscache.
In chromium repository, time of git reset --hard is changed like below.
I took 3 times stats in the repository.

master:
TotalSeconds: 21.0337971
TotalSeconds: 20.0046612
TotalSeconds: 20.6501752
Avg: 20.5628778333333

this patch:
TotalSeconds: 4.8552376
TotalSeconds: 4.8722343
TotalSeconds: 4.9268245
Avg: 4.88476546666667

Signed-off-by: Takuto Ikuta <tikuta@chromium.org>
