### PR TITLE
vcxproj: change build logic

### DIFF
--- a/contrib/buildsystems/Generators/Vcxproj.pm
+++ b/contrib/buildsystems/Generators/Vcxproj.pm
@@ -179,8 +179,9 @@ sub createProject {
 EOM
     if ($target eq 'libgit') {
         print F << "EOM";
-    <PreBuildEvent Condition="!Exists('$cdup\\compat\\vcbuild\\vcpkg')">
+    <PreBuildEvent Condition="!Exists('$cdup\\compat\\vcbuild\\vcpkg') OR (!Exists('$cdup\\compat\\vcbuild\\vcpkg\\installed\\x64-windows\\include\\openssl\\ssl.h') AND !Exists('$cdup\\compat\\vcbuild\\vcpkg\\installed\\x86-windows\\include\\openssl\\ssl.h'))">
       <Message>Initialize VCPKG</Message>
+      <Command>del "$cdup\\compat\\vcbuild\\vcpkg"</Command>
       <Command>call "$cdup\\compat\\vcbuild\\vcpkg_install.bat" </Command>
     </PreBuildEvent>
 EOM


### PR DESCRIPTION
Add new condition to invoke vcpkg_install.bat: it's not enough to check
the presence of folder vcpkg. We need to check the presence of some
header files because this is one of the main goals of this script.
Previous build attempt could be aborted, so the folder will exist but
the project will not be built properly.

Signed-off-by: Olga Telezhnaia <olyatelezhnaya@gmail.com>