### PR TITLE
Document how $HOME is set on Windows

### DIFF
--- a/Documentation/git.txt
+++ b/Documentation/git.txt
@@ -361,6 +361,14 @@ Environment Variables
 ---------------------
 Various Git commands use the following environment variables:
 
+System
+~~~~~~~~~~~~~~~~~~
+`HOME`::
+	Specifies the path to the user's home directory. On Windows, if
+	unset, Git will set a process environment variable equal to:
+	`$HOMEDRIVE$HOMEPATH` if both `$HOMEDRIVE` and `$HOMEPATH` exist;
+	otherwise `$USERPROFILE` if `$USERPROFILE` exists.
+
 The Git Repository
 ~~~~~~~~~~~~~~~~~~
 These environment variables apply to 'all' core Git commands. Nb: it


### PR DESCRIPTION
Git documentation refers to $HOME and $XDG_CONFIG_HOME often, but does not specify how or where these values come from on Windows where neither is set by default. The new documentation reflects the behavior of setup_windows_environment() in compat/mingw.c.