### PR TITLE
Prepare the gc tests for v3.x of the MSYS2 runtime

### DIFF
--- a/t/t6500-gc.sh
+++ b/t/t6500-gc.sh
@@ -162,7 +162,15 @@ test_expect_success 'background auto gc respects lock for all operations' '
 	# now fake a concurrent gc that holds the lock; we can use our
 	# shell pid so that it looks valid.
 	hostname=$(hostname || echo unknown) &&
-	printf "$$ %s" "$hostname" >.git/gc.pid &&
+	shell_pid=$$ &&
+	if test_have_prereq MINGW && test -f /proc/$shell_pid/winpid
+	then
+		# In Git for Windows, Bash (actually, the MSYS2 runtime) has a
+		# different idea of PIDs than git.exe (actually Windows). Use
+		# the Windows PID in this case.
+		shell_pid=$(cat /proc/$shell_pid/winpid)
+	fi &&
+	printf "%d %s" "$shell_pid" "$hostname" >.git/gc.pid &&
 
 	# our gc should exit zero without doing anything
 	run_and_wait_for_auto_gc &&


### PR DESCRIPTION
It was always a tricky thing to run Git's scripts with MSYS2 while insisting on running the rest via the non-MSYS2 `git.exe`.

With v3.x of the MSYS2 runtime, this became even trickier, as it now seems that the Cygwin/MSYS2 process IDs no longer are actual Windows process IDs anymore. Or at least `git.exe` cannot open those processes (and `wmic process list` seems not to list them, either).

This PR fixes the (as far as I can tell) only test case that relied on this previously.