### PR TITLE
mingw: allow building with an MSYS2 runtime v3.x

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -626,7 +626,7 @@ ifneq (,$(wildcard ../THIS_IS_MSYSGIT))
 	NO_GETTEXT = YesPlease
 	COMPAT_CLFAGS += -D__USE_MINGW_ACCESS
 else
-	ifeq ($(shell expr "$(uname_R)" : '2\.'),2)
+	ifneq ($(shell expr "$(uname_R)" : '1\.'),2)
 		# MSys2
 		prefix = /usr/
 		# Enable DEP


### PR DESCRIPTION
Recently the Git for Windows project started the upgrade process to
a MSYS2 runtime version based on Cygwin v3.x.

This has the very notable consequence that `$(uname -r)` no longer
reports a version starting with "2", but a version with "3".

That breaks our build, as df5218b4c30b (config.mak.uname: support MSys2,
2016-01-13) simply did not expect the version reported by `uname -r` to
depend on the underlying Cygwin version: it expected the reported
version to match the "2" in "MSYS2".

So let's invert that test case to test for *anything else* than a
version starting with "1" (for MSys). That should safeguard us for the
future, even if Cygwin ends up releasing versionsl like 314.272.65536.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>