### PR TITLE
find_vs_env.bat: Fix bin dir path used by msys

### DIFF
--- a/compat/vcbuild/find_vs_env.bat
+++ b/compat/vcbuild/find_vs_env.bat
@@ -154,7 +154,9 @@ REM ================================================================
    REM Include DOS-style and BASH-style path for bin dir.
 
    echo msvc_bin_dir=%msvc_bin_dir%
-   echo msvc_bin_dir_msys=%msvc_bin_dir:C:=/C%
+   SET X1=%msvc_bin_dir:C:=/C%
+   SET X2=%X1:\=/%
+   echo msvc_bin_dir_msys=%X2%
 
    echo msvc_includes=%msvc_includes%
    echo msvc_libs=%msvc_libs%


### PR DESCRIPTION
Completely convert the pathname expoted in the %msvc_bin_dir_msys%
variable to MSYS format with forward slashes rather than a mixture
of forward and back slashes.

This solves an obscure problem observed by some developers:

    [...]
    http-push.c
        CC remote-curl.o
    remote-curl.c
        * new script parameters
        GEN git-instaweb
    sed: -e expression #7, char 155: invalid reference \2 on `s' command's RHS
    make: *** [Makefile:2023: git-instaweb] Error 1

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>
