### PR TITLE
Fix a regression in the cooperation between FSCache and long paths

### DIFF
--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -73,7 +73,7 @@ struct fsentry {
 
 struct heap_fsentry {
 	struct fsentry ent;
-	char dummy[MAX_PATH];
+	char dummy[MAX_LONG_PATH];
 };
 
 /*


### PR DESCRIPTION
This fixes the bug reported at #2494.