### PR TITLE
Improve handling of commands in Git.pm on native Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2475,6 +2475,19 @@ LIB_PERL_GEN := $(patsubst perl/%.pm,perl/build/lib/%.pm,$(LIB_PERL))
 LIB_CPAN := $(wildcard perl/FromCPAN/*.pm perl/FromCPAN/*/*.pm)
 LIB_CPAN_GEN := $(patsubst perl/%.pm,perl/build/lib/%.pm,$(LIB_CPAN))
 
+# Set MSWIN32_PERL_PATH=false to disable search
+ifndef MSWIN32_PERL_PATH
+MSWIN32_PERL_PATH = $(shell \
+	for perl in $$(type -ap perl); do \
+		if "$$perl" -e 'exit 1 if $$^O ne q{MSWin32}'; then \
+			echo "$$perl"; \
+			exit 0; \
+		fi; \
+	done \
+)
+endif
+MSWIN32_PERL_PATH_SQ = $(subst ','\'',$(MSWIN32_PERL_PATH))
+
 ifndef NO_PERL
 all:: $(LIB_PERL_GEN)
 ifndef NO_PERL_CPAN_FALLBACKS
@@ -2573,6 +2586,7 @@ GIT-BUILD-OPTIONS: FORCE
 	@echo PAGER_ENV=\''$(subst ','\'',$(subst ','\'',$(PAGER_ENV)))'\' >>$@+
 	@echo DC_SHA1=\''$(subst ','\'',$(subst ','\'',$(DC_SHA1)))'\' >>$@+
 	@echo X=\'$(X)\' >>$@+
+	@echo MSWIN32_PERL_PATH=\''$(subst ','\'',$(MSWIN32_PERL_PATH_SQ))'\' >>$@+
 ifdef TEST_OUTPUT_DIRECTORY
 	@echo TEST_OUTPUT_DIRECTORY=\''$(subst ','\'',$(subst ','\'',$(TEST_OUTPUT_DIRECTORY)))'\' >>$@+
 endif

--- a/t/t9701-perl-git-MSWin32.sh
+++ b/t/t9701-perl-git-MSWin32.sh
@@ -6,24 +6,12 @@
 test_description='perl interface (Git.pm) on MSWin32'
 . ./test-lib.sh
 
-find_MSWin32_perl() {
-	local perl
-	for perl in $(type -ap perl); do
-		if "$perl" -e 'exit 1 if $^O ne q{MSWin32}'; then
-			echo "$perl"
-			return 0
-		fi
-	done
-	return 1
-}
-
-MSWin32_Perl="$(find_MSWin32_perl)"
-if [ $? -ne 0 ]; then
+if ! test_have_prereq MSWIN32_PERL; then
 	skip_all='skipping perl on MSWin32 interface tests, MSWin32 perl not available'
 	test_done
 fi
 
-"$MSWin32_Perl" -MTest::More -e 0 2>/dev/null || {
+mswin32_perl -MTest::More -e 0 2>/dev/null || {
 	skip_all="MSWin32 Perl Test::More unavailable, skipping test"
 	test_done
 }
@@ -35,11 +23,10 @@ test_external_has_tap=1
 perl_test_path="$TEST_DIRECTORY"/t9701/test.pl
 if test_have_prereq CYGWIN || test_have_prereq MINGW; then
 	perl_test_path="$(cygpath -w "$perl_test_path")"
-	GITPERLLIB="$(cygpath -w -p "$GITPERLLIB")"
 fi
 
 test_external_without_stderr \
 	'Windows command line (Perl API)' \
-	"$MSWin32_Perl" "$perl_test_path"
+	mswin32_perl "$perl_test_path"
 
 test_done

--- a/t/t9701-perl-git-MSWin32.sh
+++ b/t/t9701-perl-git-MSWin32.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+#
+# Copyright (c) 2018 Chris Lindee
+#
+
+test_description='perl interface (Git.pm) on MSWin32'
+. ./test-lib.sh
+
+find_MSWin32_perl() {
+	local perl
+	for perl in $(type -ap perl); do
+		if "$perl" -e 'exit 1 if $^O ne q{MSWin32}'; then
+			echo "$perl"
+			return 0
+		fi
+	done
+	return 1
+}
+
+MSWin32_Perl="$(find_MSWin32_perl)"
+if [ $? -ne 0 ]; then
+	skip_all='skipping perl on MSWin32 interface tests, MSWin32 perl not available'
+	test_done
+fi
+
+"$MSWin32_Perl" -MTest::More -e 0 2>/dev/null || {
+	skip_all="MSWin32 Perl Test::More unavailable, skipping test"
+	test_done
+}
+
+# The external test will outputs its own plan
+test_external_has_tap=1
+
+# Ensure paths are recognized by Windows executables.
+perl_test_path="$TEST_DIRECTORY"/t9701/test.pl
+if test_have_prereq CYGWIN || test_have_prereq MINGW; then
+	perl_test_path="$(cygpath -w "$perl_test_path")"
+	GITPERLLIB="$(cygpath -w -p "$GITPERLLIB")"
+fi
+
+test_external_without_stderr \
+	'Windows command line (Perl API)' \
+	"$MSWin32_Perl" "$perl_test_path"
+
+test_done

--- a/t/t9701/test.pl
+++ b/t/t9701/test.pl
@@ -1,0 +1,38 @@
+#!/usr/bin/perl
+use lib (split(/:/, $ENV{GITPERLLIB}));
+
+use 5.008;
+use strict;
+use warnings;
+
+use Test::More qw(no_plan);
+
+BEGIN {
+	# t9701-perl-git-MSWin32.sh kicks off our testing, so we have to go from
+	# there.
+	Test::More->builder->current_test(1);
+	Test::More->builder->no_ending(1);
+}
+
+my @tests = (
+	'\\\\',
+	'()%!^"<>&|',
+	'C:\\Windows\\system32\\',
+	map { chr } 32 .. 126, 160 .. 255	# printable ISO-8859-1, the base for Windows-1252
+);
+
+# Just in case
+plan skip_all => 'Test will not run on MSYS Perl (distributed with Git for Windows)' if $^O eq 'msys';
+plan skip_all => 'Test requires Microsoft Windows' if $^O ne 'MSWin32';
+
+require_ok('Git');
+
+foreach (@tests) {
+	my $cmdline = Git::activestate_pipe::make_windows_commandline($^X, '-e', 'print $ARGV[0]', $_);
+	is qx{$cmdline}, $_, $cmdline;
+}
+
+printf "1..%d\n", Test::More->builder->current_test;
+
+my $is_passing = eval { Test::More->is_passing };
+exit($is_passing ? 0 : 1) unless $@ =~ /Can't locate object method/;

--- a/t/t9701/test.pl
+++ b/t/t9701/test.pl
@@ -28,7 +28,7 @@ plan skip_all => 'Test requires Microsoft Windows' if $^O ne 'MSWin32';
 require_ok('Git');
 
 foreach (@tests) {
-	my $cmdline = Git::activestate_pipe::make_windows_commandline($^X, '-e', 'print $ARGV[0]', $_);
+	my $cmdline = Git::make_windows_commandline($^X, '-e', 'print $ARGV[0]', $_);
 	is qx{$cmdline}, $_, $cmdline;
 }
 

--- a/t/test-lib-functions.sh
+++ b/t/test-lib-functions.sh
@@ -933,6 +933,14 @@ perl () {
 	command "$PERL_PATH" "$@" 2>&7
 } 7>&2 2>&4
 
+mswin32_perl () {
+	local GITPERLLIB="$GITPERLLIB"
+	if test_have_prereq CYGWIN || test_have_prereq MINGW; then
+		GITPERLLIB="$(cygpath -w -p "$GITPERLLIB")"
+	fi
+	command "$MSWIN32_PERL_PATH" "$@" 2>&7
+} 7>&2 2>&4
+
 # Is the value one of the various ways to spell a boolean true/false?
 test_normalize_bool () {
 	git -c magic.variable="$1" config --bool magic.variable 2>/dev/null

--- a/t/test-lib.sh
+++ b/t/test-lib.sh
@@ -64,7 +64,7 @@ then
 	exit 1
 fi
 . "$GIT_BUILD_DIR"/GIT-BUILD-OPTIONS
-export PERL_PATH SHELL_PATH
+export MSWIN32_PERL_PATH PERL_PATH SHELL_PATH
 
 ################################################################
 # It appears that people try to run tests without building...
@@ -1267,4 +1267,12 @@ test_lazy_prereq CURL '
 # test anything meaningful (e.g. special values which cause short collisions).
 test_lazy_prereq SHA1 '
 	test $(git hash-object /dev/null) = e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+'
+
+# Some tests require a native Win32 Perl interpreter, such as Strawberry Perl
+# or ActiveState Perl, which is not distributed with Git for Windows.  These
+# tests only run if an appropriate Perl is specified (via MSWIN32_PERL_PATH).
+test_lazy_prereq MSWIN32_PERL '
+	test -n "$MSWIN32_PERL_PATH" &&
+	$MSWIN32_PERL_PATH -e "exit 1 if \$^O ne q{MSWin32}"
 '


### PR DESCRIPTION
Improve the Git.pm module so native Windows users can make use of it without overbearing restrictions on what can be sent.

This change allows users to use:
- multiple command pipes simultaneously,
- to use input pipes,
- and to use arguments with embedded spaces.

This will enable users to run even more Git commands in a Windows environment (like cmd or PowerShell) through Perl.