### PR TITLE
Fix `git status`' display of `git rebase -ir`'s `label` commands

### DIFF
--- a/wt-status.c
+++ b/wt-status.c
@@ -1197,7 +1197,9 @@ static void abbrev_sha1_in_line(struct strbuf *line)
 	int i;
 
 	if (starts_with(line->buf, "exec ") ||
-	    starts_with(line->buf, "x "))
+	    starts_with(line->buf, "x ") ||
+	    starts_with(line->buf, "label ") ||
+	    starts_with(line->buf, "l "))
 		return;
 
 	split = strbuf_split_max(line, ' ', 3);


### PR DESCRIPTION
Those label commands are currently displayed with their argument resolved as abbreviated commit hash. Not really what we want. We really want the label names instead.

Companion PR to https://github.com/gitgitgadget/git/pull/188.