### PR TITLE
Update `ready-for-upstream`

### DIFF
--- a/compat/win32/pthread.h
+++ b/compat/win32/pthread.h
@@ -34,17 +34,6 @@ typedef int pthread_mutexattr_t;
 
 #define pthread_cond_t CONDITION_VARIABLE
 
-WINBASEAPI VOID WINAPI
-InitializeConditionVariable(PCONDITION_VARIABLE ConditionVariable);
-WINBASEAPI VOID WINAPI
-WakeConditionVariable(PCONDITION_VARIABLE ConditionVariable);
-WINBASEAPI VOID WINAPI
-WakeAllConditionVariable(PCONDITION_VARIABLE ConditionVariable);
-WINBASEAPI BOOL WINAPI
-SleepConditionVariableCS(PCONDITION_VARIABLE ConditionVariable,
-                         PCRITICAL_SECTION CriticalSection,
-                         DWORD dwMilliseconds);
-
 #define pthread_cond_init(a,b) InitializeConditionVariable((a))
 #define pthread_cond_destroy(a) do {} while (0)
 #define pthread_cond_wait(a,b) return_0(SleepConditionVariableCS((a), (b), INFINITE))

--- a/config.c
+++ b/config.c
@@ -1669,7 +1669,7 @@ static int do_git_config_sequence(const struct config_options *opts,
 	if (opts->commondir)
 		repo_config = mkpathdup("%s/config", opts->commondir);
 	else if (opts->git_dir)
-		repo_config = mkpathdup("%s/config", opts->git_dir);
+		BUG("git_dir without commondir");
 	else
 		repo_config = NULL;
 

--- a/http.c
+++ b/http.c
@@ -835,7 +835,7 @@ static CURL *get_curl_handle(void)
 		curl_easy_setopt(result, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NO_REVOKE);
 #else
 		warning("CURLSSLOPT_NO_REVOKE not applied to curl SSL options because\n"
-			"your curl version is too old (>= 7.44.0)");
+			"your curl version is too old (< 7.44.0)");
 #endif
 	}
 

--- a/t/test-lib.sh
+++ b/t/test-lib.sh
@@ -68,10 +68,15 @@ export PERL_PATH SHELL_PATH
 
 ################################################################
 # It appears that people try to run tests without building...
-test -n "$GIT_TEST_INSTALLED" || "$GIT_BUILD_DIR/git$X" >/dev/null ||
+"${GIT_TEST_INSTALLED:-$GIT_BUILD_DIR}/git$X" >/dev/null
 if test $? != 1
 then
-	echo >&2 'error: you do not seem to have built git yet.'
+	if test -n "$GIT_TEST_INSTALLED"
+	then
+		echo >&2 "error: there is no working Git at '$GIT_TEST_INSTALLED'"
+	else
+		echo >&2 'error: you do not seem to have built git yet.'
+	fi
 	exit 1
 fi
 


### PR DESCRIPTION
Quite a few of the branches in the sub-thicket called `ready-for-upstream` [have been contributed to the Git mailing list](https://github.com/git-for-windows/git/issues/1884). Some of those did not survive contact with the Git mailing list without having to change.

Let's update them.

(Except for the `create-empty-bundle` one, which we [addressed in this PR already](https://github.com/git-for-windows/git/pull/1933).