### PR TITLE
config.mak.uname: PCRE1 cleanup

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -666,8 +666,7 @@ else
 		HAVE_LIBCHARSET_H = YesPlease
 		NO_GETTEXT =
 		USE_GETTEXT_SCHEME = fallthrough
-		USE_LIBPCRE= YesPlease
-		NO_LIBPCRE1_JIT = UnfortunatelyYes
+		USE_LIBPCRE = YesPlease
 		NO_CURL =
 		USE_NED_ALLOCATOR = YesPlease
 		NO_PYTHON =


### PR DESCRIPTION
no longer relevant after moving to PCRE2

Signed-off-by: Carlo Marcelo Arenas Belón <carenas@gmail.com>