### PR TITLE
credential.c: fix credential reading for DOS systems

### DIFF
--- a/credential.c
+++ b/credential.c
@@ -146,7 +146,7 @@ int credential_read(struct credential *c, FILE *fp)
 {
 	struct strbuf line = STRBUF_INIT;
 
-	while (strbuf_getline_lf(&line, fp) != EOF) {
+	while (strbuf_getline(&line, fp) != EOF) {
 		char *key = line.buf;
 		char *value = strchr(key, '=');
 


### PR DESCRIPTION
This fix makes using `git credentials` more friendly to Windows users. In previous version it was unable to finish input correctly without configuration changes (was tested in powershell, cmd, cygwin).
As we know credential filling should be finished by empty input, but
previous implementation does not take into account 'CLRF' ending, and hence instead of empty string we have '\r', which is interpreted as incorrect string.
So, this commit changes default reading function to more Windows compatible reading function.

Signed-off-by: Nikita Leonov nykyta.leonov@gmail.com