### PR TITLE
ci(mingw): speed up, by disabling the chain lint

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -229,6 +229,7 @@ phases:
     displayName: 'build & test'
     env:
       GITFILESHAREPWD: $(gitfileshare.pwd)
+      GIT_TEST_CHAIN_LINT: 0
   - task: PublishTestResults@2
     displayName: 'Publish Test Results **/TEST-*.xml'
     inputs:


### PR DESCRIPTION
This is just a test balloon, to see how much it costs us. The main cost
seems to be the subshell `(exit 117)`, which is expensive in the MSYS2
Bash due to the way `fork()` is emulated.