### PR TITLE
fixup! poll: lazy-load GetTickCount64()

### DIFF
--- a/compat/poll/poll.c
+++ b/compat/poll/poll.c
@@ -269,20 +269,6 @@ win32_compute_revents_socket (SOCKET h, int sought, long lNetworkEvents)
   return happened;
 }
 
-#include <windows.h>
-#include "compat/win32/lazyload.h"
-
-static ULONGLONG CompatGetTickCount64(void)
-{
-	DECLARE_PROC_ADDR(kernel32.dll, ULONGLONG, GetTickCount64, void);
-
-	if (!INIT_PROC_ADDR(GetTickCount64))
-		return (ULONGLONG)GetTickCount();
-
-	return GetTickCount64();
-}
-#define GetTickCount64 CompatGetTickCount64
-
 #else /* !MinGW */
 
 /* Convert select(2) returned fd_sets into poll(2) revents values.  */


### PR DESCRIPTION
Remove another patch that was needed for Windows XP.