### PR TITLE
Synchronize built-in add -i/-p patches with upstream

### DIFF
--- a/add-interactive.c
+++ b/add-interactive.c
@@ -427,7 +427,7 @@ static int pathname_entry_cmp(const void *unused_cmp_data,
 }
 
 struct collection_status {
-	enum { FROM_WORKTREE = 0, FROM_INDEX = 1 } phase;
+	enum { FROM_WORKTREE = 0, FROM_INDEX = 1 } mode;
 
 	const char *reference;
 
@@ -473,7 +473,7 @@ static void collect_changes_cb(struct diff_queue_struct *q,
 		}
 
 		file_item = entry->item;
-		adddel = s->phase == FROM_INDEX ?
+		adddel = s->mode == FROM_INDEX ?
 			&file_item->index : &file_item->worktree;
 		other_adddel = s->phase == FROM_INDEX ?
 			&file_item->worktree : &file_item->index;
@@ -526,9 +526,9 @@ static int get_modified_files(struct repository *r,
 		struct setup_revision_opt opt = { 0 };
 
 		if (filter == INDEX_ONLY)
-			s.phase = i ? FROM_WORKTREE : FROM_INDEX;
+			s.mode = (i == 0) ? FROM_INDEX : FROM_WORKTREE;
 		else
-			s.phase = i ? FROM_INDEX : FROM_WORKTREE;
+			s.mode = (i == 0) ? FROM_WORKTREE : FROM_INDEX;
 		s.skip_unseen = filter && i;
 
 		opt.def = is_initial ?
@@ -544,7 +544,7 @@ static int get_modified_files(struct repository *r,
 		if (ps)
 			copy_pathspec(&rev.prune_data, ps);
 
-		if (s.phase == FROM_INDEX)
+		if (s.mode == FROM_INDEX)
 			run_diff_index(&rev, 1);
 		else {
 			rev.diffopt.flags.ignore_dirty_submodules = 1;

--- a/add-interactive.c
+++ b/add-interactive.c
@@ -475,7 +475,7 @@ static void collect_changes_cb(struct diff_queue_struct *q,
 		file_item = entry->item;
 		adddel = s->mode == FROM_INDEX ?
 			&file_item->index : &file_item->worktree;
-		other_adddel = s->phase == FROM_INDEX ?
+		other_adddel = s->mode == FROM_INDEX ?
 			&file_item->worktree : &file_item->index;
 		adddel->seen = 1;
 		adddel->add = stat.files[i]->added;


### PR DESCRIPTION
https://github.com/gitgitgadget/git/pull/171 just made it into `next`, but in a slightly different form than is included in Git for Windows' `master`. This PR brings the latter up to date with the former.