### PR TITLE
Fix a performance regression in the built-in rebase

### DIFF
--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -368,6 +368,7 @@ static void add_var(struct strbuf *buf, const char *name, const char *value)
 
 #define RESET_HEAD_DETACH (1<<0)
 #define RESET_HEAD_HARD (1<<1)
+#define RESET_HEAD_REFS_ONLY (1<<2)
 
 static int reset_head(struct object_id *oid, const char *action,
 		      const char *switch_to_branch, unsigned flags,
@@ -375,6 +376,7 @@ static int reset_head(struct object_id *oid, const char *action,
 {
 	unsigned detach_head = flags & RESET_HEAD_DETACH;
 	unsigned reset_hard = flags & RESET_HEAD_HARD;
+	unsigned refs_only = flags & RESET_HEAD_REFS_ONLY;
 	struct object_id head_oid;
 	struct tree_desc desc[2] = { { NULL }, { NULL } };
 	struct lock_file lock = LOCK_INIT;
@@ -390,7 +392,7 @@ static int reset_head(struct object_id *oid, const char *action,
 	if (switch_to_branch && !starts_with(switch_to_branch, "refs/"))
 		BUG("Not a fully qualified branch: '%s'", switch_to_branch);
 
-	if (hold_locked_index(&lock, LOCK_REPORT_ON_ERROR) < 0) {
+	if (!refs_only && hold_locked_index(&lock, LOCK_REPORT_ON_ERROR) < 0) {
 		ret = -1;
 		goto leave_reset_head;
 	}
@@ -402,6 +404,9 @@ static int reset_head(struct object_id *oid, const char *action,
 
 	if (!oid)
 		oid = &head_oid;
+
+	if (flags & RESET_HEAD_REFS_ONLY)
+		goto reset_head_refs;
 
 	memset(&unpack_tree_opts, 0, sizeof(unpack_tree_opts));
 	setup_unpack_trees_porcelain(&unpack_tree_opts, action);
@@ -443,6 +448,7 @@ static int reset_head(struct object_id *oid, const char *action,
 		goto leave_reset_head;
 	}
 
+reset_head_refs:
 	reflog_action = getenv(GIT_REFLOG_ACTION_ENVIRONMENT);
 	strbuf_addf(&msg, "%s: ", reflog_action ? reflog_action : "rebase");
 	prefix_len = msg.len;

--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -505,7 +505,8 @@ static int move_to_original_branch(struct rebase_options *opts)
 		    opts->head_name, oid_to_hex(&opts->onto->object.oid));
 	strbuf_addf(&head_reflog, "rebase finished: returning to %s",
 		    opts->head_name);
-	ret = reset_head(NULL, "checkout", opts->head_name, 0,
+	ret = reset_head(NULL, "checkout", opts->head_name,
+			 RESET_HEAD_REFS_ONLY,
 			 orig_head_reflog.buf, head_reflog.buf);
 
 	strbuf_release(&orig_head_reflog);


### PR DESCRIPTION
In the VFSforGit project, it was detected that the patches to call the `--am` backend directly (i.e the `builtin-rebase--am` topic branch) introduced a performance regression.

The root cause was that we translated the `move_to_original_branch` to C by using the `reset_head()` function which *always* updated the worktree.

But in the case of `move_to_original_branch`, we want to update the original branch to point at the current revision, and *not* change the worktree at all.

To work around that performance issue, let's teach `reset_head()` to update *only* the refs.