### PR TITLE
clink.pl: fix MSVC compile script to handle libcurl-d.lib

### DIFF
--- a/compat/vcbuild/scripts/clink.pl
+++ b/compat/vcbuild/scripts/clink.pl
@@ -54,7 +54,8 @@ while (@ARGV) {
 		# need to use that instead?
 		foreach my $flag (@lflags) {
 			if ($flag =~ /^-LIBPATH:(.*)/) {
-				foreach my $l ("libcurl_imp.lib", "libcurl.lib") {
+				my $libcurl = $is_debug ? "libcurl-d.lib" : "libcurl.lib";
+				foreach my $l ("libcurl_imp.lib", $libcurl) {
 					if (-f "$1/$l") {
 						$lib = $l;
 						last;


### PR DESCRIPTION
I don't remember having to do this in the past, so maybe something
changed with the libcurl distribution to cause the problem.  And ideally
I could send this upstream first rather than adding more ballast for GFW.


Update clink.pl to link with either libcurl.lib or libcurl-d.lib
depending on whether DEBUG=1 is set.

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>

