### PR TITLE
mingw: safeguard against compiling with `-DUNICODE`

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1679,7 +1679,7 @@ static pid_t mingw_spawnve_fd(const char *cmd, const char **argv, char **deltaen
 	do_unset_environment_variables();
 
 	/* Determine whether or not we are associated to a console */
-	cons = CreateFile("CONOUT$", GENERIC_WRITE,
+	cons = CreateFileA("CONOUT$", GENERIC_WRITE,
 			FILE_SHARE_WRITE, NULL, OPEN_EXISTING,
 			FILE_ATTRIBUTE_NORMAL, NULL);
 	if (cons == INVALID_HANDLE_VALUE) {
@@ -2344,7 +2344,7 @@ struct passwd *getpwuid(int uid)
 		return p;
 
 	len = sizeof(user_name);
-	if (!GetUserName(user_name, &len)) {
+	if (!GetUserNameA(user_name, &len)) {
 		initialized = 1;
 		return NULL;
 	}

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -3270,7 +3270,7 @@ int is_inside_windows_container(void)
 		return inside_container;
 
 	inside_container = ERROR_SUCCESS ==
-		RegOpenKeyEx(HKEY_LOCAL_MACHINE, key, 0, KEY_READ, &handle);
+		RegOpenKeyExA(HKEY_LOCAL_MACHINE, key, 0, KEY_READ, &handle);
 	RegCloseKey(handle);
 
 	return inside_container;

--- a/compat/poll/poll.c
+++ b/compat/poll/poll.c
@@ -147,7 +147,7 @@ win32_compute_revents (HANDLE h, int *p_sought)
       if (!once_only)
 	{
 	  NtQueryInformationFile = (PNtQueryInformationFile)
-	    GetProcAddress (GetModuleHandle ("ntdll.dll"),
+	    GetProcAddress (GetModuleHandleA ("ntdll.dll"),
 			    "NtQueryInformationFile");
 	  once_only = TRUE;
 	}

--- a/compat/win32/exit-process.h
+++ b/compat/win32/exit-process.h
@@ -127,7 +127,7 @@ static int exit_process(HANDLE process, int exit_code)
 		HANDLE thread = NULL;
 
 		if (!initialized) {
-			HINSTANCE kernel32 = GetModuleHandle("kernel32");
+			HINSTANCE kernel32 = GetModuleHandleA("kernel32");
 			if (!kernel32)
 				die("BUG: cannot find kernel32");
 			exit_process_address = (LPTHREAD_START_ROUTINE)

--- a/compat/winansi.c
+++ b/compat/winansi.c
@@ -629,12 +629,12 @@ void winansi_init(void)
 
 	/* create a named pipe to communicate with the console thread */
 	xsnprintf(name, sizeof(name), "\\\\.\\pipe\\winansi%lu", GetCurrentProcessId());
-	hwrite = CreateNamedPipe(name, PIPE_ACCESS_OUTBOUND,
+	hwrite = CreateNamedPipeA(name, PIPE_ACCESS_OUTBOUND,
 		PIPE_TYPE_BYTE | PIPE_WAIT, 1, BUFFER_SIZE, 0, 0, NULL);
 	if (hwrite == INVALID_HANDLE_VALUE)
 		die_lasterr("CreateNamedPipe failed");
 
-	hread = CreateFile(name, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL);
+	hread = CreateFileA(name, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL);
 	if (hread == INVALID_HANDLE_VALUE)
 		die_lasterr("CreateFile for named pipe failed");
 


### PR DESCRIPTION
While technically not necessary, it is nice to have code that compiles both with and without the `UNICODE` constant defined.

Practically, this means that we have to use the `*A()` and `*W()` variants of the Win32 API functions explicitly.