### PR TITLE
Drop a redundant patch

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,4 +16,3 @@
 /Documentation/gitk.txt conflict-marker-size=32
 /Documentation/user-manual.txt conflict-marker-size=32
 /t/t????-*.sh conflict-marker-size=32
-/t/oid-info/* eol=lf


### PR DESCRIPTION
This reverts a patch in Git for Windows' thicket which made it upstream in a slightly different form, and therefore became obsolete.