### PR TITLE
fscache: add GIT_TEST_FSCACHE support

### DIFF
--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -2,6 +2,7 @@
 #include "../../hashmap.h"
 #include "../win32.h"
 #include "fscache.h"
+#include "config.h"
 
 static int initialized;
 static volatile long enabled;
@@ -396,7 +397,11 @@ int fscache_enable(int enable)
 	int result;
 
 	if (!initialized) {
+		int fscache = git_env_bool("GIT_TEST_FSCACHE", -1);
+
 		/* allow the cache to be disabled entirely */
+		if (fscache != -1)
+			core_fscache = fscache;
 		if (!core_fscache)
 			return 0;
 

--- a/t/README
+++ b/t/README
@@ -319,6 +319,9 @@ GIT_TEST_OE_DELTA_SIZE=<n> exercises the uncomon pack-objects code
 path where deltas larger than this limit require extra memory
 allocation for bookkeeping.
 
+GIT_TEST_FSCACHE=<boolean> exercises the uncommon fscache code path
+which adds a cache below mingw's lstat and dirent implementations.
+
 Naming Tests
 ------------
 


### PR DESCRIPTION
Add support to fscache to enable running the entire test suite with the fscache enabled.

Signed-off-by: Ben Peart <benpeart@microsoft.com>
