### PR TITLE
Fix refresh error in gitk

### DIFF
--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -580,7 +580,7 @@ proc updatecommits {} {
 	set fd [open [concat | git log --no-color -z --pretty=raw $show_notes \
 			--parents --boundary $args --stdin \
 			"<<[join [concat $revs "--" \
-				[escape_filter_paths
+				[escape_filter_paths \
 					$vfilelimit($view)]] "\\n"]"] r]
     } err]} {
 	error_popup "[mc "Error executing git log:"] $err"


### PR DESCRIPTION
https://github.com/git-for-windows/git/pull/2297 tried to escape the paths when refreshing, but it was missing a continuation. This led to the error message

```
	Error executing git log: wrong # args: should be "escape_filter_paths paths"
```

This fixes https://github.com/git-for-windows/git/issues/2390