### PR TITLE
Avoid a buffer overrun in `needs_hiding()`

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -591,6 +591,8 @@ static inline int needs_hiding(const char *path)
 			/* ignore trailing slashes */
 			if (*path)
 				basename = path;
+			else
+				break;
 		}
 
 	if (hide_dotfiles == HIDE_DOTFILES_TRUE)


### PR DESCRIPTION
Inspired by https://github.com/gitgitgadget/git/pull/414, this is a minimal fix for the issue that `needs_hiding()` runs right outside the buffer when being passed a path with a trailing slash.

The patch in https://github.com/gitgitgadget/git/pull/414 does too many things: it not only fixes the bug, but rewrites a large part of the function. This late in the -rc phase leading up to v2.24.0, I am not willing to risk such a rewrite.

Cc: @SyntevoAlex