### PR TITLE
built-in rebase: pick up the ORIG_HEAD fix early

### DIFF
--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -476,7 +476,7 @@ reset_head_refs:
 				 detach_head ? REF_NO_DEREF : 0,
 				 UPDATE_REFS_MSG_ON_ERR);
 	else {
-		ret = update_ref(reflog_orig_head, switch_to_branch, oid,
+		ret = update_ref(reflog_head, switch_to_branch, oid,
 				 NULL, 0, UPDATE_REFS_MSG_ON_ERR);
 		if (!ret)
 			ret = create_symref("HEAD", switch_to_branch,

--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -369,6 +369,7 @@ static void add_var(struct strbuf *buf, const char *name, const char *value)
 #define RESET_HEAD_HARD (1<<1)
 #define RESET_HEAD_RUN_POST_CHECKOUT_HOOK (1<<2)
 #define RESET_HEAD_REFS_ONLY (1<<3)
+#define RESET_ORIG_HEAD (1<<4)
 
 static int reset_head(struct object_id *oid, const char *action,
 		      const char *switch_to_branch, unsigned flags,
@@ -378,6 +379,7 @@ static int reset_head(struct object_id *oid, const char *action,
 	unsigned reset_hard = flags & RESET_HEAD_HARD;
 	unsigned run_hook = flags & RESET_HEAD_RUN_POST_CHECKOUT_HOOK;
 	unsigned refs_only = flags & RESET_HEAD_REFS_ONLY;
+	unsigned update_orig_head = flags & RESET_ORIG_HEAD;
 	struct object_id head_oid;
 	struct tree_desc desc[2] = { { NULL }, { NULL } };
 	struct lock_file lock = LOCK_INIT;
@@ -454,18 +456,21 @@ reset_head_refs:
 	strbuf_addf(&msg, "%s: ", reflog_action ? reflog_action : "rebase");
 	prefix_len = msg.len;
 
-	if (!get_oid("ORIG_HEAD", &oid_old_orig))
-		old_orig = &oid_old_orig;
-	if (!get_oid("HEAD", &oid_orig)) {
-		orig = &oid_orig;
-		if (!reflog_orig_head) {
-			strbuf_addstr(&msg, "updating ORIG_HEAD");
-			reflog_orig_head = msg.buf;
-		}
-		update_ref(reflog_orig_head, "ORIG_HEAD", orig, old_orig, 0,
-			   UPDATE_REFS_MSG_ON_ERR);
-	} else if (old_orig)
-		delete_ref(NULL, "ORIG_HEAD", old_orig, 0);
+	if (update_orig_head) {
+		if (!get_oid("ORIG_HEAD", &oid_old_orig))
+			old_orig = &oid_old_orig;
+		if (!get_oid("HEAD", &oid_orig)) {
+			orig = &oid_orig;
+			if (!reflog_orig_head) {
+				strbuf_addstr(&msg, "updating ORIG_HEAD");
+				reflog_orig_head = msg.buf;
+			}
+			update_ref(reflog_orig_head, "ORIG_HEAD", orig,
+				   old_orig, 0, UPDATE_REFS_MSG_ON_ERR);
+		} else if (old_orig)
+			delete_ref(NULL, "ORIG_HEAD", old_orig, 0);
+	}
+
 	if (!reflog_head) {
 		strbuf_setlen(&msg, prefix_len);
 		strbuf_addstr(&msg, "updating HEAD");
@@ -1760,8 +1765,8 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 	strbuf_addf(&msg, "%s: checkout %s",
 		    getenv(GIT_REFLOG_ACTION_ENVIRONMENT), options.onto_name);
 	if (reset_head(&options.onto->object.oid, "checkout", NULL,
-		       RESET_HEAD_DETACH | RESET_HEAD_RUN_POST_CHECKOUT_HOOK,
-		       NULL, msg.buf))
+		       RESET_HEAD_DETACH | RESET_HEAD_RUN_POST_CHECKOUT_HOOK |
+		       RESET_ORIG_HEAD, NULL, msg.buf))
 		die(_("Could not detach HEAD"));
 	strbuf_release(&msg);
 

--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1776,8 +1776,8 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 		strbuf_addf(&msg, "rebase finished: %s onto %s",
 			options.head_name ? options.head_name : "detached HEAD",
 			oid_to_hex(&options.onto->object.oid));
-		reset_head(NULL, "Fast-forwarded", options.head_name, 0,
-			   "HEAD", msg.buf);
+		reset_head(NULL, "Fast-forwarded", options.head_name,
+			   RESET_HEAD_REFS_ONLY, "HEAD", msg.buf);
 		strbuf_release(&msg);
 		ret = !!finish_rebase(&options);
 		goto cleanup;

--- a/t/t3400-rebase.sh
+++ b/t/t3400-rebase.sh
@@ -59,7 +59,7 @@ test_expect_success 'rebase against master' '
 	git rebase master
 '
 
-test_expect_failure 'rebase sets ORIG_HEAD to pre-rebase state' '
+test_expect_success 'rebase sets ORIG_HEAD to pre-rebase state' '
 	git checkout -b orig-head topic &&
 	pre="$(git rev-parse --verify HEAD)" &&
 	git rebase master &&

--- a/t/t3400-rebase.sh
+++ b/t/t3400-rebase.sh
@@ -59,6 +59,14 @@ test_expect_success 'rebase against master' '
 	git rebase master
 '
 
+test_expect_failure 'rebase sets ORIG_HEAD to pre-rebase state' '
+	git checkout -b orig-head topic &&
+	pre="$(git rev-parse --verify HEAD)" &&
+	git rebase master &&
+	test_cmp_rev "$pre" ORIG_HEAD &&
+	! test_cmp_rev "$pre" HEAD
+'
+
 test_expect_success 'rebase, with <onto> and <upstream> specified as :/quuxery' '
 	test_when_finished "git branch -D torebase" &&
 	git checkout -b torebase my-topic-branch^ &&


### PR DESCRIPTION
It was reported (a bit belatedly) that there was a regression in v2.21.0 where the built-in rebase would update `ORIG_HEAD` one times too many, so that it would not point at the pre-rebase state immediately after a rebase completed.

This regression is related (but not identical) to one that was already reported in early January (which was fixed immediately), and for which a regression test had been promised, but which did not materialize until after v2.21.0. Which is too bad, because that re-regression was totally avoidable.

This patch series fixes that problem, and adds a regression test (better late than never, right?) to avoid re-introducing that regression a third time.

This made it (in a slightly different form, see range-diff below) into git.git's `next` already, via https://github.com/git/git/commit/f805f820b4b4. Let's take this early, to let Git for Windows' users benefit from the fix as soon as possible.

The range-diff (demonstrating that the `RESET_HEAD_RUN_POST_CHECKOUT_HOOK` constant requires an adjustment to the `RESET_ORIG_HEAD` constant):

```
$ git range-diff cbd29ead92d8~4..cbd29ead92d8 1c5bf602cb63~4..1c5bf602cb63
1:  e6aac8177d02 ! 1:  626431089390 built-in rebase: no need to check out `onto` twice
    @@ -21,7 +21,6 @@
         passing that flag.
     
         Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
    -    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      diff --git a/builtin/rebase.c b/builtin/rebase.c
      --- a/builtin/rebase.c
2:  eaf81605b8d1 ! 2:  f13cff1f6457 built-in rebase: use the correct reflog when switching branches
    @@ -5,7 +5,6 @@
         By mistake, we used the reflog intended for ORIG_HEAD.
     
         Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
    -    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      diff --git a/builtin/rebase.c b/builtin/rebase.c
      --- a/builtin/rebase.c
3:  c2d96293602b ! 3:  3dfe7f7bb92d built-in rebase: demonstrate that ORIG_HEAD is not set correctly
    @@ -11,7 +11,6 @@
         Reported by Nazri Ramliy.
     
         Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
    -    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      diff --git a/t/t3400-rebase.sh b/t/t3400-rebase.sh
      --- a/t/t3400-rebase.sh
4:  cbd29ead92d8 ! 4:  1c5bf602cb63 built-in rebase: set ORIG_HEAD just once, before the rebase
    @@ -16,22 +16,21 @@
         So let's do that.
     
         Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
    -    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      diff --git a/builtin/rebase.c b/builtin/rebase.c
      --- a/builtin/rebase.c
      +++ b/builtin/rebase.c
     @@
    - #define RESET_HEAD_DETACH (1<<0)
      #define RESET_HEAD_HARD (1<<1)
    - #define RESET_HEAD_REFS_ONLY (1<<2)
    -+#define RESET_ORIG_HEAD (1<<3)
    + #define RESET_HEAD_RUN_POST_CHECKOUT_HOOK (1<<2)
    + #define RESET_HEAD_REFS_ONLY (1<<3)
    ++#define RESET_ORIG_HEAD (1<<4)
      
      static int reset_head(struct object_id *oid, const char *action,
      		      const char *switch_to_branch, unsigned flags,
     @@
    - 	unsigned detach_head = flags & RESET_HEAD_DETACH;
      	unsigned reset_hard = flags & RESET_HEAD_HARD;
    + 	unsigned run_hook = flags & RESET_HEAD_RUN_POST_CHECKOUT_HOOK;
      	unsigned refs_only = flags & RESET_HEAD_REFS_ONLY;
     +	unsigned update_orig_head = flags & RESET_ORIG_HEAD;
      	struct object_id head_oid;
    @@ -75,8 +74,10 @@
      	strbuf_addf(&msg, "%s: checkout %s",
      		    getenv(GIT_REFLOG_ACTION_ENVIRONMENT), options.onto_name);
      	if (reset_head(&options.onto->object.oid, "checkout", NULL,
    --		       RESET_HEAD_DETACH, NULL, msg.buf))
    -+		       RESET_HEAD_DETACH | RESET_ORIG_HEAD, NULL, msg.buf))
    +-		       RESET_HEAD_DETACH | RESET_HEAD_RUN_POST_CHECKOUT_HOOK,
    +-		       NULL, msg.buf))
    ++		       RESET_HEAD_DETACH | RESET_HEAD_RUN_POST_CHECKOUT_HOOK |
    ++		       RESET_ORIG_HEAD, NULL, msg.buf))
      		die(_("Could not detach HEAD"));
      	strbuf_release(&msg);
      
```