### PR TITLE
fixup! mingw: really handle SIGINT

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -3344,7 +3344,7 @@ static void adjust_symlink_flags(void)
 
 }
 
-static WINAPI WINBOOL handle_ctrl_c(DWORD ctrl_type)
+static BOOL WINAPI handle_ctrl_c(DWORD ctrl_type)
 {
 	if (ctrl_type != CTRL_C_EVENT)
 		return FALSE; /* we did not handle this */


### PR DESCRIPTION
Fix compiler error introduced in this commit:

error C2061: syntax error: identifier 'handle_ctrl_c'

Implements the fix suggested by @kgybels in #1735 
