### PR TITLE
[fix] Gitk fails to open on a bare Git repository on Windows

### DIFF
--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -12631,7 +12631,9 @@ set cdup {}
 if {[expr {[exec git rev-parse --is-inside-work-tree] == "true"}]} {
     set cdup [exec git rev-parse --show-cdup]
 }
-set worktree [exec git rev-parse --show-toplevel]
+if {$hasworktree} {
+    set worktree [exec git rev-parse --show-toplevel]
+}
 setcoords
 makewindow
 if {$::tcl_platform(platform) eq {windows} && [file exists $gitk_prefix/etc/git.ico]} {


### PR DESCRIPTION
Running 'git rev-parse --show-toplevel' fails on a bare git repo.
This causes gitk to fail to startup.

Signed-off-by: Remy Bohmer <github@bohmer.net>

