### PR TITLE
adding http.schannel.checkRevoke support

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -2025,6 +2025,14 @@ http.sslBackend::
 	This option is ignored if cURL lacks support for choosing the SSL
 	backend at runtime.
 
+http.schannel.checkRevoke::
+	Used to enforce or disable certificate revocation checks in cURL
+	when http.sslBackend is set to "schannel". Defaults to `true` if
+	unset. Only necessary to disable this if Git consistently errors
+	and the message is about checking the revocation status of a
+	certificate. This option is ignored if cURL lacks support for 
+	setting the relevant SSL option at runtime.
+
 http.pinnedpubkey::
 	Public key of the https service. It may either be the filename of
 	a PEM or DER encoded public key file or a string starting with

--- a/http.c
+++ b/http.c
@@ -148,6 +148,8 @@ static char *cached_accept_language;
 
 static char *http_ssl_backend;
 
+static int http_schannel_check_revoke = 1;
+
 size_t fread_buffer(char *ptr, size_t eltsize, size_t nmemb, void *buffer_)
 {
 	size_t size = eltsize * nmemb;
@@ -298,6 +300,11 @@ static int http_options(const char *var, const char *value, void *cb)
 	if (!strcmp("http.sslbackend", var)) {
 		free(http_ssl_backend);
 		http_ssl_backend = xstrdup_or_null(value);
+		return 0;
+	}
+
+	if (!strcmp("http.schannel.checkRevoke", var)) {
+		http_schannel_check_revoke = git_config_bool(var, value);
 		return 0;
 	}
 
@@ -745,6 +752,15 @@ static CURL *get_curl_handle(void)
 				curl_deleg);
 	}
 #endif
+
+	if (!strcmp("schannel", http_ssl_backend) && !http_schannel_check_revoke) {
+#if LIBCURL_VERSION_NUM >= 0x074400
+		curl_easy_setopt(result, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NO_REVOKE);
+#else
+		warning("CURLSSLOPT_NO_REVOKE not applied to curl SSL options because\n"
+			"your curl version is too old (>= 7.44.0)");
+#endif
+	}
 
 	if (http_proactive_auth)
 		init_curl_http_auth(result);


### PR DESCRIPTION
Fixes #1446 

Opening this up early to gather feedback (I'm not strong on curl's internals) as I think we're all in agreement on the approach:

 - [x] implement the config lookup
 - [x] set this flag on the curl operation when `schannel` is the backend
 - [x] default to true if unset
 - [x] add mention in docs
