### PR TITLE
Vcpkg Install: detect lack of working Git, and note possible vcpkg time outs

### DIFF
--- a/compat/vcbuild/vcpkg_install.bat
+++ b/compat/vcbuild/vcpkg_install.bat
@@ -80,6 +80,12 @@ REM ================================================================
 :sub__install_one
 	echo     Installing package %1...
 
+	REM vcpkg may not be reliable on slow, intermittent or proxy
+	REM connections, see e.g.
+	REM https://social.msdn.microsoft.com/Forums/windowsdesktop/en-US/4a8f7be5-5e15-4213-a7bb-ddf424a954e6/winhttpsendrequest-ends-with-12002-errorhttptimeout-after-21-seconds-no-matter-what-timeout?forum=windowssdk
+	REM which explains the hidden 21 second timeout
+	REM (last post by Dave : Microsoft - Windows Networking team)
+
 	.\vcpkg.exe install %1:%arch%
 	IF ERRORLEVEL 1 ( EXIT /B 1 )
 

--- a/compat/vcbuild/vcpkg_install.bat
+++ b/compat/vcbuild/vcpkg_install.bat
@@ -36,6 +36,13 @@ REM ================================================================
 
 	dir vcpkg\vcpkg.exe >nul 2>nul && GOTO :install_libraries
 
+	git.exe version 2>nul
+	IF ERRORLEVEL 1 (
+	echo "***"
+	echo "Git not found. Please adjust you CMD path or Git install option."
+	echo "***"
+	EXIT /B 1 )
+
 	echo Fetching vcpkg in %cwd%vcpkg
 	git.exe clone https://github.com/Microsoft/vcpkg vcpkg
 	IF ERRORLEVEL 1 ( EXIT /B 1 )


### PR DESCRIPTION
While testing out the vs/master branch that should provide a ready-to-go git.sln for compilation with
Visual Studio, I hit a couple of snags.

These ultimately were problems with my local installation, but the sln compilation should offer extra guidance if users fall into the same trap.

The compilation stage that uses the vcpkg download can also fail on slow networks, so a batch file remark is included to inform users who follow-up the error message.

The fixes #2349 (in conjunction with https://github.com/git-for-windows/build-extra/pull/258).

Signed-off-by: Philip Oakley <philipoakley@iee.email>