### PR TITLE
Two things I totally forgot

### DIFF
--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1035,7 +1035,7 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 			PARSE_OPT_OPTARG, NULL, (intptr_t) "" },
 		OPT_STRING_LIST(0, "whitespace", &whitespace,
 				N_("whitespace"), N_("passed to 'git apply'")),
-		OPT_SET_INT('C', 0, &opt_c, N_("passed to 'git apply'"),
+		OPT_SET_INT('C', NULL, &opt_c, N_("passed to 'git apply'"),
 			    REBASE_AM),
 		OPT_BOOL(0, "autostash", &options.autostash,
 			 N_("automatically stash/stash pop before and after")),

--- a/git-gui/git-gui.sh
+++ b/git-gui/git-gui.sh
@@ -623,7 +623,11 @@ proc git_write {args} {
 }
 
 proc githook_read {hook_name args} {
-	set pchook [gitdir hooks $hook_name]
+	if {[package vcompare $::_git_version 2.5.0] >= 0} {
+		set pchook [git rev-parse --git-path "hooks/$hook_name"]
+	} else {
+		set pchook [gitdir hooks $hook_name]
+	}
 	lappend args 2>@1
 
 	# On Windows [file executable] might lie so we need to ask


### PR DESCRIPTION
One thing is a fix for a patch in the `builtin-rebase` part: it [had been pointed out](https://public-inbox.org/git/d5d0f6c3-748b-b83f-f9d4-2812f4509313@ramsayjones.plus.com/) that one of the patches introduced a `0` where a `NULL` would have been correct (I had missed this because it was not sent as a reply to the original mail thread).

The other thing is more subtle, and even more worrisome: due to the way we start with a merging rebase, all patches that had been part of a previous branch thicket are assumed to be applied already. But this is not the case for branches we merged directly from https://github.com/gitster/git's branches: they would have to be re-applied. Previously, this was not a problem because merging rebases always rebased *everything* on top of the initial merge commit. But with the introduction of `git rebase --rebase-merges`, we switched to that mode, and that mode uses the `no-rebase-cousins` mode by default. Meaning: branches we merged that are not based on Git for Windows' `master`, but are based on commits reachable from core Git's `master`, are lost during merging rebases.

I noticed this yesterday, by pure luck, with the patch that teaches Git GUI about `core.hooksPath`. It was applied, but subsequently lost in a merging rebase.

Happily, I could verify (by looking manually through the latest 10 merging rebases) that this was the only such case.

This PR addresses both oversights.