### PR TITLE
mingw: use modern strftime implementation if possible

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1176,7 +1176,15 @@ revert_attrs:
 size_t mingw_strftime(char *s, size_t max,
 		      const char *format, const struct tm *tm)
 {
-	size_t ret = strftime(s, max, format, tm);
+	/* a pointer to the original strftime in case we can't find the UCRT version */
+	static size_t (*fallback)(char *, size_t, const char *, const struct tm *) = strftime;
+	size_t ret;
+	DECLARE_PROC_ADDR(ucrtbase.dll, size_t, strftime, char *, size_t,
+		const char *, const struct tm *);
+	if (INIT_PROC_ADDR(strftime))
+		ret = strftime(s, max, format, tm);
+	else
+		ret = fallback(s, max, format, tm);
 
 	if (!ret && errno == EINVAL)
 		die("invalid strftime format: '%s'", format);


### PR DESCRIPTION
Microsoft introduced a new "Universal C Runtime Library" (UCRT) with
Visual Studio 2015. The UCRT comes with a new strftime() implementation that
supports more date formats. We link git against the older "Microsoft Visual C
Runtime Library" (MSVCRT), so to use the UCRT strftime() we need to load it from
ucrtbase.dll using DECLARE_PROC_ADDR()/INIT_PROC_ADDR().

Most supported Windows systems should have recieved the UCRT via Windows update,
but in some cases only MSVCRT might be available. In that case we fall back to
using that implementation.

