### PR TITLE
Avoid traversing NTFS junction points in `git clean -dfx`

### DIFF
--- a/builtin/clean.c
+++ b/builtin/clean.c
@@ -984,6 +984,7 @@ int cmd_clean(int argc, const char **argv, const char *prefix)
 
 	if (read_cache() < 0)
 		die(_("index file corrupt"));
+	enable_fscache(active_nr);
 
 	if (!ignored)
 		setup_standard_excludes(&dir);
@@ -1073,6 +1074,7 @@ int cmd_clean(int argc, const char **argv, const char *prefix)
 		strbuf_reset(&abs_path);
 	}
 
+	disable_fscache();
 	strbuf_release(&abs_path);
 	strbuf_release(&buf);
 	string_list_clear(&del_list, 0);

--- a/builtin/clean.c
+++ b/builtin/clean.c
@@ -33,8 +33,10 @@ static const char *msg_remove = N_("Removing %s\n");
 static const char *msg_would_remove = N_("Would remove %s\n");
 static const char *msg_skip_git_dir = N_("Skipping repository %s\n");
 static const char *msg_would_skip_git_dir = N_("Would skip repository %s\n");
+#ifndef CAN_UNLINK_MOUNT_POINTS
 static const char *msg_skip_mount_point = N_("Skipping mount point %s\n");
 static const char *msg_would_skip_mount_point = N_("Would skip mount point %s\n");
+#endif
 static const char *msg_warn_remove_failed = N_("failed to remove %s");
 
 enum color_clean {
@@ -171,6 +173,7 @@ static int remove_dirs(struct strbuf *path, const char *prefix, int force_flag,
 	}
 
 	if (is_mount_point(path)) {
+#ifndef CAN_UNLINK_MOUNT_POINTS
 		if (!quiet) {
 			quote_path_relative(path->buf, prefix, &quoted);
 			printf(dry_run ?
@@ -178,6 +181,16 @@ static int remove_dirs(struct strbuf *path, const char *prefix, int force_flag,
 			       _(msg_skip_mount_point), quoted.buf);
 		}
 		*dir_gone = 0;
+#else
+		if (!dry_run && unlink(path->buf)) {
+			int saved_errno = errno;
+			quote_path_relative(path->buf, prefix, &quoted);
+			errno = saved_errno;
+			warning_errno(_(msg_warn_remove_failed), quoted.buf);
+			*dir_gone = 0;
+			ret = -1;
+		}
+#endif
 
 		goto out;
 	}

--- a/builtin/clean.c
+++ b/builtin/clean.c
@@ -33,6 +33,8 @@ static const char *msg_remove = N_("Removing %s\n");
 static const char *msg_would_remove = N_("Would remove %s\n");
 static const char *msg_skip_git_dir = N_("Skipping repository %s\n");
 static const char *msg_would_skip_git_dir = N_("Would skip repository %s\n");
+static const char *msg_skip_mount_point = N_("Skipping mount point %s\n");
+static const char *msg_would_skip_mount_point = N_("Would skip mount point %s\n");
 static const char *msg_warn_remove_failed = N_("failed to remove %s");
 
 enum color_clean {
@@ -165,6 +167,18 @@ static int remove_dirs(struct strbuf *path, const char *prefix, int force_flag,
 		}
 
 		*dir_gone = 0;
+		goto out;
+	}
+
+	if (is_mount_point(path)) {
+		if (!quiet) {
+			quote_path_relative(path->buf, prefix, &quoted);
+			printf(dry_run ?
+			       _(msg_would_skip_mount_point) :
+			       _(msg_skip_mount_point), quoted.buf);
+		}
+		*dir_gone = 0;
+
 		goto out;
 	}
 

--- a/cache.h
+++ b/cache.h
@@ -1267,6 +1267,7 @@ int normalize_path_copy_len(char *dst, const char *src, int *prefix_len);
 int normalize_path_copy(char *dst, const char *src);
 int longest_ancestor_length(const char *path, struct string_list *prefixes);
 char *strip_path_suffix(const char *path, const char *suffix);
+int is_mount_point_via_stat(struct strbuf *path);
 int daemon_avoid_alias(const char *path);
 
 /*

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2845,6 +2845,28 @@ pid_t waitpid(pid_t pid, int *status, int options)
 	return -1;
 }
 
+int mingw_is_mount_point(struct strbuf *path)
+{
+	WIN32_FIND_DATAW findbuf = { 0 };
+	HANDLE handle;
+	wchar_t wfilename[MAX_LONG_PATH];
+	int wlen = xutftowcs_long_path(wfilename, path->buf);
+	if (wlen < 0)
+		die(_("could not get long path for '%s'"), path->buf);
+
+	/* remove trailing slash, if any */
+	if (wlen > 0 && wfilename[wlen - 1] == L'/')
+		wfilename[--wlen] = L'\0';
+
+	handle = FindFirstFileW(wfilename, &findbuf);
+	if (handle == INVALID_HANDLE_VALUE)
+		return 0;
+	FindClose(handle);
+
+	return (findbuf.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) &&
+		(findbuf.dwReserved0 == IO_REPARSE_TAG_MOUNT_POINT);
+}
+
 int xutftowcsn(wchar_t *wcs, const char *utfs, size_t wcslen, int utflen)
 {
 	int upos = 0, wpos = 0;

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2845,6 +2845,8 @@ pid_t waitpid(pid_t pid, int *status, int options)
 	return -1;
 }
 
+int (*win32_is_mount_point)(struct strbuf *path) = mingw_is_mount_point;
+
 int mingw_is_mount_point(struct strbuf *path)
 {
 	WIN32_FIND_DATAW findbuf = { 0 };

--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -466,6 +466,7 @@ static inline void convert_slashes(char *path)
 struct strbuf;
 int mingw_is_mount_point(struct strbuf *path);
 #define is_mount_point mingw_is_mount_point
+#define CAN_UNLINK_MOUNT_POINTS 1
 #define PATH_SEP ';'
 extern char *mingw_query_user_email(void);
 #define query_user_email mingw_query_user_email

--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -463,6 +463,9 @@ static inline void convert_slashes(char *path)
 		if (*path == '\\')
 			*path = '/';
 }
+struct strbuf;
+int mingw_is_mount_point(struct strbuf *path);
+#define is_mount_point mingw_is_mount_point
 #define PATH_SEP ';'
 extern char *mingw_query_user_email(void);
 #define query_user_email mingw_query_user_email

--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -465,7 +465,8 @@ static inline void convert_slashes(char *path)
 }
 struct strbuf;
 int mingw_is_mount_point(struct strbuf *path);
-#define is_mount_point mingw_is_mount_point
+extern int (*win32_is_mount_point)(struct strbuf *path);
+#define is_mount_point win32_is_mount_point
 #define CAN_UNLINK_MOUNT_POINTS 1
 #define PATH_SEP ';'
 extern char *mingw_query_user_email(void);

--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -465,6 +465,7 @@ int fscache_enable(size_t initial_size)
 		/* redirect opendir and lstat to the fscache implementations */
 		opendir = fscache_opendir;
 		lstat = fscache_lstat;
+		win32_is_mount_point = fscache_is_mount_point;
 	}
 	initialized++;
 	LeaveCriticalSection(&fscache_cs);
@@ -525,6 +526,7 @@ void fscache_disable(void)
 		/* reset opendir and lstat to the original implementations */
 		opendir = dirent_opendir;
 		lstat = mingw_lstat;
+		win32_is_mount_point = mingw_is_mount_point;
 	}
 	LeaveCriticalSection(&fscache_cs);
 
@@ -590,6 +592,38 @@ int fscache_lstat(const char *filename, struct stat *st)
 	/* don't forget to release fsentry */
 	fsentry_release(fse);
 	return 0;
+}
+
+/*
+ * is_mount_point() replacement, uses cache if enabled, otherwise falls
+ * back to mingw_is_mount_point().
+ */
+int fscache_is_mount_point(struct strbuf *path)
+{
+	int dirlen, base, len;
+	struct fsentry key[2], *fse;
+	struct fscache *cache = fscache_getcache();
+
+	if (!cache || !do_fscache_enabled(cache, path->buf))
+		return mingw_is_mount_point(path);
+
+	cache->lstat_requests++;
+	/* split path into path + name */
+	len = path->len;
+	if (len && is_dir_sep(path->buf[len - 1]))
+		len--;
+	base = len;
+	while (base && !is_dir_sep(path->buf[base - 1]))
+		base--;
+	dirlen = base ? base - 1 : 0;
+
+	/* lookup entry for path + name in cache */
+	fsentry_init(key, NULL, path->buf, dirlen);
+	fsentry_init(key + 1, key, path->buf + base, len - base);
+	fse = fscache_get(cache, key + 1);
+	if (!fse)
+		return mingw_is_mount_point(path);
+	return fse->reparse_tag == IO_REPARSE_TAG_MOUNT_POINT;
 }
 
 typedef struct fscache_DIR {

--- a/compat/win32/fscache.h
+++ b/compat/win32/fscache.h
@@ -22,6 +22,7 @@ void fscache_flush(void);
 
 DIR *fscache_opendir(const char *dir);
 int fscache_lstat(const char *file_name, struct stat *buf);
+int fscache_is_mount_point(struct strbuf *path);
 
 /* opaque fscache structure */
 struct fscache;

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -415,6 +415,10 @@ static inline int git_create_symlink(struct index_state *index, const char *targ
 #define create_symlink git_create_symlink
 #endif
 
+#ifndef is_mount_point
+#define is_mount_point is_mount_point_via_stat
+#endif
+
 #ifndef query_user_email
 #define query_user_email() NULL
 #endif

--- a/path.c
+++ b/path.c
@@ -1253,6 +1253,45 @@ char *strip_path_suffix(const char *path, const char *suffix)
 	return xstrndup(path, chomp_trailing_dir_sep(path, path_len));
 }
 
+int is_mount_point_via_stat(struct strbuf *path)
+{
+	size_t len = path->len;
+	unsigned int current_dev;
+	struct stat st;
+
+	if (!strcmp("/", path->buf))
+		return 1;
+
+	strbuf_addstr(path, "/.");
+	if (lstat(path->buf, &st)) {
+		/*
+		 * If we cannot access the current directory, we cannot say
+		 * that it is a bind mount.
+		 */
+		strbuf_setlen(path, len);
+		return 0;
+	}
+	current_dev = st.st_dev;
+
+	/* Now look at the parent directory */
+	strbuf_addch(path, '.');
+	if (lstat(path->buf, &st)) {
+		/*
+		 * If we cannot access the parent directory, we cannot say
+		 * that it is a bind mount.
+		 */
+		strbuf_setlen(path, len);
+		return 0;
+	}
+	strbuf_setlen(path, len);
+
+	/*
+	 * If the device ID differs between current and parent directory,
+	 * then it is a bind mount.
+	 */
+	return current_dev != st.st_dev;
+}
+
 int daemon_avoid_alias(const char *p)
 {
 	int sl, ndot;

--- a/t/t7300-clean.sh
+++ b/t/t7300-clean.sh
@@ -680,4 +680,13 @@ test_expect_success MINGW 'handle clean & core.longpaths = false nicely' '
 	grep "too long" .git/err
 '
 
+test_expect_success MINGW 'clean does not traverse mount points' '
+	mkdir target &&
+	>target/dont-clean-me &&
+	git init with-mountpoint &&
+	cmd //c "mklink /j with-mountpoint\\mountpoint target" &&
+	git -C with-mountpoint clean -dfx &&
+	test_path_is_file target/dont-clean-me
+'
+
 test_done

--- a/t/t7300-clean.sh
+++ b/t/t7300-clean.sh
@@ -686,6 +686,7 @@ test_expect_success MINGW 'clean does not traverse mount points' '
 	git init with-mountpoint &&
 	cmd //c "mklink /j with-mountpoint\\mountpoint target" &&
 	git -C with-mountpoint clean -dfx &&
+	test_path_is_missing with-mountpoint/mountpoint &&
 	test_path_is_file target/dont-clean-me
 '
 


### PR DESCRIPTION
This addresses #607.

Based on #1976.