### PR TITLE
mingw: quote argument to 'sh' if it contains brace

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1134,13 +1134,13 @@ static const char *quote_arg_msys2(const char *arg)
 
 	for (p = arg; *p; p++) {
 		int ws = isspace(*p);
-		if (!ws && *p != '\\' && *p != '"')
+		if (!ws && *p != '\\' && *p != '"' && *p != '{')
 			continue;
 		if (!buf.len)
 			strbuf_addch(&buf, '"');
 		if (p != p2)
 			strbuf_add(&buf, p2, p - p2);
-		if (!ws)
+		if (!ws && *p != '{')
 			strbuf_addch(&buf, '\\');
 		p2 = p;
 	}


### PR DESCRIPTION
Fixes https://github.com/git-for-windows/git/issues/1220

