### PR TITLE
Add rfc to remove an TODO: that seems to be referencing the wrong struct field commit.c:360

### DIFF
--- a/commit.c
+++ b/commit.c
@@ -357,8 +357,6 @@ void release_commit_memory(struct commit *c)
 	c->index = 0;
 	free_commit_buffer(c);
 	free_commit_list(c->parents);
-	/* TODO: what about commit->util? */
-
 	c->object.parsed = 0;
 }
 


### PR DESCRIPTION


Thanks for taking the time to contribute to Git!

Those seeking to contribute to the Git for Windows fork should see
http://gitforwindows.org/#contribute on how to contribute Windows specific enhancements.

If your contribution is for the core Git functions and documentation
please be aware that the Git community does not use the github.com issues
or pull request mechanism for their contributions. 

Instead, we use the Git mailing list (git@vger.kernel.org) for code and 
documenatation submissions, code reviews, and bug reports. The
mailing list is plain text only (anything with HTML is sent directly
to the spam folder). 

Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
