### PR TITLE
config.c: fix regression for core.safecrlf false

### DIFF
--- a/config.c
+++ b/config.c
@@ -1156,7 +1156,7 @@ static int git_default_core_config(const char *var, const char *value)
 		}
 		eol_rndtrp_die = git_config_bool(var, value);
 		global_conv_flags_eol = eol_rndtrp_die ?
-			CONV_EOL_RNDTRP_DIE : CONV_EOL_RNDTRP_WARN;
+			CONV_EOL_RNDTRP_DIE : 0;
 		return 0;
 	}
 

--- a/t/t0020-crlf.sh
+++ b/t/t0020-crlf.sh
@@ -98,6 +98,16 @@ test_expect_success 'safecrlf: git diff demotes safecrlf=true to warn' '
 '
 
 
+test_expect_success 'safecrlf: no warning with safecrlf=false' '
+	git config core.autocrlf input &&
+	git config core.safecrlf false &&
+
+	for w in I am all CRLF; do echo $w; done | append_cr >allcrlf &&
+	git add allcrlf 2>err &&
+	test_must_be_empty err
+'
+
+
 test_expect_success 'switch off autocrlf, safecrlf, reset HEAD' '
 	git config core.autocrlf false &&
 	git config core.safecrlf false &&


### PR DESCRIPTION
A regression introduced in 8462ff43 ("convert_to_git(): safe_crlf/checksafe becomes int conv_flags", 2018-01-13) back in Git 2.17 cycle caused autocrlf rewrites to produce a warning message despite setting safecrlf=false.

This should fix https://github.com/git-for-windows/git/issues/1242

/cc @tboegi