### PR TITLE
Fix linkage on MinGW

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -434,7 +434,7 @@ ifeq ($(uname_S),Windows)
 	# invalidcontinue.obj allows Git's source code to close the same file
 	# handle twice, or to access the osfhandle of an already-closed stdout
 	# See https://msdn.microsoft.com/en-us/library/ms235330.aspx
-	EXTLIBS = user32.lib advapi32.lib shell32.lib wininet.lib ws2_32.lib invalidcontinue.obj kernel32.lib ntdll.lib
+	EXTLIBS = user32.lib advapi32.lib shell32.lib wininet.lib ws2_32.lib invalidcontinue.obj kernel32.lib ntdll.lib ntoskrnl.lib
 	PTHREAD_LIBS =
 	lib =
 	BASIC_CFLAGS += $(vcpkg_inc) $(sdk_includes) $(msvc_includes)
@@ -609,7 +609,7 @@ ifneq (,$(findstring MINGW,$(uname_S)))
 		compat/win32/pthread.o compat/win32/syslog.o \
 		compat/win32/dirent.o compat/win32/fscache.o
 	BASIC_CFLAGS += -DWIN32 -DPROTECT_NTFS_DEFAULT=1
-	EXTLIBS += -lws2_32
+	EXTLIBS += -lws2_32 -lntoskrnl
 	GITLIBS += git.res
 	PTHREAD_LIBS =
 	RC = windres -O coff


### PR DESCRIPTION
fscache is using NtQueryDirectoryFile, but the required library (ntoskrnl) was not linked against.

This amends commit 27a0a6f516ad9f3966a0b34d9a79f7e6a7c45ead.
