### PR TITLE
Support compiling with GCC v8.*

### DIFF
--- a/compat/obstack.c
+++ b/compat/obstack.c
@@ -113,14 +113,14 @@ compat_symbol (libc, _obstack_compat, _obstack, GLIBC_2_0);
 # define CALL_CHUNKFUN(h, size) \
   (((h) -> use_extra_arg) \
    ? (*(h)->chunkfun) ((h)->extra_arg, (size)) \
-   : (*(struct _obstack_chunk *(*) (long)) (h)->chunkfun) ((size)))
+   : (*(struct _obstack_chunk *(*) (long)) (void *) (h)->chunkfun) ((size)))
 
 # define CALL_FREEFUN(h, old_chunk) \
   do { \
     if ((h) -> use_extra_arg) \
       (*(h)->freefun) ((h)->extra_arg, (old_chunk)); \
     else \
-      (*(void (*) (void *)) (h)->freefun) ((old_chunk)); \
+      (*(void (*) (void *)) (void *) (h)->freefun) ((old_chunk)); \
   } while (0)
 
 
@@ -159,8 +159,8 @@ _obstack_begin (struct obstack *h,
       size = 4096 - extra;
     }
 
-  h->chunkfun = (struct _obstack_chunk * (*)(void *, long)) chunkfun;
-  h->freefun = (void (*) (void *, struct _obstack_chunk *)) freefun;
+  h->chunkfun = (struct _obstack_chunk * (*)(void *, long)) (void *) chunkfun;
+  h->freefun = (void (*) (void *, struct _obstack_chunk *)) (void *) freefun;
   h->chunk_size = size;
   h->alignment_mask = alignment - 1;
   h->use_extra_arg = 0;

--- a/compat/obstack.h
+++ b/compat/obstack.h
@@ -214,31 +214,32 @@ extern void (*obstack_alloc_failed_handler) (void);
 #define obstack_alignment_mask(h) ((h)->alignment_mask)
 
 /* To prevent prototype warnings provide complete argument list.  */
-#define obstack_init(h)						\
-  _obstack_begin ((h), 0, 0,					\
-		  (void *(*) (long)) obstack_chunk_alloc,	\
-		  (void (*) (void *)) obstack_chunk_free)
+#define obstack_init(h)							\
+  _obstack_begin ((h), 0, 0,						\
+		  (void *(*) (long)) (void *) obstack_chunk_alloc,	\
+		  (void (*) (void *)) (void *) obstack_chunk_free)
 
-#define obstack_begin(h, size)					\
-  _obstack_begin ((h), (size), 0,				\
-		  (void *(*) (long)) obstack_chunk_alloc,	\
-		  (void (*) (void *)) obstack_chunk_free)
+#define obstack_begin(h, size)						\
+  _obstack_begin ((h), (size), 0,					\
+		  (void *(*) (long)) (void *) obstack_chunk_alloc,	\
+		  (void (*) (void *)) (void *) obstack_chunk_free)
 
 #define obstack_specify_allocation(h, size, alignment, chunkfun, freefun)  \
   _obstack_begin ((h), (size), (alignment),				   \
-		  (void *(*) (long)) (chunkfun),			   \
-		  (void (*) (void *)) (freefun))
+		  (void *(*) (long)) (void *) (chunkfun),		   \
+		  (void (*) (void *)) (void *) (freefun))
 
 #define obstack_specify_allocation_with_arg(h, size, alignment, chunkfun, freefun, arg) \
   _obstack_begin_1 ((h), (size), (alignment),				\
-		    (void *(*) (void *, long)) (chunkfun),		\
-		    (void (*) (void *, void *)) (freefun), (arg))
+		    (void *(*) (void *, long)) (void *) (chunkfun),	\
+		    (void (*) (void *, void *)) (void *) (freefun), (arg))
 
 #define obstack_chunkfun(h, newchunkfun) \
-  ((h) -> chunkfun = (struct _obstack_chunk *(*)(void *, long)) (newchunkfun))
+  ((h) -> chunkfun = (struct _obstack_chunk *(*)(void *, long)) (void *) \
+		      (newchunkfun))
 
 #define obstack_freefun(h, newfreefun) \
-  ((h) -> freefun = (void (*)(void *, struct _obstack_chunk *)) (newfreefun))
+  ((h) -> freefun = (void (*)(void *, struct _obstack_chunk *)) (void *) (newfreefun))
 
 #define obstack_1grow_fast(h,achar) (*((h)->next_free)++ = (achar))
 

--- a/compat/poll/poll.c
+++ b/compat/poll/poll.c
@@ -146,7 +146,7 @@ win32_compute_revents (HANDLE h, int *p_sought)
     case FILE_TYPE_PIPE:
       if (!once_only)
 	{
-	  NtQueryInformationFile = (PNtQueryInformationFile)
+	  NtQueryInformationFile = (PNtQueryInformationFile) (void *)
 	    GetProcAddress (GetModuleHandle ("ntdll.dll"),
 			    "NtQueryInformationFile");
 	  once_only = TRUE;

--- a/compat/win32/exit-process.h
+++ b/compat/win32/exit-process.h
@@ -130,7 +130,7 @@ static int exit_process(HANDLE process, int exit_code)
 			HINSTANCE kernel32 = GetModuleHandle("kernel32");
 			if (!kernel32)
 				die("BUG: cannot find kernel32");
-			exit_process_address = (LPTHREAD_START_ROUTINE)
+			exit_process_address = (LPTHREAD_START_ROUTINE) (void *)
 				GetProcAddress(kernel32, "ExitProcess");
 			initialized = 1;
 		}

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -622,8 +622,7 @@ else
 			BASIC_LDFLAGS += -Wl,--large-address-aware
 		endif
 		CC = gcc
-		COMPAT_CFLAGS += -D__USE_MINGW_ANSI_STDIO=0 -DDETECT_MSYS_TTY \
-			-fstack-protector-strong
+		COMPAT_CFLAGS += -D__USE_MINGW_ANSI_STDIO=0 -DDETECT_MSYS_TTY
 		EXTLIBS += -lntdll
 		INSTALL = /bin/install
 		NO_R_TO_GCC_LINKER = YesPlease


### PR DESCRIPTION
It's that time again, when a new GCC version is pushed upon us, with enterprisey new requirements as to the source code.

In this instance, a couple of casts of function pointers now cause errors when building with `DEVELOPER=1`. As our code should be `DEVELOPER=1`-clean, let's work around those issues.