### PR TITLE
Fix a network drive related bug in the new, fast FSCache

### DIFF
--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -24,7 +24,13 @@ struct fscache {
 	unsigned int opendir_requests;
 	unsigned int fscache_requests;
 	unsigned int fscache_misses;
-	WCHAR buffer[64 * 1024];
+	/*
+	 * 32k wide characters translates to 64kB, which is the maximum that
+	 * Windows 8.1 and earlier can handle. On network drives, not only
+	 * the client's Windows version matters, but also the server's,
+	 * therefore we need to keep this to 64kB.
+	 */
+	WCHAR buffer[32 * 1024];
 };
 static struct trace_key trace_fscache = TRACE_KEY_INIT(FSCACHE);
 


### PR DESCRIPTION
It was reported in https://github.com/git-for-windows/git/issues/1989 and https://github.com/git-for-windows/git/issues/2022 that our new FSCache code (which is quite a bit faster than the old version, partially due to using a low-level API instead of a high-level API) caused regressions on network drives in combination with older Windows versions than Windows 10.

This PR fixes it by adjusting the buffer size to accommodate the limits on older Windows versions (and remember, if the server has an older version, this bug hits, too).