### PR TITLE
updated mention of http.useSSLCAInfo to use correct name

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -2138,7 +2138,7 @@ http.schannelUseSSLCAInfo::
 	override the Windows Certificate Store. Since this is not desirable
 	by default, Git will tell cURL not to use that bundle by default
 	when the `schannel` backend was configured via `http.sslBackend`,
-	unless `useSSLCAInfo` overrides this behavior.
+	unless `http.schannelUseSSLCAInfo` overrides this behavior.
 
 http.pinnedpubkey::
 	Public key of the https service. It may either be the filename of


### PR DESCRIPTION
I overlooked this while reviewing #1747 - not sure if it should be fully qualified to `http. schannelUseSSLCAInfo` but I'll let the reviewer weigh in.