### PR TITLE
Fix a bug in the hunk-splitting code of the built-in `git add -p`

### DIFF
--- a/add-patch.c
+++ b/add-patch.c
@@ -867,6 +867,10 @@ static int split_hunk(struct add_p_state *s, struct file_diff *file_diff,
 
 		if (marker != ' ' || (ch != '-' && ch != '+')) {
 next_hunk_line:
+			/* Comment lines are attached to the previous line */
+			if (ch == '\\')
+				ch = marker ? marker : ' ';
+
 			/* current hunk not done yet */
 			if (ch == ' ')
 				context_line_count++;

--- a/add-patch.c
+++ b/add-patch.c
@@ -853,6 +853,10 @@ static int split_hunk(struct add_p_state *s, struct file_diff *file_diff,
 
 	while (splittable_into > 1) {
 		ch = s->plain.buf[current];
+
+		if (!ch)
+			BUG("buffer overrun while splitting hunks");
+
 		if ((marker == '-' || marker == '+') && ch == ' ') {
 			first = 0;
 			hunk[1].start = current;

--- a/add-patch.c
+++ b/add-patch.c
@@ -562,8 +562,13 @@ mismatched_output:
 
 static size_t find_next_line(struct strbuf *sb, size_t offset)
 {
-	char *eol = memchr(sb->buf + offset, '\n', sb->len - offset);
+	char *eol;
 
+	if (offset >= sb->len)
+		BUG("looking for next line beyond buffer (%d >= %d)\n%s",
+		    (int)offset, (int)sb->len, sb->buf);
+
+	eol = memchr(sb->buf + offset, '\n', sb->len - offset);
 	if (!eol)
 		return sb->len;
 	return eol - sb->buf + 1;

--- a/add-patch.c
+++ b/add-patch.c
@@ -857,6 +857,10 @@ static int split_hunk(struct add_p_state *s, struct file_diff *file_diff,
 		if (!ch)
 			BUG("buffer overrun while splitting hunks");
 
+		/*
+		 * Is this the first context line after a chain of +/- lines?
+		 * Then record the start of the next split hunk.
+		 */
 		if ((marker == '-' || marker == '+') && ch == ' ') {
 			first = 0;
 			hunk[1].start = current;
@@ -865,6 +869,16 @@ static int split_hunk(struct add_p_state *s, struct file_diff *file_diff,
 			context_line_count = 0;
 		}
 
+		/*
+		 * Was the previous line a +/- one? Alternatively, is this the
+		 * first line (and not a +/- one)?
+		 *
+		 * Then just increment the appropriate counter and continue
+		 * with the next line.
+		 *
+		 * Otherwise this is the first of a chain of +/- lines.
+		 * neither the first of a chain of context lines?
+		 */
 		if (marker != ' ' || (ch != '-' && ch != '+')) {
 next_hunk_line:
 			/* Comment lines are attached to the previous line */

--- a/add-patch.c
+++ b/add-patch.c
@@ -511,10 +511,9 @@ static int parse_diff(struct add_p_state *s, const struct pathspec *ps)
 			    (int)(eol - (plain->buf + file_diff->head.start)),
 			    plain->buf + file_diff->head.start);
 
-		if ((marker == '-' || marker == '+') &&
-		    (*p == ' ' || *p == '\\'))
+		if ((marker == '-' || marker == '+') && *p == ' ')
 			hunk->splittable_into++;
-		if (marker)
+		if (marker && *p != '\\')
 			marker = *p;
 
 		p = eol == pend ? pend : eol + 1;

--- a/t/t3701-add-interactive.sh
+++ b/t/t3701-add-interactive.sh
@@ -472,6 +472,18 @@ test_expect_failure 'split hunk "add -p (no, yes, edit)"' '
 	! grep "^+31" actual
 '
 
+test_expect_success 'split hunk with incomplete line at end' '
+	git reset --hard &&
+	printf "missing LF" >>test &&
+	git add test &&
+	test_write_lines before 10 20 30 40 50 60 70 >test &&
+	git grep --cached missing &&
+	test_write_lines s n y q | git add -p &&
+	test_must_fail git grep --cached missing &&
+	git grep before &&
+	test_must_fail git grep --cached before
+'
+
 test_expect_failure 'edit, adding lines to the first hunk' '
 	test_write_lines 10 11 20 30 40 50 51 60 >test &&
 	git reset &&


### PR DESCRIPTION
This bug was reported over at https://github.com/git-for-windows/git/issues/2364: the code mishandled comment lines in the diffs (i.e. lines starting with a backslash).

While in that part of the code already, I also added some defensive code, and some comments.