### PR TITLE
http: add support selecting http version

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -2189,6 +2189,15 @@ http.saveCookies::
 	If set, store cookies received during requests to the file specified by
 	http.cookieFile. Has no effect if http.cookieFile is unset.
 
+http.version::
+	Use the specified HTTP protocol version when communicating with a server.
+	If you want to force the default. The available and default version depend
+	on libcurl. Actually the possible values of
+	this option are:
+
+	- HTTP/2
+	- HTTP/1.1
+
 http.sslVersion::
 	The SSL version to use when negotiating an SSL connection, if you
 	want to force the default.  The available and default version


### PR DESCRIPTION
This is a backport of https://github.com/git/git/commit/d73019feb44b (which made it already to `next`). It allows setting `http.version` to `HTTP/1.1` or `HTTP/2` to choose the version of the HTTP protocol to use.

This might be important e.g. to let users choose to downgrade to HTTP/1.1 when the desired authentication scheme is incompatible with HTTP/2 (such is the case for NTLM, but we already have a cURL-side patch for that in the pipeline: https://github.com/curl/curl/pull/3345).