### PR TITLE
1422 Properly Color Failed Remote Push Messages

### DIFF
--- a/builtin/push.c
+++ b/builtin/push.c
@@ -12,11 +12,39 @@
 #include "submodule.h"
 #include "submodule-config.h"
 #include "send-pack.h"
+#include "color.h"
 
 static const char * const push_usage[] = {
 	N_("git push [<options>] [<repository> [<refspec>...]]"),
 	NULL,
 };
+
+static int push_use_color = -1;
+static char push_colors[][COLOR_MAXLEN] = {
+	GIT_COLOR_RESET,
+	GIT_COLOR_RED,	/* ERROR */
+};
+
+enum color_push {
+	PUSH_COLOR_RESET = 0,
+	PUSH_COLOR_ERROR = 1
+};
+
+static int parse_push_color_slot(const char *slot)
+{
+	if (!strcasecmp(slot, "reset"))
+		return PUSH_COLOR_RESET;
+	if (!strcasecmp(slot, "error"))
+		return PUSH_COLOR_ERROR;
+	return -1;
+}
+
+static const char *push_get_color(enum color_push ix)
+{
+	if (want_color(push_use_color))
+		return push_colors[ix];
+	return "";
+}
 
 static int thin = 1;
 static int deleterefs;
@@ -338,7 +366,9 @@ static int push_with_options(struct transport *transport, int flags)
 	err = transport_push(transport, refspec_nr, refspec, flags,
 			     &reject_reasons);
 	if (err != 0)
+		fprintf(stderr, "%s", push_get_color(PUSH_COLOR_ERROR));
 		error(_("failed to push some refs to '%s'"), transport->url);
+		fprintf(stderr, "%s", push_get_color(PUSH_COLOR_RESET));
 
 	err |= transport_disconnect(transport);
 	if (!err)

--- a/transport.c
+++ b/transport.c
@@ -18,6 +18,34 @@
 #include "sha1-array.h"
 #include "sigchain.h"
 #include "transport-internal.h"
+#include "color.h"
+
+static int transport_use_color = -1;
+static char transport_colors[][COLOR_MAXLEN] = {
+	GIT_COLOR_RESET,
+	GIT_COLOR_RED		/* REJECTED */
+};
+
+enum color_transport {
+	TRANSPORT_COLOR_RESET = 0,
+	TRANSPORT_COLOR_REJECTED = 1
+};
+
+static int parse_transport_color_slot(const char *slot)
+{
+	if (!strcasecmp(slot, "reset"))
+		return TRANSPORT_COLOR_RESET;
+	if (!strcasecmp(slot, "rejected"))
+		return TRANSPORT_COLOR_REJECTED;
+	return -1;
+}
+
+static const char *transport_get_color(enum color_transport ix)
+{
+	if (want_color(transport_use_color))
+		return transport_colors[ix];
+	return "";
+}
 
 static void set_upstreams(struct transport *transport, struct ref *refs,
 	int pretend)
@@ -326,7 +354,11 @@ static void print_ref_status(char flag, const char *summary,
 		else
 			fprintf(stdout, "%s\n", summary);
 	} else {
-		fprintf(stderr, " %c %-*s ", flag, summary_width, summary);
+		if (strstr(summary, "rejected") != NULL || strstr(summary, "failure") != NULL)
+			fprintf(stderr, " %s%c %-*s%s ", transport_get_color(TRANSPORT_COLOR_REJECTED),
+				flag, summary_width, summary, transport_get_color(TRANSPORT_COLOR_RESET));
+		else
+			fprintf(stderr, " %c %-*s ", flag, summary_width, summary);
 		if (from)
 			fprintf(stderr, "%s -> %s", prettify_refname(from->name), prettify_refname(to->name));
 		else


### PR DESCRIPTION
**area**: transport.c, push.c, advice.c

**problem**:  This is an attempt to resolve an issue I experience with people that are new to Git -- especially colleagues in a team setting -- where they miss that their push to a remote location failed because the failure and success both return a block of white text.

**solution**: I received some guidance from the community on how to do it myself and I did my best to model after existing code (especially since C is not my wheelhouse).  When a push to remote errors/is rejected/fails, the output text for the rejection message and the error is colored red and the advice hints are colored yellow.

Before:
![git-push-message](https://user-images.githubusercontent.com/8908849/35024232-91638abe-fafb-11e7-9c12-e33bb18a75aa.JPG)

After:
![capture](https://user-images.githubusercontent.com/8908849/34974840-3eb26e66-fa4c-11e7-81ea-85b0b5f388df.PNG)

https://github.com/git-for-windows/git/issues/1422#issuecomment-355962979

Signed-off-by:  Ryan Dammrose <ryandammrose@gmail.com>
