### PR TITLE
diff: ensure correct lifetime of external_diff_cmd

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -489,7 +489,7 @@ static const char *external_diff(void)
 
 	if (done_preparing)
 		return external_diff_cmd;
-	external_diff_cmd = getenv("GIT_EXTERNAL_DIFF");
+	external_diff_cmd = xstrdup_or_null(getenv("GIT_EXTERNAL_DIFF"));
 	if (!external_diff_cmd)
 		external_diff_cmd = external_diff_cmd_cfg;
 	done_preparing = 1;


### PR DESCRIPTION
According to getenv(3)'s notes:

    The implementation of getenv() is not required to be reentrant.  The
    string pointed to by the return value of getenv() may be statically
    allocated, and can be modified by a subsequent call to getenv(),
    putenv(3), setenv(3), or unsetenv(3).

Since strings returned by getenv() are allowed to change on subsequent
calls to getenv(), make sure to duplicate when caching external_diff_cmd
from environment.

This problem becomes apparent on Git for Windows since fe21c6b285df
(mingw: reencode environment variables on the fly (UTF-16 <-> UTF-8)),
when the getenv() implementation provided in compat/mingw.c was changed
to keep a certain amount of alloc'ed strings and freeing them on
subsequent calls.

This fixes https://github.com/git-for-windows/git/issues/2007:

    $ yes n | git -c difftool.prompt=yes difftool fe21c6b285df fe21c6b285df~100

    Viewing (1/404): '.gitignore'
    Launch 'bc3' [Y/n]?
    Viewing (2/404): 'Documentation/.gitignore'
    Launch 'bc3' [Y/n]?
    Viewing (3/404): 'Documentation/Makefile'
    Launch 'bc3' [Y/n]?
    Viewing (4/404): 'Documentation/RelNotes/2.14.5.txt'
    Launch 'bc3' [Y/n]?
    Viewing (5/404): 'Documentation/RelNotes/2.15.3.txt'
    Launch 'bc3' [Y/n]?
    Viewing (6/404): 'Documentation/RelNotes/2.16.5.txt'
    Launch 'bc3' [Y/n]?
    Viewing (7/404): 'Documentation/RelNotes/2.17.2.txt'
    Launch 'bc3' [Y/n]?
    Viewing (8/404): 'Documentation/RelNotes/2.18.1.txt'
    Launch 'bc3' [Y/n]?
    Viewing (9/404): 'Documentation/RelNotes/2.19.0.txt'
    Launch 'bc3' [Y/n]? error: cannot spawn ¦?: No such file or directory
    fatal: external diff died, stopping at Documentation/RelNotes/2.19.1.txt
