### PR TITLE
fixup! Win32: change default of 'core.symlinks' to false

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -3160,15 +3160,6 @@ static void setup_windows_environment(void)
 			setenv("HOME", tmp, 1);
 	}
 
-	/*
-	 * Change 'core.symlinks' default to false, unless native symlinks are
-	 * enabled in MSys2 (via 'MSYS=winsymlinks:nativestrict'). Thus we can
-	 * run the test suite (which doesn't obey config files) with or without
-	 * symlink support.
-	 */
-	if (!(tmp = getenv("MSYS")) || !strstr(tmp, "winsymlinks:nativestrict"))
-		has_symlinks = 0;
-
 	if (!getenv("LC_ALL") && !getenv("LC_CTYPE") && !getenv("LANG"))
 		setenv("LC_CTYPE", "C", 1);
 }


### PR DESCRIPTION
Revert this change, as it does not take into account that Windows 10 now
allows all users to create symbolic links in developer mode.

Noticed by Ed Thomson.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>

Thanks for taking the time to contribute to Git!

Those seeking to contribute to the Git for Windows fork should see
http://gitforwindows.org/#contribute on how to contribute Windows specific enhancements.

If your contribution is for the core Git functions and documentation
please be aware that the Git community does not use the github.com issues
or pull request mechanism for their contributions. 

Instead, we use the Git mailing list (git@vger.kernel.org) for code and 
documenatation submissions, code reviews, and bug reports. The
mailing list is plain text only (anything with HTML is sent directly
to the spam folder). 

Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
