### PR TITLE
status: disable and free fscache at the end of the status command

### DIFF
--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -1410,6 +1410,7 @@ int cmd_status(int argc, const char **argv, const char *prefix)
 		s.prefix = prefix;
 
 	wt_status_print(&s);
+	enable_fscache(0);
 	return 0;
 }
 


### PR DESCRIPTION
At the end of the status command, disable and free the fscache so that we don't leak the memory and so that we can dump the fscache statistics.

Signed-off-by: Ben Peart <benpeart@microsoft.com>
