### PR TITLE
At the end of the add command, disable and free the fscache

### DIFF
--- a/builtin/add.c
+++ b/builtin/add.c
@@ -542,6 +542,7 @@ finish:
 			       COMMIT_LOCK | SKIP_IF_UNCHANGED))
 		die(_("Unable to write new index file"));
 
+	enable_fscache(0);
 	UNLEAK(pathspec);
 	UNLEAK(dir);
 	return exit_status;


### PR DESCRIPTION
At the end of the add command, disable and free the fscache so that we don't leak the memory and so that we can dump the fscache statistics.

Signed-off-by: Ben Peart <benpeart@microsoft.com>
