### PR TITLE
mingw: Fix unlink for open files

### DIFF
--- a/t/t2035-checkout-locked.sh
+++ b/t/t2035-checkout-locked.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+test_description='checkout must be able to overwrite open files'
+. ./test-lib.sh
+
+test_expect_success 'setup' '
+
+	test_commit hello world &&
+	git branch other &&
+	test_commit hello-again world
+'
+
+test_expect_success 'checkout overwrites file open for read' '
+
+	git checkout -f master &&
+	exec 8<world &&
+	git checkout other &&
+	exec 8<&- &&
+	git diff-files --raw >output &&
+	test_must_be_empty output
+'
+
+test_expect_success 'checkout overwrites file open for write' '
+
+	git checkout -f master &&
+	exec 8>>world &&
+	git checkout other &&
+	exec 8>&- &&
+	git diff-files --raw >output &&
+	test_must_be_empty output
+'
+
+test_expect_success 'subdir' '
+
+	git checkout -f master &&
+	mkdir -p dear &&
+	test_commit hello-dear dear/world &&
+	git branch other-dir &&
+	git mv dear cruel &&
+	test_commit goodbye cruel/world
+'
+
+test_expect_success 'subdir checkout overwrites file open for read' '
+
+	git checkout -f master &&
+	exec 8<cruel/world &&
+	git checkout other-dir &&
+	exec 8<&- &&
+	git diff-files --raw >output &&
+	test_must_be_empty output
+'
+
+test_expect_success 'subdir checkout overwrites file open for write' '
+
+	git checkout -f master &&
+	exec 8>>cruel/world &&
+	git checkout other-dir &&
+	exec 8>&- &&
+	git diff-files --raw >output &&
+	test_must_be_empty output
+'
+
+test_done


### PR DESCRIPTION
This is an attempt to implement @cbuchacher's idea in https://github.com/git-for-windows/git/issues/1653

Files that were opened by a (possibly another) process either for read or for failed to be replaced by Git on checkout.

If a file is opened with FILE_SHARE_DELETE share mode, it is possible to delete or rename the file, but it is *not possible* to create a new file until the file's handle is closed.

To overcome this, unlink now renames the file before actually unlinking it.

If rename fails, then the file either doesn't exist, or it is open without share permissions. On this case, it is still possible to unlink the file. The file will effectively be deleted when it is closed. On this case, preserve the existing behavior.

If rename succeeds, unlink the temporary file, making it possible for the real file name to be reused.

Fixes #1653.