### PR TITLE
Fix doc formatting error in git.txt

### DIFF
--- a/Documentation/git.txt
+++ b/Documentation/git.txt
@@ -362,7 +362,7 @@ Environment Variables
 Various Git commands use the following environment variables:
 
 System
-~~~~~~~~~~~~~~~~~~
+~~~~~~
 `HOME`::
 	Specifies the path to the user's home directory. On Windows, if
 	unset, Git will set a process environment variable equal to:


### PR DESCRIPTION
Fixing the header for Environment Variables > System header added in b2956b369ab926417652def4cd7f85e9f475cd53.

Original PR: https://github.com/git-for-windows/git/pull/1548