### PR TITLE
Prepare for skipping `git rebase -p` tests on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -215,8 +215,8 @@ phases:
          . ci/lib.sh
 
          make -j10 DEVELOPER=1 NO_PERL=1 || exit 1
-         NO_PERL=1 NO_SVN_TESTS=1 GIT_TEST_OPTS=\"--no-chain-lint --no-bin-wrappers --quiet --write-junit-xml\" time make -j15 -k DEVELOPER=1 test || {
-           NO_PERL=1 NO_SVN_TESTS=1 GIT_TEST_OPTS=\"-i -v -x\" make -k -C t failed; exit 1
+         NO_PERL=1 NO_SVN_TESTS=1 GIT_TEST_SKIP_REBASE_P=1 GIT_TEST_OPTS=\"--no-chain-lint --no-bin-wrappers --quiet --write-junit-xml\" time make -j15 -k DEVELOPER=1 test || {
+           NO_PERL=1 NO_SVN_TESTS=1 GIT_TEST_SKIP_REBASE_P=1 GIT_TEST_OPTS=\"-i -v -x\" make -k -C t failed; exit 1
          }
 
          save_good_tree


### PR DESCRIPTION
The Windows phase still takes a ton of time, but we can cut corners e.g. by skipping the tests for the `--preserve-merges` mode of `git rebase` (which is soon to be deprecated in favor of `--rebase-merges`, if everything goes according to my plan).