### PR TITLE
Don't use uninitialized variable

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -828,7 +828,7 @@ static int has_valid_directory_prefix(wchar_t *wfilename)
 int mingw_lstat(const char *file_name, struct stat *buf)
 {
 	WIN32_FILE_ATTRIBUTE_DATA fdata;
-	WIN32_FIND_DATAW findbuf;
+	WIN32_FIND_DATAW findbuf = { 0 };
 	wchar_t wfilename[MAX_LONG_PATH];
 	int wlen = xutftowcs_long_path(wfilename, file_name);
 	if (wlen < 0)


### PR DESCRIPTION
The usage of the uninitialized variable `findbuf` on https://github.com/git-for-windows/git/blob/master/compat/mingw.c#L858 causes undefined behavior in libgit (if `if (fdata.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {` is false).

This is fixed by initializing it properly which is only present in Git for Windows but not vanilla Git.
