### PR TITLE
crtdbg: fix MSVC CRTDBG memory leak reporting

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -428,8 +428,6 @@ else
 endif
 	BASIC_CFLAGS += $(sdk_libs) $(msvc_libs)
 
-	# Optionally enable memory leak reporting.
-	# BASIC_CLFAGS += -DUSE_MSVC_CRTDBG
 	BASIC_CFLAGS += -DPROTECT_NTFS_DEFAULT=1
 	# Always give "-Zi" to the compiler and "-debug" to linker (even in
 	# release mode) to force a PDB to be generated (like RelWithDebInfo).
@@ -446,6 +444,11 @@ ifndef DEBUG
 	AR += -LTCG
 else
 	BASIC_CFLAGS += -MDd -DDEBUG -D_DEBUG
+ifdef CRTDBG
+	# Optionally enable memory leak reporting using:
+	#    make MSVC=1 DEBUG=1 CRTDBG=1
+	BASIC_CFLAGS += -DUSE_MSVC_CRTDBG=1
+endif
 endif
 	X = .exe
 

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -6,8 +6,11 @@
  * For these to work they must appear very early in each
  * file -- before most of the standard header files.
  */
+#define _CRTDBG_MAP_ALLOC
 #include <stdlib.h>
 #include <crtdbg.h>
+#undef getcwd /* don't complain about mapping to mingw_getcwd() */
+#undef free /* don't collide with structure fields named "free" */
 #endif
 
 #define _FILE_OFFSET_BITS 64

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -9,8 +9,26 @@
 #define _CRTDBG_MAP_ALLOC
 #include <stdlib.h>
 #include <crtdbg.h>
-#undef getcwd /* don't complain about mapping to mingw_getcwd() */
-#undef free /* don't collide with structure fields named "free" */
+#undef getcwd       /* don't complain about mapping to mingw_getcwd() */
+#undef free         /* don't collide with structure fields named "free" */
+
+#define xstrdup(s)           crtdbg_xstrdup((s), __FILE__, __LINE__)
+#define xmalloc(s)           crtdbg_xmalloc((s), __FILE__, __LINE__)
+#define xmallocz(s)          crtdbg_xmallocz((s), __FILE__, __LINE__)
+#define xmallocz_gently(s)   crtdbg_xmallocz_gently((s), __FILE__, __LINE__)
+#define xmemdupz(s, l)       crtdbg_xmemdupz((s), (l), __FILE__, __LINE__)
+#define xstrndup(s, l)       crtdbg_xstrndup((s), (l), __FILE__, __LINE__)
+#define xrealloc(p, s)       crtdbg_xrealloc((p), (s), __FILE__, __LINE__)
+#define xcalloc(n, s)        crtdbg_xcalloc((n), (s), __FILE__, __LINE__)
+
+extern char *crtdbg_xstrdup(const char *str, const char *fn, int ln);
+extern void *crtdbg_xmalloc(size_t size, const char *fn, int ln);
+extern void *crtdbg_xmallocz(size_t size, const char *fn, int ln);
+extern void *crtdbg_xmallocz_gently(size_t size, const char *fn, int ln);
+extern void *crtdbg_xmemdupz(const void *data, size_t len, const char *fn, int ln);
+extern char *crtdbg_xstrndup(const char *str, size_t len, const char *fn, int ln);
+extern void *crtdbg_xrealloc(void *ptr, size_t size, const char *fn, int ln);
+extern void *crtdbg_xcalloc(size_t nmemb, size_t size, const char *fn, int ln);
 #endif
 
 #define _FILE_OFFSET_BITS 64
@@ -883,6 +901,7 @@ static inline size_t st_sub(size_t a, size_t b)
 # define xalloca(size)      (xmalloc(size))
 # define xalloca_free(p)    (free(p))
 #endif
+#ifndef USE_MSVC_CRTDBG
 extern char *xstrdup(const char *str);
 extern void *xmalloc(size_t size);
 extern void *xmallocz(size_t size);
@@ -891,6 +910,7 @@ extern void *xmemdupz(const void *data, size_t len);
 extern char *xstrndup(const char *str, size_t len);
 extern void *xrealloc(void *ptr, size_t size);
 extern void *xcalloc(size_t nmemb, size_t size);
+#endif
 extern void *xmmap(void *start, size_t length, int prot, int flags, int fd, off_t offset);
 extern void *xmmap_gently(void *start, size_t length, int prot, int flags, int fd, off_t offset);
 extern int xopen(const char *path, int flags, ...);

--- a/kwset.c
+++ b/kwset.c
@@ -41,6 +41,14 @@
 #define obstack_chunk_alloc xmalloc
 #define obstack_chunk_free free
 
+#ifdef USE_MSVC_CRTDBG
+#undef xmalloc
+static void *xmalloc(size_t size)
+{
+	return crtdbg_xmalloc(size, "kwset.c", -1);
+}
+#endif
+
 #define U(c) ((unsigned char) (c))
 
 /* Balanced tree of edges and labels leaving a given trie node. */


### PR DESCRIPTION
Teach git to report memory leaks both to a file and to the
VS debug output window.

From the SDK command line, build Git as follows:

	make MSVC=1 DEBUG=1 CRTDBG=1

When built this way, leaks will always be reported to the
Visual Studio debug output window.

Enable GIT_TRACE_CRTDBG and the leaks will also be reported
to the trace target.  This works from both the command line
and from Visual Studio.

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>

