### PR TITLE
Update `create-empty-bundle`

### DIFF
--- a/bundle.c
+++ b/bundle.c
@@ -457,11 +457,10 @@ int create_bundle(struct bundle_header *header, const char *path,
 	object_array_remove_duplicates(&revs.pending);
 
 	ref_count = write_bundle_refs(bundle_fd, &revs);
-	if (ref_count <= 0)  {
-		if (!ref_count)
-			error(_("Refusing to create empty bundle."));
+	if (!ref_count)
+		die(_("Refusing to create empty bundle."));
+	else if (ref_count < 0)
 		goto err;
-	}
 
 	/* write pack */
 	if (write_pack_data(bundle_fd, &revs)) {

--- a/t/t5607-clone-bundle.sh
+++ b/t/t5607-clone-bundle.sh
@@ -71,4 +71,10 @@ test_expect_success 'prerequisites with an empty commit message' '
 	git bundle verify bundle
 '
 
+test_expect_success 'failed bundle creation does not leave cruft' '
+	# This fails because the bundle would be empty.
+	test_must_fail git bundle create fail.bundle master..master &&
+	test_path_is_missing fail.bundle.lock
+'
+
 test_done

--- a/t/t5607-clone-bundle.sh
+++ b/t/t5607-clone-bundle.sh
@@ -71,8 +71,4 @@ test_expect_success 'prerequisites with an empty commit message' '
 	git bundle verify bundle
 '
 
-test_expect_success 'try to create a bundle with empty ref count' '
-	test_expect_code 1 git bundle create foobar.bundle master..master
-'
-
 test_done


### PR DESCRIPTION
On the Git mailing list, the [contributed v2](https://public-inbox.org/git/pull.79.v2.git.gitgitgadget@gmail.com/) was countered by [a better patch](https://public-inbox.org/git/20181116094358.GA6054@sigill.intra.peff.net/).

Let's update this in our branch thicket, too.