### PR TITLE
Fix gitk (long cmdline)

### DIFF
--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -406,14 +406,16 @@ proc start_rev_list {view} {
 	if {$revs eq {}} {
 	    return 0
 	}
-	set args [concat $vflags($view) $revs]
+	set args $vflags($view)
     } else {
+	set revs {}
 	set args $vorigargs($view)
     }
 
     if {[catch {
 	set fd [open [concat | git log --no-color -z --pretty=raw $show_notes \
-			--parents --boundary $args "--" $files] r]
+			--parents --boundary $args --stdin \
+			"<<[join [concat $revs "--" $files] "\\n"]"] r]
     } err]} {
 	error_popup "[mc "Error executing git log:"] $err"
 	return 0
@@ -555,13 +557,19 @@ proc updatecommits {} {
 	    set revs $newrevs
 	    set vposids($view) [lsort -unique [concat $oldpos $vposids($view)]]
 	}
-	set args [concat $vflags($view) $revs --not $oldpos]
+	set args $vflags($view)
+	foreach r $oldpos {
+		lappend revs "^$r"
+	}
     } else {
+	set revs {}
 	set args $vorigargs($view)
     }
     if {[catch {
 	set fd [open [concat | git log --no-color -z --pretty=raw $show_notes \
-			--parents --boundary $args "--" $vfilelimit($view)] r]
+			--parents --boundary $args --stdin \
+			"<<[join [concat $revs "--" \
+				$vfilelimit($view)] "\\n"]" r]
     } err]} {
 	error_popup "[mc "Error executing git log:"] $err"
 	return
@@ -10174,10 +10182,16 @@ proc getallcommits {} {
 	    foreach id $seeds {
 		lappend ids "^$id"
 	    }
+	    lappend ids "--"
 	}
     }
     if {$ids ne {}} {
-	set fd [open [concat $cmd $ids] r]
+	if {$ids eq "--all"} {
+	    set cmd [concat $cmd "--all"]
+	} else {
+	    set cmd [concat $cmd --stdin "<<[join $ids "\\n"]"]
+	}
+	set fd [open $cmd r]
 	fconfigure $fd -blocking 0
 	incr allcommits
 	nowbusy allcommits

--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -406,7 +406,7 @@ proc start_rev_list {view} {
 	if {$revs eq {}} {
 	    return 0
 	}
-	set args [limit_arg_length [concat $vflags($view) $revs]]
+	set args [concat $vflags($view) $revs]
     } else {
 	set args $vorigargs($view)
     }
@@ -10177,7 +10177,18 @@ proc getallcommits {} {
 	}
     }
     if {$ids ne {}} {
-	set cmd [limit_arg_length [concat $cmd $ids]]
+	set cmd [concat $cmd $ids]
+	# The maximum command line length for the CreateProcess function is 32767 characters, see
+	# http://blogs.msdn.com/oldnewthing/archive/2003/12/10/56028.aspx
+	# Be a little conservative in case Tcl adds some more stuff to the command line we do not
+	# know about and truncate the command line at a SHA1-boundary below 32000 characters.
+	if {[tk windowingsystem] == "win32" &&
+		[string length $cmd] > 32000} {
+	    set ndx [string last " " $cmd 32000]
+	    if {$ndx != -1} {
+		set cmd [string range $cmd 0 $ndx]
+	    }
+	}
 	set fd [open $cmd r]
 	fconfigure $fd -blocking 0
 	incr allcommits
@@ -10186,21 +10197,6 @@ proc getallcommits {} {
     } else {
 	dispneartags 0
     }
-}
-
-# The maximum command line length for the CreateProcess function is 32767 characters, see
-# http://blogs.msdn.com/oldnewthing/archive/2003/12/10/56028.aspx
-# Be a little conservative in case Tcl adds some more stuff to the command line we do not
-# know about and truncate the command line at a SHA1-boundary below 32000 characters.
-proc limit_arg_length {cmd} {
-    if {[tk windowingsystem] == "win32" &&
-       [string length $cmd] > 32000} {
-        set ndx [string last " " $cmd 32000]
-        if {$ndx != -1} {
-            return [string range $cmd 0 $ndx]
-        }
-    }
-    return $cmd
 }
 
 # Since most commits have 1 parent and 1 child, we group strings of

--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -569,7 +569,7 @@ proc updatecommits {} {
 	set fd [open [concat | git log --no-color -z --pretty=raw $show_notes \
 			--parents --boundary $args --stdin \
 			"<<[join [concat $revs "--" \
-				$vfilelimit($view)] "\\n"]" r]
+				$vfilelimit($view)] "\\n"]"] r]
     } err]} {
 	error_popup "[mc "Error executing git log:"] $err"
 	return

--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -10177,19 +10177,7 @@ proc getallcommits {} {
 	}
     }
     if {$ids ne {}} {
-	set cmd [concat $cmd $ids]
-	# The maximum command line length for the CreateProcess function is 32767 characters, see
-	# http://blogs.msdn.com/oldnewthing/archive/2003/12/10/56028.aspx
-	# Be a little conservative in case Tcl adds some more stuff to the command line we do not
-	# know about and truncate the command line at a SHA1-boundary below 32000 characters.
-	if {[tk windowingsystem] == "win32" &&
-		[string length $cmd] > 32000} {
-	    set ndx [string last " " $cmd 32000]
-	    if {$ndx != -1} {
-		set cmd [string range $cmd 0 $ndx]
-	    }
-	}
-	set fd [open $cmd r]
+	set fd [open [concat $cmd $ids] r]
 	fconfigure $fd -blocking 0
 	incr allcommits
 	nowbusy allcommits


### PR DESCRIPTION
When `gitk` is faced with *a lot* of refs, it simply passes them to `git rev-list` and `git log` via the command-line without caring about any command-line size limits. On Windows, this fails as soon as the command-line is longer than roughly 32k characters (which is *a lot*, but not if you have over a thousand tags/branches that would amount to a longer command-line than 32k characters, which apparently some users do have).

Based on the excellent groundwork performed in https://github.com/git-for-windows/git/pull/2053, this PR addresses that problem by specifying the revs/files via `stdin`. In contrast to #2053, we try to avoid the full bidirectional inter-process communication: we know in advance what needs to be passed in via `stdin` (it does not depend on any interactive output of the spawned process), so we can use the (otherwise rarely used) [`<<value` feature](https://www.tcl.tk/man/tcl8.4/TclCmd/exec.htm#M11) of Tcl's `open`/`exec` commands.

This fixes https://github.com/git-for-windows/git/issues/1987