### PR TITLE
Drop some obsolete patches

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -408,8 +408,6 @@ include::config/reset.txt[]
 
 include::config/sendemail.txt[]
 
-include::config/sendpack.txt[]
-
 include::config/sequencer.txt[]
 
 include::config/showbranch.txt[]

--- a/Documentation/config/sendpack.txt
+++ b/Documentation/config/sendpack.txt
@@ -1,5 +1,0 @@
-sendpack.sideband::
-	Allows to disable the side-band-64k capability for send-pack even
-	when it is advertised by the server. Makes it possible to work
-	around a limitation in the git for windows implementation together
-	with the dump git protocol. Defaults to true.

--- a/credential.c
+++ b/credential.c
@@ -136,9 +136,7 @@ static void credential_getpass(struct credential *c)
 {
 	if (!c->username)
 		c->username = credential_ask_one("Username", c,
-						 (getenv("GIT_ASKPASS") ?
-						  PROMPT_ASKPASS : 0) |
-						 PROMPT_ECHO);
+						 PROMPT_ASKPASS|PROMPT_ECHO);
 	if (!c->password)
 		c->password = credential_ask_one("Password", c,
 						 PROMPT_ASKPASS);

--- a/send-pack.c
+++ b/send-pack.c
@@ -38,16 +38,6 @@ int option_parse_push_signed(const struct option *opt,
 	die("bad %s argument: %s", opt->long_name, arg);
 }
 
-static int config_use_sideband = 1;
-
-static int send_pack_config(const char *var, const char *value, void *unused)
-{
-	if (!strcmp("sendpack.sideband", var))
-		config_use_sideband = git_config_bool(var, value);
-
-	return 0;
-}
-
 static void feed_object(const struct object_id *oid, FILE *fh, int negative)
 {
 	if (negative && !has_object_file(oid))
@@ -400,8 +390,6 @@ int send_pack(struct send_pack_args *args,
 	const char *push_cert_nonce = NULL;
 	struct packet_reader reader;
 
-	git_config(send_pack_config, NULL);
-
 	/* Does the other end support the reporting? */
 	if (server_supports("report-status"))
 		status_report = 1;
@@ -409,7 +397,7 @@ int send_pack(struct send_pack_args *args,
 		allow_deleting_refs = 1;
 	if (server_supports("ofs-delta"))
 		args->use_ofs_delta = 1;
-	if (config_use_sideband && server_supports("side-band-64k"))
+	if (server_supports("side-band-64k"))
 		use_sideband = 1;
 	if (server_supports("quiet"))
 		quiet_supported = 1;


### PR DESCRIPTION
I recently upstreamed a few more patches to the Git mailing list, and the consensus for these two (https://github.com/gitgitgadget/git/pull/137 and https://github.com/gitgitgadget/git/pull/138) was to drop them, as they are no longer necessary.