### PR TITLE
Drop duplicate patch

### DIFF
--- a/builtin/repack.c
+++ b/builtin/repack.c
@@ -421,8 +421,6 @@ int cmd_repack(int argc, const char **argv, const char *prefix)
 
 	close_all_packs(the_repository->objects);
 
-	close_all_packs(the_repository->objects);
-
 	/*
 	 * Ok we have prepared all new packfiles.
 	 * First see if there are packs of the same name and if so


### PR DESCRIPTION
This patch made it upstream, but due to its nature (empty lines on both sides), it was not dropped during the merging-rebases, but instead duplicated. Let's drop it.