### PR TITLE
Touch up symlink .gitattributes support

### DIFF
--- a/Documentation/gitattributes.txt
+++ b/Documentation/gitattributes.txt
@@ -382,6 +382,36 @@ sign `$` upon checkout.  Any byte sequence that begins with
 with `$Id$` upon check-in.
 
 
+`symlink`
+^^^^^^^^^
+
+On Windows, symbolic links have a type: a "file symlink" must point at
+a file, and a "directory symlink" must point at a directory. If the
+type of symlink does not match its target, it doesn't work.
+
+Git does not record the type of symlink in the index or in a tree. On
+checkout it'll guess the type, which only works if the target exists
+at the time the symlink is created. This may often not be the case,
+for example when the link points at a directory inside a submodule.
+
+The `symlink` attribute allows you to explicitly set the type of symlink
+to `file` or `dir`, so Git doesn't have to guess. If you have a set of
+symlinks that point at other files, you can do:
+
+------------------------
+*.gif 	symlink=file
+------------------------
+
+To tell Git that a symlink points at a directory, use:
+
+------------------------
+tools_folder 	symlink=dir
+------------------------
+
+The `symlink` attribute is ignored on platforms other than Windows,
+since they don't distinguish between different types of symlinks.
+
+
 `filter`
 ^^^^^^^^
 

--- a/Documentation/gitattributes.txt
+++ b/Documentation/gitattributes.txt
@@ -382,36 +382,6 @@ sign `$` upon checkout.  Any byte sequence that begins with
 with `$Id$` upon check-in.
 
 
-`symlink`
-^^^^^^^^^
-
-On Windows, symbolic links have a type: a "file symlink" must point at
-a file, and a "directory symlink" must point at a directory. If the
-type of symlink does not match its target, it doesn't work.
-
-Git does not record the type of symlink in the index or in a tree. On
-checkout it'll guess the type, which only works if the target exists
-at the time the symlink is created. This may often not be the case,
-for example when the link points at a directory inside a submodule.
-
-The `symlink` attribute allows you to explicitly set the type of symlink
-to `file` or `dir`, so Git doesn't have to guess. If you have a set of
-symlinks that point at other files, you can do:
-
-------------------------
-*.gif 	symlink=file
-------------------------
-
-To tell Git that a symlink points at a directory, use:
-
-------------------------
-tools_folder 	symlink=dir
-------------------------
-
-The `symlink` attribute is ignored on platforms other than Windows,
-since they don't distinguish between different types of symlinks.
-
-
 `filter`
 ^^^^^^^^
 

--- a/apply.c
+++ b/apply.c
@@ -4346,7 +4346,7 @@ static int try_create_file(struct apply_state *state, const char *path,
 		/* Although buf:size is counted string, it also is NUL
 		 * terminated.
 		 */
-		return !!symlink(buf, path);
+		return !!create_symlink(state && state->repo ? state->repo->index : NULL, buf, path);
 
 	fd = open(path, O_CREAT | O_EXCL | O_WRONLY, (mode & 0100) ? 0777 : 0666);
 	if (fd < 0)

--- a/builtin/difftool.c
+++ b/builtin/difftool.c
@@ -505,7 +505,7 @@ static int run_dir_diff(const char *extcmd, int symlinks, const char *prefix,
 				}
 				add_path(&wtdir, wtdir_len, dst_path);
 				if (symlinks) {
-					if (symlink(wtdir.buf, rdir.buf)) {
+					if (create_symlink(lstate.istate, wtdir.buf, rdir.buf)) {
 						ret = error_errno("could not symlink '%s' to '%s'", wtdir.buf, rdir.buf);
 						goto finish;
 					}

--- a/builtin/init-db.c
+++ b/builtin/init-db.c
@@ -76,7 +76,7 @@ static void copy_templates_1(struct strbuf *path, struct strbuf *template_path,
 			if (strbuf_readlink(&lnk, template_path->buf,
 					    st_template.st_size) < 0)
 				die_errno(_("cannot readlink '%s'"), template_path->buf);
-			if (symlink(lnk.buf, path->buf))
+			if (create_symlink(NULL, lnk.buf, path->buf))
 				die_errno(_("cannot symlink '%s' '%s'"),
 					  lnk.buf, path->buf);
 			strbuf_release(&lnk);
@@ -278,7 +278,7 @@ static int create_default_files(const char *template_path,
 		path = git_path_buf(&buf, "tXXXXXX");
 		if (!close(xmkstemp(path)) &&
 		    !unlink(path) &&
-		    !symlink("testing", path) &&
+		    !create_symlink(NULL, "testing", path) &&
 		    !lstat(path, &st1) &&
 		    S_ISLNK(st1.st_mode))
 			unlink(path); /* good */

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -9,6 +9,7 @@
 #include "win32/lazyload.h"
 #include "../config.h"
 #include "dir.h"
+#include "../attr.h"
 
 #define HCAST(type, handle) ((type)(intptr_t)handle)
 
@@ -2381,6 +2382,37 @@ int link(const char *oldpath, const char *newpath)
 	return 0;
 }
 
+enum symlink_type {
+	SYMLINK_TYPE_UNSPECIFIED = 0,
+	SYMLINK_TYPE_FILE,
+	SYMLINK_TYPE_DIRECTORY,
+};
+
+static enum symlink_type check_symlink_attr(struct index_state *index, const char *link)
+{
+	static struct attr_check *check;
+	const char *value;
+
+	if (!index)
+		return SYMLINK_TYPE_UNSPECIFIED;
+
+	if (!check)
+		check = attr_check_initl("symlink", NULL);
+
+	git_check_attr(index, link, check);
+
+	value = check->items[0].value;
+	if (ATTR_UNSET(value))
+		return SYMLINK_TYPE_UNSPECIFIED;
+	if (!strcmp(value, "file"))
+		return SYMLINK_TYPE_FILE;
+	if (!strcmp(value, "dir") || !strcmp(value, "directory"))
+		return SYMLINK_TYPE_DIRECTORY;
+
+	warning(_("ignoring invalid symlink type '%s' for '%s'"), value, link);
+	return SYMLINK_TYPE_UNSPECIFIED;
+}
+
 int mingw_create_symlink(struct index_state *index, const char *target, const char *link)
 {
 	wchar_t wtarget[MAX_LONG_PATH], wlink[MAX_LONG_PATH];
@@ -2401,7 +2433,31 @@ int mingw_create_symlink(struct index_state *index, const char *target, const ch
 		if (wtarget[len] == '/')
 			wtarget[len] = '\\';
 
-	return create_phantom_symlink(wtarget, wlink);
+	switch (check_symlink_attr(index, link)) {
+	case SYMLINK_TYPE_UNSPECIFIED:
+		/* Create a phantom symlink: it is initially created as a file
+		 * symlink, but may change to a directory symlink later if/when
+		 * the target exists. */
+		return create_phantom_symlink(wtarget, wlink);
+	case SYMLINK_TYPE_FILE:
+		if (!CreateSymbolicLinkW(wlink, wtarget, symlink_file_flags))
+			break;
+		return 0;
+	case SYMLINK_TYPE_DIRECTORY:
+		if (!CreateSymbolicLinkW(wlink, wtarget,
+					 symlink_directory_flags))
+			break;
+		/* There may be dangling phantom symlinks that point at this
+		 * one, which should now morph into directory symlinks. */
+		process_phantom_symlinks();
+		return 0;
+	default:
+		BUG("unhandled symlink type");
+	}
+
+	/* CreateSymbolicLinkW failed. */
+	errno = err_win_to_posix(GetLastError());
+	return -1;
 }
 
 #ifndef _WINNT_H

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -9,7 +9,6 @@
 #include "win32/lazyload.h"
 #include "../config.h"
 #include "dir.h"
-#include "../attr.h"
 
 #define HCAST(type, handle) ((type)(intptr_t)handle)
 
@@ -2382,33 +2381,6 @@ int link(const char *oldpath, const char *newpath)
 	return 0;
 }
 
-enum symlink_type {
-	SYMLINK_TYPE_UNSPECIFIED = 0,
-	SYMLINK_TYPE_FILE,
-	SYMLINK_TYPE_DIRECTORY,
-};
-
-static enum symlink_type check_symlink_attr(const char *link)
-{
-	static struct attr_check *check;
-	const char *value;
-
-	if (!check)
-		check = attr_check_initl("symlink", NULL);
-
-	git_check_attr(the_repository->index, link, check);
-
-	value = check->items[0].value;
-	if (value == NULL)
-		;
-	else if (!strcmp(value, "file"))
-		return SYMLINK_TYPE_FILE;
-	else if (!strcmp(value, "dir"))
-		return SYMLINK_TYPE_DIRECTORY;
-
-	return SYMLINK_TYPE_UNSPECIFIED;
-}
-
 int symlink(const char *target, const char *link)
 {
 	wchar_t wtarget[MAX_LONG_PATH], wlink[MAX_LONG_PATH];
@@ -2429,31 +2401,7 @@ int symlink(const char *target, const char *link)
 		if (wtarget[len] == '/')
 			wtarget[len] = '\\';
 
-	switch (check_symlink_attr(link)) {
-	case SYMLINK_TYPE_UNSPECIFIED:
-		/* Create a phantom symlink: it is initially created as a file
-		 * symlink, but may change to a directory symlink later if/when
-		 * the target exists. */
-		return create_phantom_symlink(wtarget, wlink);
-	case SYMLINK_TYPE_FILE:
-		if (!CreateSymbolicLinkW(wlink, wtarget, symlink_file_flags))
-			break;
-		return 0;
-	case SYMLINK_TYPE_DIRECTORY:
-		if (!CreateSymbolicLinkW(wlink, wtarget,
-					 symlink_directory_flags))
-			break;
-		/* There may be dangling phantom symlinks that point at this
-		 * one, which should now morph into directory symlinks. */
-		process_phantom_symlinks();
-		return 0;
-	default:
-		BUG("unhandled symlink type");
-	}
-
-	/* CreateSymbolicLinkW failed. */
-	errno = err_win_to_posix(GetLastError());
-	return -1;
+	return create_phantom_symlink(wtarget, wlink);
 }
 
 #ifndef _WINNT_H

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2381,7 +2381,7 @@ int link(const char *oldpath, const char *newpath)
 	return 0;
 }
 
-int symlink(const char *target, const char *link)
+int mingw_create_symlink(struct index_state *index, const char *target, const char *link)
 {
 	wchar_t wtarget[MAX_LONG_PATH], wlink[MAX_LONG_PATH];
 	int len;

--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -214,8 +214,10 @@ int setitimer(int type, struct itimerval *in, struct itimerval *out);
 int sigaction(int sig, struct sigaction *in, struct sigaction *out);
 int link(const char *oldpath, const char *newpath);
 int uname(struct utsname *buf);
-int symlink(const char *target, const char *link);
 int readlink(const char *path, char *buf, size_t bufsiz);
+struct index_state;
+int mingw_create_symlink(struct index_state *index, const char *target, const char *link);
+#define create_symlink mingw_create_symlink
 
 /*
  * replacements of existing functions

--- a/entry.c
+++ b/entry.c
@@ -289,7 +289,7 @@ static int write_entry(struct cache_entry *ce,
 		if (!has_symlinks || to_tempfile)
 			goto write_file_entry;
 
-		ret = symlink(new_blob, path);
+		ret = create_symlink(state ? state->istate : NULL, new_blob, path);
 		free(new_blob);
 		if (ret)
 			return error_errno("unable to create symlink %s", path);

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -405,6 +405,15 @@ static inline char *git_find_last_dir_sep(const char *path)
 #define find_last_dir_sep git_find_last_dir_sep
 #endif
 
+#ifndef create_symlink
+struct index_state;
+static inline int git_create_symlink(struct index_state *index, const char *target, const char *link)
+{
+	return symlink(target, link);
+}
+#define create_symlink git_create_symlink
+#endif
+
 #ifndef query_user_email
 #define query_user_email() NULL
 #endif

--- a/merge-recursive.c
+++ b/merge-recursive.c
@@ -1011,7 +1011,7 @@ static int update_file_flags(struct merge_options *o,
 			char *lnk = xmemdupz(buf, size);
 			safe_create_leading_directories_const(path);
 			unlink(path);
-			if (symlink(lnk, path))
+			if (create_symlink(&o->orig_index, lnk, path))
 				ret = err(o, _("failed to symlink '%s': %s"),
 					  path, strerror(errno));
 			free(lnk);

--- a/refs/files-backend.c
+++ b/refs/files-backend.c
@@ -1786,7 +1786,7 @@ static int create_ref_symlink(struct ref_lock *lock, const char *target)
 #ifndef NO_SYMLINK_HEAD
 	char *ref_path = get_locked_file_path(&lock->lk);
 	unlink(ref_path);
-	ret = symlink(target, ref_path);
+	ret = create_symlink(NULL, target, ref_path);
 	free(ref_path);
 
 	if (ret)


### PR DESCRIPTION
In git.git's `master`, the `git_check_attr()` function already reflects the fact that it relies on the presence of a Git index: the `git_check_attr()` function takes an explicit `index` parameter, in preparation for some future in which multiple submodules can be processed in the same process (i.e. with multiple Git indexes).

To reflect that in our `.gitattributes` support for symbolic link types, let's redo a part of those patches: instead of hacking into `symlink()`, we implement and use an index-aware function that creates symbolic links.