### PR TITLE
Work around that pesky Homebrew `perforce` problem

### DIFF
--- a/ci/install-dependencies.sh
+++ b/ci/install-dependencies.sh
@@ -40,7 +40,11 @@ osx-clang|osx-gcc)
 	test -z "$BREW_INSTALL_PACKAGES" ||
 	brew install $BREW_INSTALL_PACKAGES
 	brew link --force gettext
-	brew cask install perforce ||
+	brew cask install perforce || {
+		# Update the definitions and try again
+		git -C "$(brew --repository)"/Library/Taps/homebrew/homebrew-cask pull &&
+		brew cask install perforce
+	} ||
 	brew install caskroom/cask/perforce
 	case "$jobname" in
 	osx-gcc)


### PR DESCRIPTION
I just pushed a fix that was also contributed to git.git via gitgitgadget/git#400, but it _still_ does not fix the problem.

Turns out that @szeder was spot on when he said that we were reluctant to switch to `brew cask install perforce` because stale caches could cause a problem: the `perforce` recipe downloads the latest binaries from Perforce's website, and when that changes, the recipe needs to be updated with the new version number and the new SHA-256. Perforce updated that file on Fri, 11 Oct 2019 20:53:43 GMT most recently, and I offered [a PR to update the recipe](https://github.com/Homebrew/homebrew-cask/pull/70981), and even though that PR was merged, the Azure Pipeline still failed because it still had the old version.

Let's work around this by falling back to pulling `homebrew-cask`'s `master`. As long as the `perforce` recipe in that repository is updated, we will be fine. To make sure that it is updated, I started implementing [an Azure Pipeline to do that](https://dev.azure.com/gitgitgadget/git/_build?definitionId=11&_a=summary). With the change in this PR, we can always re-run the jobs after `homebrew-cask` was updated in order to turn the jobs green.