### PR TITLE
Visual Studio solution: check for updates of vcpkg

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,6 +174,7 @@ jobs:
       (New-Object Net.WebClient).DownloadFile($downloadUrl, "compat.zip")
       Expand-Archive compat.zip -DestinationPath . -Force
       Remove-Item compat.zip
+      new-item -path "$(Build.SourcesDirectory)/compat/vcbuild" -name NoPrebuildEvent.txt -type "file" -value "Inhibit git.sln PrebuildEvent"
     displayName: 'Download vcpkg artifacts'
   - task: MSBuild@1
     inputs:

--- a/contrib/buildsystems/Generators/Vcxproj.pm
+++ b/contrib/buildsystems/Generators/Vcxproj.pm
@@ -180,9 +180,8 @@ sub createProject {
 EOM
     if ($target eq 'libgit') {
         print F << "EOM";
-    <PreBuildEvent Condition="!Exists('$cdup\\compat\\vcbuild\\vcpkg\\installed\\\$(VCPKGArch)\\include\\openssl\\ssl.h')">
-      <Message>Initialize VCPKG</Message>
-      <Command>del "$cdup\\compat\\vcbuild\\vcpkg"</Command>
+    <PreBuildEvent Condition="!Exists('$cdup\\compat\\vcbuild\\NoPrebuildEvent.txt')">
+      <Message>Initialize or update VCPKG</Message>
       <Command>call "$cdup\\compat\\vcbuild\\vcpkg_install.bat"</Command>
     </PreBuildEvent>
 EOM


### PR DESCRIPTION
The Microsoft vcpkg package manager recieves continual updates. The
pre-built vs/master git.sln Visual Studio solution would clone and
compile the vcpkg dependencies if missing, but did not check for
updates. Fix this.

Update the contrib/buildsystems/Generators/Vcxproj.pm.

Remove the condition on 'Pre-Build' event for installation, and thus
always check for updates if the vcpkg manager is already present.

The `vcpkg_install.bat' file name is retained to avoid churn. The batch
file now also handles the vcpkg update check.

See https://github.com/microsoft/vcpkg/issues/9148 for update documentation,
however the use of "./vcpkg" is a bashism, not suited to a cmd.bat file.
Use `vcpkg`, no need for the .exe part, removing the `./` should be
sufficient.

Signed-off-by: Philip Oakley <philipoakley@iee.email>

---
I have moderately tested this, and it's working on my VS2017 community edition by pulling and checking for updates, however I don't think there's been any major updates while I've been testing.

This follows the mailing list discussion with @SyntevoAlex https://public-inbox.org/git/?q=%3C021de37a-5317-6c96-eae3-d0228a193d8b%40iee.email%3E 

Suggestion for driving the tesing would be helpful (e.g. best way / how to spoof the initial clone to be from say March 2019, so that updates would be needed on second compile.)