### PR TITLE
Drop deprecated `git status --no-lock-index` option

### DIFF
--- a/Documentation/git-status.txt
+++ b/Documentation/git-status.txt
@@ -149,13 +149,6 @@ ignored, then the directory is not shown, but all contents are shown.
 	threshold.
 	See also linkgit:git-diff[1] `--find-renames`.
 
---no-lock-index::
---lock-index::
-	(DEPRECATED: use --no-optional-locks instead)
-	Specifies whether `git status` should try to lock the index and
-	update it afterwards if any changes were detected. Defaults to
-	`--lock-index`.
-
 <pathspec>...::
 	See the 'pathspec' entry in linkgit:gitglossary[7].
 

--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -1475,7 +1475,6 @@ int cmd_status(int argc, const char **argv, const char *prefix)
 {
 	static int no_renames = -1;
 	static const char *rename_score_arg = (const char *)-1;
-	static int no_lock_index = 0;
 	static struct wt_status s;
 	unsigned int progress_flag = 0;
 	int fd;
@@ -1514,9 +1513,6 @@ int cmd_status(int argc, const char **argv, const char *prefix)
 		OPT_CALLBACK_F('M', "find-renames", &rename_score_arg,
 		  N_("n"), N_("detect renames, optionally set similarity index"),
 		  PARSE_OPT_OPTARG | PARSE_OPT_NONEG, opt_parse_rename_score),
-		OPT_BOOL(0, "no-lock-index", &no_lock_index,
-			 N_("(DEPRECATED: use `git --no-optional-locks status` "
-			    "instead) Do not lock the index")),
 		OPT_END(),
 	};
 
@@ -1532,12 +1528,6 @@ int cmd_status(int argc, const char **argv, const char *prefix)
 			     builtin_status_usage, 0);
 	finalize_colopts(&s.colopts, -1);
 	finalize_deferred_config(&s);
-
-	if (no_lock_index) {
-		warning("--no-lock-index is deprecated, use --no-optional-locks"
-			" instead");
-		setenv(GIT_OPTIONAL_LOCKS_ENVIRONMENT, "false", 1);
-	}
 
 	handle_untracked_files_arg(&s);
 	handle_ignored_arg(&s);

--- a/t/t7508-status.sh
+++ b/t/t7508-status.sh
@@ -1646,17 +1646,6 @@ test_expect_success '"Initial commit" should not be noted in commit template' '
 	test_i18ngrep ! "Initial commit" output
 '
 
-test_expect_success '--no-lock-index prevents index update and is deprecated' '
-	test-tool chmtime =1234567890 .git/index &&
-	git status --no-lock-index 2>err &&
-	grep "no-lock-index is deprecated" err &&
-	test-tool chmtime -v +0 .git/index >out &&
-	grep ^1234567890 out &&
-	git status &&
-	test-tool chmtime -v +0 .git/index >out &&
-	! grep ^1234567890 out
-'
-
 test_expect_success '--no-optional-locks prevents index update' '
 	test_set_magic_mtime .git/index &&
 	git --no-optional-locks status &&


### PR DESCRIPTION
This option was quite contentious and we were only able to get it into core Git in a very different form:

```sh
git --no-optional-locks status
```

To help Git for Windows users off of the `--no-lock-index` option, we re-added it and deprecated it.

Now is the time to drop it.

This PR should be applied *after* https://github.com/git-for-windows/git/pull/2067