### PR TITLE
Fix up compat/poll/poll.c

### DIFF
--- a/compat/poll/poll.c
+++ b/compat/poll/poll.c
@@ -29,9 +29,6 @@
 
 #include <sys/types.h>
 
-/* Specification.  */
-#include <poll.h>
-
 #include <errno.h>
 #include <limits.h>
 #include <assert.h>
@@ -54,6 +51,9 @@
 # endif
 # include <unistd.h>
 #endif
+
+/* Specification.  */
+#include "poll.h"
 
 #ifdef HAVE_SYS_IOCTL_H
 # include <sys/ioctl.h>


### PR DESCRIPTION
I noticed that a recent GitGitGadget build failed in the Windows phase, with `compat/poll/poll.h` problems all over the place.

Turns out that this is caused by the recent upgrade of the mingw-w64 headers and crt files (7.0.0.5233.e0c09544 -> 7.0.0.5245.edf66197, which I assume now enforces Vista as minimal Windows version also for all mingw-w64 projects).

Luckily, in Git for Windows' `master`, we already had changes to require Vista (for unrelated reasons: to restrict the std handle inheritance when spawning new processes). But we missed one thing: we still included the `winsock2.h` header file in `compat/poll/poll.c` *after* including `poll.h`, so we did not really override the constants and structs defined in the former. Let's fix this.