### PR TITLE
Revert "reset.c: enable fscache"

### DIFF
--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -52,7 +52,6 @@ static int reset_index(const struct object_id *oid, int reset_type, int quiet)
 	struct tree *tree;
 	struct unpack_trees_options opts;
 	int ret = -1;
-	int unpack_result;
 
 	memset(&opts, 0, sizeof(opts));
 	opts.head_idx = 1;
@@ -92,11 +91,7 @@ static int reset_index(const struct object_id *oid, int reset_type, int quiet)
 	}
 	nr++;
 
-	enable_fscache(1);
-	unpack_result = unpack_trees(nr, desc, &opts);
-	enable_fscache(0);
-
-	if (unpack_result)
+	if (unpack_trees(nr, desc, &opts))
 		goto out;
 
 	if (reset_type == MIXED || reset_type == HARD) {


### PR DESCRIPTION
This reverts commit fcba80a2696c48fba77dd2ab3810092476e36fc2.
Usinsg fscache for reset broke git worktree, git stash. #1437 #1440 

Signed-off-by: Takuto Ikuta <tikuta@chromium.org>
