### PR TITLE
pass extended startup info directly

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1776,7 +1776,7 @@ static pid_t mingw_spawnve_fd(const char *cmd, const char **argv, char **deltaen
 	ret = CreateProcessW(*wcmd ? wcmd : NULL, wargs, NULL, NULL,
 			     stdhandles_count ? TRUE : FALSE,
 			     flags, wenvblk, dir ? wdir : NULL,
-			     &si.StartupInfo, &pi);
+			     (LPSTARTUPINFOW)&si, &pi);
 
 	/*
 	 * On Windows 2008 R2, it seems that specifying certain types of handles


### PR DESCRIPTION
The extended startup info is not passed to CreateProcess. It is passed
indirectly as &si.StartupInfo. Since StartupInfo is the first member of
the extended startup info struct, the address of si.StartupInfo
coincides with the address of si.

Although it makes no difference functionally, it seems cleaner to pass
extended startup info directly, as suggested also by the
UpdateProcThreadAttribute example:

https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute

Signed-off-by: Clemens Buchacher <drizzd@gmx.net>