### PR TITLE
fscache: use FindFirstFileExW to avoid retrieving the short name

### DIFF
--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -206,7 +206,8 @@ static struct fsentry *fsentry_create_list(const struct fsentry *dir,
 	pattern[wlen] = 0;
 
 	/* open find handle */
-	h = FindFirstFileW(pattern, &fdata);
+	h = FindFirstFileExW(pattern, FindExInfoBasic, &fdata, FindExSearchNameMatch,
+		NULL, FIND_FIRST_EX_LARGE_FETCH);
 	if (h == INVALID_HANDLE_VALUE) {
 		err = GetLastError();
 		*dir_not_found = 1; /* or empty directory */


### PR DESCRIPTION
Use FindFirstFileExW with FindExInfoBasic to avoid forcing NTFS to look up
the short name.  Also switch to a larger (64K vs 4K) buffer using
FIND_FIRST_EX_LARGE_FETCH to minimize round trips to the kernel.

In a repo with ~200K files, this drops warm cache status times from 3.19
seconds to 2.67 seconds for a 16% savings.

Signed-off-by: Ben Peart <benpeart@microsoft.com>
