### PR TITLE
checkout.c: use fscache stat only in usable place

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -359,7 +359,7 @@ static int checkout_paths(const struct checkout_opts *opts,
 	state.istate = &the_index;
 
 	enable_delayed_checkout(&state);
-	enable_fscache(1);
+	enable_explicit_fscache(1);
 	for (pos = 0; pos < active_nr; pos++) {
 		struct cache_entry *ce = active_cache[pos];
 		if (ce->ce_flags & CE_MATCHED) {
@@ -374,7 +374,7 @@ static int checkout_paths(const struct checkout_opts *opts,
 			pos = skip_same_name(ce, pos) - 1;
 		}
 	}
-	enable_fscache(0);
+	enable_explicit_fscache(0);
 	errs |= finish_delayed_checkout(&state);
 
 	if (write_locked_index(&the_index, &lock_file, COMMIT_LOCK))

--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -377,8 +377,9 @@ static struct fsentry *fscache_get(struct fsentry *key)
 /*
  * Enables or disables the cache. Note that the cache is read-only, changes to
  * the working directory are NOT reflected in the cache while enabled.
+ * If explicit_only is set, only explicit call of fscache_lstat uses fscache.
  */
-int fscache_enable(int enable)
+int fscache_enable(int enable, int explicit_only)
 {
 	int result;
 
@@ -396,9 +397,11 @@ int fscache_enable(int enable)
 			: InterlockedDecrement(&enabled);
 
 	if (enable && result == 1) {
-		/* redirect opendir and lstat to the fscache implementations */
-		opendir = fscache_opendir;
-		lstat = fscache_lstat;
+		if (!explicit_only) {
+			/* redirect opendir and lstat to the fscache implementations */
+			opendir = fscache_opendir;
+			lstat = fscache_lstat;
+		}
 	} else if (!enable && !result) {
 		/* reset opendir and lstat to the original implementations */
 		opendir = dirent_opendir;

--- a/compat/win32/fscache.h
+++ b/compat/win32/fscache.h
@@ -1,8 +1,10 @@
 #ifndef FSCACHE_H
 #define FSCACHE_H
 
-int fscache_enable(int enable);
-#define enable_fscache(x) fscache_enable(x)
+int fscache_enable(int enable, int explicit_only);
+#define enable_fscache(x) fscache_enable(x, 0)
+
+#define enable_explicit_fscache(x) fscache_enable(x, 1)
 
 int fscache_enabled(const char *path);
 #define is_fscache_enabled(path) fscache_enabled(path)

--- a/entry.c
+++ b/entry.c
@@ -5,6 +5,7 @@
 #include "submodule.h"
 #include "progress.h"
 #include "fsmonitor.h"
+#include "git-compat-util.h"
 
 static void create_directories(const char *path, int path_len,
 			       const struct checkout *state)
@@ -395,7 +396,7 @@ static int check_path(const char *path, int len, struct stat *st, int skiplen)
 		errno = ENOENT;
 		return -1;
 	}
-	return lstat(path, st);
+	return fscache_lstat(path, st);
 }
 
 /*

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -1276,6 +1276,8 @@ static inline int is_missing_file_error(int errno_)
  */
 #ifndef enable_fscache
 #define enable_fscache(x) /* noop */
+#define enable_explicit_fscache(x) /* noop */
+#define fscache_lstat lstat
 #endif
 
 #ifndef is_fscache_enabled


### PR DESCRIPTION
This is fix for #1438, #1442
This patch introduces explicitly enabled fscache_lstat and
fix the issue stat unintendedly returned from cache.

I replace lstat with fscache_lstat in check_path called for every file in a repository.

When we run `git checkout`, following two conditions are hold.
* check_path is only called to get stat of file in working tree before checked out.
* check_path is not called for the file after it is checked out.

So cached stat when directory traversing does not affect returned value in check_path here.

Signed-off-by: Takuto Ikuta <tikuta@chromium.org>