### PR TITLE
http: rename http.schannel.checkRevoke to http.schannelCheckRevoke

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -2124,12 +2124,12 @@ http.sslBackend::
 	This option is ignored if cURL lacks support for choosing the SSL
 	backend at runtime.
 
-http.schannel.checkRevoke::
+http.schannelCheckRevoke::
 	Used to enforce or disable certificate revocation checks in cURL
 	when http.sslBackend is set to "schannel". Defaults to `true` if
 	unset. Only necessary to disable this if Git consistently errors
 	and the message is about checking the revocation status of a
-	certificate. This option is ignored if cURL lacks support for 
+	certificate. This option is ignored if cURL lacks support for
 	setting the relevant SSL option at runtime.
 
 http.schannel.useSSLCAInfo::

--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -2132,7 +2132,7 @@ http.schannelCheckRevoke::
 	certificate. This option is ignored if cURL lacks support for
 	setting the relevant SSL option at runtime.
 
-http.schannel.useSSLCAInfo::
+http.schannelUseSSLCAInfo::
 	As of cURL v7.60.0, the Secure Channel backend can use the
 	certificate bundle provided via `http.sslCAInfo`, but that would
 	override the Windows Certificate Store. Since this is not desirable

--- a/http.c
+++ b/http.c
@@ -318,7 +318,7 @@ static int http_options(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
-	if (!strcmp("http.schannel.checkrevoke", var)) {
+	if (!strcmp("http.schannelcheckrevoke", var)) {
 		http_schannel_check_revoke = git_config_bool(var, value);
 		return 0;
 	}
@@ -831,7 +831,7 @@ static CURL *get_curl_handle(void)
 
 	if (http_ssl_backend && !strcmp("schannel", http_ssl_backend) &&
 	    !http_schannel_check_revoke) {
-#if LIBCURL_VERSION_NUM >= 0x074400
+#if LIBCURL_VERSION_NUM >= 0x072c00
 		curl_easy_setopt(result, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NO_REVOKE);
 #else
 		warning("CURLSSLOPT_NO_REVOKE not applied to curl SSL options because\n"

--- a/http.c
+++ b/http.c
@@ -323,7 +323,7 @@ static int http_options(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
-	if (!strcmp("http.schannel.usesslcainfo", var)) {
+	if (!strcmp("http.schannelusesslcainfo", var)) {
 		http_schannel_use_ssl_cainfo = git_config_bool(var, value);
 		return 0;
 	}


### PR DESCRIPTION
The `http.*` config settings can be limited to specific URLs via
`http.<url>.*`. Unfortunately, this prevented our beautiful
`http.schannel.checkRevoke` *from ever working*, as the `schannel` part
was interpreted as a URL.

Let's just change this completely, by avoiding having "a middle part"
that is then interpreted as a URL.

As a fringe benefit, this now also allows users to disable the
revocation checking on a URL-by-URL basis.

This fixes https://github.com/git-for-windows/git/issues/1531 (for real)

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
