### PR TITLE
Add a GitHub workflow to generate Git for Windows' installer, portable Git, MinGit, etc

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -7,6 +7,10 @@ on:
     inputs:
       build_only:
         description: 'Optionally restrict what artifacts to build'
+      ref:
+        description: 'Optionally override which branch to build'
+      repository:
+        description: 'Optionally override from where to fetch the specified ref'
 
 env:
   GPG_OPTIONS: "--batch --yes --no-tty --list-options no-show-photos --verify-options no-show-photos --pinentry-mode loopback"
@@ -14,6 +18,8 @@ env:
   MSYSTEM: MINGW64
   USERPROFILE: "${{github.workspace}}\\home"
   BUILD_ONLY: "${{github.event.inputs.build_only}}"
+  REPOSITORY: "${{github.event.inputs.repository}}"
+  REF: "${{github.event.inputs.ref}}"
 
 jobs:
   bundle-artifacts:
@@ -70,9 +76,11 @@ jobs:
             printf '#!/bin/sh\n\nexec /mingw64/bin/git.exe "`$@"\n' >/usr/bin/git &&
             mkdir -p bundle-artifacts &&
 
+            { test -n \"`$REPOSITORY\" || REPOSITORY='${{github.repository}}'; } &&
+            { test -n \"`$REF\" || REF='${{github.ref}}'; } &&
             git -c init.defaultBranch=main init --bare &&
             git remote add -f origin https://github.com/git-for-windows/git &&
-            git fetch https://github.com/${{github.repository}} ${{github.ref}}:${{github.ref}} &&
+            git fetch \"https://github.com/`$REPOSITORY\" \"`$REF:`$REF\" &&
 
             tag_name=\"`$(git describe --match 'v[0-9]*' FETCH_HEAD)-`$(date +%Y%m%d%H%M%S)\" &&
             echo \"prerelease-`${tag_name#v}\" >bundle-artifacts/ver &&

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -135,6 +135,18 @@ jobs:
           git remote add -f origin https://github.com/git-for-windows/git &&
           git fetch --tags bundle-artifacts/git.bundle $(cat bundle-artifacts/next_version) &&
           git reset --hard $(cat bundle-artifacts/next_version)
+      - name: Prepare home directory for code-signing
+        env:
+          CODESIGN_P12: ${{secrets.CODESIGN_P12}}
+          CODESIGN_PASS: ${{secrets.CODESIGN_PASS}}
+        if: env.CODESIGN_P12 != '' && env.CODESIGN_PASS != ''
+        shell: bash
+        run: |
+          cd home &&
+          mkdir -p .sig &&
+          echo -n "$CODESIGN_P12" | tr % '\n' | base64 -d >.sig/codesign.p12 &&
+          echo -n "$CODESIGN_PASS" >.sig/codesign.pass
+          git config --global alias.signtool '!sh "/usr/src/build-extra/signtool.sh"'
       - name: Prepare home directory for GPG signing
         if: env.GPGKEY != ''
         shell: bash

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -1,0 +1,141 @@
+name: mingw-w64-x86_64-git
+
+on:
+  # This workflow can be triggered manually in the Actions tab, see
+  # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
+  - workflow_dispatch
+
+env:
+  HOME: "${{github.workspace}}\\home"
+  MSYSTEM: MINGW64
+  USERPROFILE: "${{github.workspace}}\\home"
+
+jobs:
+  bundle-artifacts:
+    runs-on: windows-latest
+    steps:
+      - name: Configure user
+        shell: bash
+        run:
+          USER_NAME="${{github.actor}}" &&
+          USER_EMAIL="${{github.actor}}@users.noreply.github.com" &&
+          mkdir "$HOME" &&
+          git config --global user.name "$USER_NAME" &&
+          git config --global user.email "$USER_EMAIL" &&
+          echo "PACKAGER=$USER_NAME <$USER_EMAIL>" >>$GITHUB_ENV
+      - name: Download git-sdk-64-build-installers
+        shell: bash
+        run: |
+          # Use Git Bash to download and unpack the artifact
+
+          ## Get artifact
+          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
+          id=$(curl "$urlbase?definitions=29&statusFilter=completed&resultFilter=succeeded&\$top=1" |
+            jq -r '.value[0].id')
+          download_url=$(curl "$urlbase/$id/artifacts" |
+            jq -r '.value[] | select(.name == "git-sdk-64-build-installers").resource.downloadUrl')
+
+          curl -o artifacts.zip "$download_url"
+
+          ## Unpack artifact
+          unzip artifacts.zip
+      - name: Clone build-extra
+        shell: bash
+        run: |
+          d=git-sdk-64-build-installers/usr/src/build-extra &&
+          git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d
+      - name: Generate bundle artifacts
+        shell: powershell
+        run: |
+          & .\git-sdk-64-build-installers\git-cmd.exe --command=usr\bin\bash.exe -lc @"
+            printf '#!/bin/sh\n\nexec /mingw64/bin/git.exe "`$@"\n' >/usr/bin/git &&
+            mkdir -p bundle-artifacts &&
+
+            git -c init.defaultBranch=main init --bare &&
+            git remote add -f origin https://github.com/git-for-windows/git &&
+            git fetch https://github.com/${{github.repository}} ${{github.ref}}:${{github.ref}} &&
+
+            tag_name=\"`$(git describe --match 'v[0-9]*' FETCH_HEAD)-`$(date +%Y%m%d%H%M%S)\" &&
+            echo \"prerelease-`${tag_name#v}\" >bundle-artifacts/ver &&
+            echo \"`${tag_name#v}\" >bundle-artifacts/display_version &&
+            echo \"`$tag_name\" >bundle-artifacts/next_version &&
+            git tag -m \"Snapshot build\" \"`$tag_name\" FETCH_HEAD &&
+            git bundle create bundle-artifacts/git.bundle origin/main..\"`$tag_name\" &&
+
+            sh -x /usr/src/build-extra/please.sh mention feature \"Snapshot of `$(git show -s  --pretty='tformat:%h (%s, %ad)' --date=short FETCH_HEAD)\" &&
+            git -C /usr/src/build-extra bundle create \"`$PWD/bundle-artifacts/build-extra.bundle\" origin/main..main
+          "@
+      - name: 'Publish Pipeline Artifact: bundle-artifacts'
+        uses: actions/upload-artifact@v1
+        with:
+          name: bundle-artifacts
+          path: bundle-artifacts
+  pkg-x86_64:
+    runs-on: windows-latest
+    needs: bundle-artifacts
+    steps:
+      - name: Configure user
+        shell: bash
+        run:
+          USER_NAME="${{github.actor}}" &&
+          USER_EMAIL="${{github.actor}}@users.noreply.github.com" &&
+          mkdir "$HOME" &&
+          git config --global user.name "$USER_NAME" &&
+          git config --global user.email "$USER_EMAIL" &&
+          echo "PACKAGER=$USER_NAME <$USER_EMAIL>" >>$GITHUB_ENV
+      - name: Download git-sdk-64-makepkg-git
+        shell: bash
+        run: |
+          # Use Git Bash to download and unpack the artifact
+
+          ## Get artifact
+          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
+          id=${{ needs.bundle-artifacts.outputs.latest-sdk64-extra-build-id }}
+          download_url="$(curl "$urlbase/$id/artifacts" |
+            jq -r '.value[] | select(.name == "git-sdk-64-makepkg-git").resource.downloadUrl')"
+
+          curl -o artifacts.zip "$download_url"
+
+          ## Unpack artifact
+          unzip artifacts.zip
+      - name: Download bundle-artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: bundle-artifacts
+          path: bundle-artifacts
+      - name: Clone and update build-extra
+        shell: bash
+        run: |
+          d=git-sdk-64-makepkg-git/usr/src/build-extra &&
+          git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d &&
+          git -C $d pull "$PWD"/bundle-artifacts/build-extra.bundle main
+      - name: Check out git/git
+        shell: bash
+        run: |
+          git -c init.defaultBranch=main init &&
+          git remote add -f origin https://github.com/git-for-windows/git &&
+          git fetch --tags bundle-artifacts/git.bundle $(cat bundle-artifacts/next_version) &&
+          git reset --hard $(cat bundle-artifacts/next_version)
+      - name: Build mingw-w64-x86_64-git
+        shell: powershell
+        run: |
+          & git-sdk-64-makepkg-git\usr\bin\sh.exe -lc @"
+            set -x
+            # Let `cv2pdb` find the DLLs
+            PATH=\"`$PATH:/C/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64\"
+            type -p mspdb140.dll || exit 1
+            sh -x /usr/src/build-extra/please.sh build-mingw-w64-git --only-64-bit --build-src-pkg -o artifacts HEAD &&
+            cp bundle-artifacts/ver artifacts/ &&
+
+            b=`$PWD/artifacts &&
+            version=`$(cat bundle-artifacts/next_version) &&
+            (cd /usr/src/MINGW-packages/mingw-w64-git &&
+            cp PKGBUILD.`$version PKGBUILD &&
+            git commit -s -m \"mingw-w64-git: new version (`$version)\" PKGBUILD &&
+            git bundle create \"`$b\"/MINGW-packages.bundle origin/main..main)
+          "@
+      - name: Publish mingw-w64-x86_64-git
+        uses: actions/upload-artifact@v1
+        with:
+          name: pkg-x86_64
+          path: artifacts

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -149,16 +149,23 @@ jobs:
           git config --global user.name "$USER_NAME" &&
           git config --global user.email "$USER_EMAIL" &&
           echo "PACKAGER=$USER_NAME <$USER_EMAIL>" >>$GITHUB_ENV
-      - name: Download git-sdk-64-makepkg-git
+      - name: Cache git-sdk-64-build-installers
+        id: cache-sdk-build-installers
+        uses: actions/cache@v2
+        with:
+          path: git-sdk-64-build-installers
+          key: build-installers-64-${{ needs.bundle-artifacts.outputs.latest-sdk64-extra-build-id }}
+      - name: Download git-sdk-64-build-installers
+        if: steps.cache-sdk-build-installers.outputs.cache-hit != 'true'
         shell: bash
         run: |
           # Use Git Bash to download and unpack the artifact
 
           ## Get artifact
           urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
-          id=${{ needs.bundle-artifacts.outputs.latest-sdk64-extra-build-id }}
-          download_url="$(curl "$urlbase/$id/artifacts" |
-            jq -r '.value[] | select(.name == "git-sdk-64-makepkg-git").resource.downloadUrl')"
+          id=${{ needs.pkg.outputs.latest-sdk64-extra-build-id }}
+          download_url=$(curl "$urlbase/$id/artifacts" |
+            jq -r '.value[] | select(.name == "git-sdk-64-build-installers").resource.downloadUrl')
 
           curl -o artifacts.zip "$download_url"
 
@@ -172,8 +179,14 @@ jobs:
       - name: Clone and update build-extra
         shell: bash
         run: |
-          d=git-sdk-64-makepkg-git/usr/src/build-extra &&
-          git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d &&
+          d=git-sdk-64-build-installers/usr/src/build-extra &&
+          if test ! -d $d/.git
+          then
+            git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d
+          else
+            git -C $d fetch https://github.com/git-for-windows/build-extra main &&
+            git -C $d switch -C main FETCH_HEAD
+          fi &&
           git -C $d pull "$PWD"/bundle-artifacts/build-extra.bundle main
       - name: Check out git/git
         shell: bash
@@ -209,7 +222,7 @@ jobs:
           GPGKEY: "${{secrets.GPGKEY}}"
         shell: powershell
         run: |
-          & git-sdk-64-makepkg-git\usr\bin\sh.exe -lc @"
+          & git-sdk-64-build-installers\usr\bin\sh.exe -lc @"
             set -x
             # Let `cv2pdb` find the DLLs
             PATH=\"`$PATH:/C/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin${{matrix.arch.bin}}\"

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -1,4 +1,4 @@
-name: mingw-w64-x86_64-git
+name: git-artifacts
 
 on:
   # This workflow can be triggered manually in the Actions tab, see
@@ -192,4 +192,77 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: pkg-x86_64
+          path: artifacts
+  installer-x86_64:
+    runs-on: windows-latest
+    needs: pkg-x86_64
+    env:
+      MSYSTEM: MINGW64
+    steps:
+      - name: Download pkg-x86_64
+        uses: actions/download-artifact@v1
+        with:
+          name: pkg-x86_64
+          path: pkg-x86_64
+      - name: Download bundle-artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: bundle-artifacts
+          path: bundle-artifacts
+      - name: Download git-sdk-64-build-installers
+        shell: bash
+        run: |
+          # Use Git Bash to download and unpack the artifact
+
+          ## Get artifact
+          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
+          id=${{ needs.pkg.outputs.latest-sdk64-extra-build-id }}
+          download_url="$(curl "$urlbase/$id/artifacts" |
+            jq -r '.value[] | select(.name == "git-sdk-64-build-installers").resource.downloadUrl')"
+
+          curl -o artifacts.zip "$download_url"
+
+          ## Unpack artifact
+          unzip artifacts.zip
+      - name: Clone and update build-extra
+        shell: bash
+        run: |
+          d=git-sdk-64-build-installers/usr/src/build-extra &&
+          git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d &&
+          git -C $d pull "$PWD"/bundle-artifacts/build-extra.bundle main
+      - name: Prepare home directory for code-signing
+        env:
+          CODESIGN_P12: ${{secrets.CODESIGN_P12}}
+          CODESIGN_PASS: ${{secrets.CODESIGN_PASS}}
+        if: (matrix.artifact.name == 'installer' || matrix.artifact.name == 'portable') && env.CODESIGN_P12 != '' && env.CODESIGN_PASS != ''
+        shell: bash
+        run: |
+          mkdir -p home/.sig &&
+          echo -n "$CODESIGN_P12" | tr % '\n' | base64 -d >home/.sig/codesign.p12 &&
+          echo -n "$CODESIGN_PASS" >home/.sig/codesign.pass &&
+          git config --global alias.signtool '!sh "/usr/src/build-extra/signtool.sh"'
+      - name: Build 64-bit installer
+        shell: powershell
+        run: |
+          & .\git-sdk-64-build-installers\usr\bin\bash.exe -lc @"
+            set -x
+            /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=`$(cat pkg-x86_64/ver) -o artifacts --installer --pkg=pkg-x86_64/mingw-w64-x86_64-git-[0-9]*.tar.xz --pkg=pkg-x86_64/mingw-w64-x86_64-git-doc-html-[0-9]*.tar.xz &&
+            openssl dgst -sha256 artifacts/Git-*.exe | sed \"s/.* //\" >artifacts/sha-256.txt &&
+            cp /usr/src/build-extra/installer/package-versions.txt artifacts/ &&
+
+            a=`$PWD/artifacts &&
+            p=`$PWD/pkg-x86_64 &&
+            (cd /usr/src/build-extra &&
+            mkdir -p cached-source-packages &&
+            cp \"`$p\"/*-pdb* cached-source-packages/ &&
+            GIT_CONFIG_PARAMETERS=\"'windows.sdk64.path='\" ./please.sh bundle_pdbs --arch=x86_64 --directory=\"`$a\" installer/package-versions.txt)
+          "@
+      - name: Clean up temporary files
+        if: always()
+        shell: bash
+        run: rm -rf home
+      - name: Publish installer-x86_64
+        uses: actions/upload-artifact@v1
+        with:
+          name: installer-x86_64
           path: artifacts

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -6,6 +6,7 @@ on:
   - workflow_dispatch
 
 env:
+  GPG_OPTIONS: "--batch --yes --no-tty --list-options no-show-photos --verify-options no-show-photos --pinentry-mode loopback"
   HOME: "${{github.workspace}}\\home"
   MSYSTEM: MINGW64
   USERPROFILE: "${{github.workspace}}\\home"
@@ -44,7 +45,21 @@ jobs:
         run: |
           d=git-sdk-64-build-installers/usr/src/build-extra &&
           git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d
+      - name: Prepare home directory for GPG signing
+        if: env.GPGKEY != ''
+        shell: bash
+        run: |
+          echo '${{secrets.PRIVGPGKEY}}' | tr % '\n' | gpg $GPG_OPTIONS --import &&
+          mkdir -p home &&
+          git config --global gpg.program "$PWD/git-sdk-64-build-installers/usr/src/build-extra/gnupg-with-gpgkey.sh" &&
+          info="$(gpg --list-keys --with-colons "${GPGKEY%% *}" | cut -d : -f 1,10 | sed -n '/^uid/{s|uid:||p;q}')" &&
+          git config --global user.name "${info% <*}" &&
+          git config --global user.email "<${info#*<}"
+        env:
+          GPGKEY: ${{secrets.GPGKEY}}
       - name: Generate bundle artifacts
+        env:
+          GPGKEY: ${{secrets.GPGKEY}}
         shell: powershell
         run: |
           & .\git-sdk-64-build-installers\git-cmd.exe --command=usr\bin\bash.exe -lc @"
@@ -59,12 +74,16 @@ jobs:
             echo \"prerelease-`${tag_name#v}\" >bundle-artifacts/ver &&
             echo \"`${tag_name#v}\" >bundle-artifacts/display_version &&
             echo \"`$tag_name\" >bundle-artifacts/next_version &&
-            git tag -m \"Snapshot build\" \"`$tag_name\" FETCH_HEAD &&
+            git tag `$(test -z \"`$GPGKEY\" || echo \" -s\") -m \"Snapshot build\" \"`$tag_name\" FETCH_HEAD &&
             git bundle create bundle-artifacts/git.bundle origin/main..\"`$tag_name\" &&
 
             sh -x /usr/src/build-extra/please.sh mention feature \"Snapshot of `$(git show -s  --pretty='tformat:%h (%s, %ad)' --date=short FETCH_HEAD)\" &&
             git -C /usr/src/build-extra bundle create \"`$PWD/bundle-artifacts/build-extra.bundle\" origin/main..main
           "@
+      - name: Clean up temporary files
+        if: always()
+        shell: bash
+        run: rm -rf home
       - name: 'Publish Pipeline Artifact: bundle-artifacts'
         uses: actions/upload-artifact@v1
         with:
@@ -116,7 +135,19 @@ jobs:
           git remote add -f origin https://github.com/git-for-windows/git &&
           git fetch --tags bundle-artifacts/git.bundle $(cat bundle-artifacts/next_version) &&
           git reset --hard $(cat bundle-artifacts/next_version)
+      - name: Prepare home directory for GPG signing
+        if: env.GPGKEY != ''
+        shell: bash
+        run: |
+          echo '${{secrets.PRIVGPGKEY}}' | tr % '\n' | gpg $GPG_OPTIONS --import &&
+          info="$(gpg --list-keys --with-colons "${GPGKEY%% *}" | cut -d : -f 1,10 | sed -n '/^uid/{s|uid:||p;q}')" &&
+          git config --global user.name "${info% <*}" &&
+          git config --global user.email "<${info#*<}"
+        env:
+          GPGKEY: ${{secrets.GPGKEY}}
       - name: Build mingw-w64-x86_64-git
+        env:
+          GPGKEY: "${{secrets.GPGKEY}}"
         shell: powershell
         run: |
           & git-sdk-64-makepkg-git\usr\bin\sh.exe -lc @"
@@ -126,6 +157,13 @@ jobs:
             type -p mspdb140.dll || exit 1
             sh -x /usr/src/build-extra/please.sh build-mingw-w64-git --only-64-bit --build-src-pkg -o artifacts HEAD &&
             cp bundle-artifacts/ver artifacts/ &&
+            if test -n \"`$GPGKEY\"
+            then
+              for tar in artifacts/*.tar*
+              do
+                /usr/src/build-extra/gnupg-with-gpgkey.sh --detach-sign --no-armor `$tar
+              done
+            fi &&
 
             b=`$PWD/artifacts &&
             version=`$(cat bundle-artifacts/next_version) &&
@@ -134,6 +172,10 @@ jobs:
             git commit -s -m \"mingw-w64-git: new version (`$version)\" PKGBUILD &&
             git bundle create \"`$b\"/MINGW-packages.bundle origin/main..main)
           "@
+      - name: Clean up temporary files
+        if: always()
+        shell: bash
+        run: rm -rf home
       - name: Publish mingw-w64-x86_64-git
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -193,9 +193,26 @@ jobs:
         with:
           name: pkg-x86_64
           path: artifacts
-  installer-x86_64:
+  artifacts:
     runs-on: windows-latest
-    needs: pkg-x86_64
+    needs: pkg
+    strategy:
+      matrix:
+        artifact:
+          - name: installer
+          - name: portable
+            fileprefix: PortableGit
+            fileextension: exe
+          - name: archive
+            fileprefix: Git
+            fileextension: tar.bz2
+          - name: mingit
+            fileprefix: MinGit
+            fileextension: zip
+          - name: mingit-busybox
+            fileprefix: MinGit
+            fileextension: zip
+      fail-fast: false
     env:
       MSYSTEM: MINGW64
     steps:
@@ -241,13 +258,23 @@ jobs:
           echo -n "$CODESIGN_P12" | tr % '\n' | base64 -d >home/.sig/codesign.p12 &&
           echo -n "$CODESIGN_PASS" >home/.sig/codesign.pass &&
           git config --global alias.signtool '!sh "/usr/src/build-extra/signtool.sh"'
-      - name: Build 64-bit installer
+      - name: Build 64-bit ${{matrix.artifact.name}}
         shell: powershell
         run: |
           & .\git-sdk-64-build-installers\usr\bin\bash.exe -lc @"
             set -x
-            /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=`$(cat pkg-x86_64/ver) -o artifacts --installer --pkg=pkg-x86_64/mingw-w64-x86_64-git-[0-9]*.tar.xz --pkg=pkg-x86_64/mingw-w64-x86_64-git-doc-html-[0-9]*.tar.xz &&
-            openssl dgst -sha256 artifacts/Git-*.exe | sed \"s/.* //\" >artifacts/sha-256.txt &&
+            /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=`$(cat pkg-x86_64/ver) -o artifacts --${{matrix.artifact.name}} --pkg=pkg-x86_64/mingw-w64-x86_64-git-[0-9]*.tar.xz --pkg=pkg-x86_64/mingw-w64-x86_64-git-doc-html-[0-9]*.tar.xz &&
+            if test portable = '${{matrix.artifact.name}}' && test -n \"`$(git config alias.signtool)\"
+            then
+              git signtool artifacts/PortableGit-*.exe
+            fi &&
+            openssl dgst -sha256 artifacts/${{matrix.artifact.fileprefix}}-*.${{matrix.artifact.fileextension}} | sed \"s/.* //\" >artifacts/sha-256.txt
+          "@
+      - name: Copy package-versions and pdbs
+        if: matrix.artifact.name == 'installer'
+        shell: powershell
+        run: |
+          & .\git-sdk-64-build-installers\usr\bin\bash.exe -lc @"
             cp /usr/src/build-extra/installer/package-versions.txt artifacts/ &&
 
             a=`$PWD/artifacts &&
@@ -261,8 +288,8 @@ jobs:
         if: always()
         shell: bash
         run: rm -rf home
-      - name: Publish installer-x86_64
+      - name: Publish ${{matrix.artifact.name}}-x86_64
         uses: actions/upload-artifact@v1
         with:
-          name: installer-x86_64
+          name: ${{matrix.artifact.name}}-x86_64
           path: artifacts

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -89,9 +89,18 @@ jobs:
         with:
           name: bundle-artifacts
           path: bundle-artifacts
-  pkg-x86_64:
+  pkg:
     runs-on: windows-latest
     needs: bundle-artifacts
+    strategy:
+      matrix:
+        arch:
+          - name: x86_64
+            bitness: 64
+            bin: /amd64
+          - name: i686
+            bitness: 32
+            bin: ''
     steps:
       - name: Configure user
         shell: bash
@@ -157,7 +166,7 @@ jobs:
           git config --global user.email "<${info#*<}"
         env:
           GPGKEY: ${{secrets.GPGKEY}}
-      - name: Build mingw-w64-x86_64-git
+      - name: Build mingw-w64-${{matrix.arch.name}}-git
         env:
           GPGKEY: "${{secrets.GPGKEY}}"
         shell: powershell
@@ -165,9 +174,9 @@ jobs:
           & git-sdk-64-makepkg-git\usr\bin\sh.exe -lc @"
             set -x
             # Let `cv2pdb` find the DLLs
-            PATH=\"`$PATH:/C/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64\"
+            PATH=\"`$PATH:/C/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin${{matrix.arch.bin}}\"
             type -p mspdb140.dll || exit 1
-            sh -x /usr/src/build-extra/please.sh build-mingw-w64-git --only-64-bit --build-src-pkg -o artifacts HEAD &&
+            sh -x /usr/src/build-extra/please.sh build-mingw-w64-git --only-${{matrix.arch.bitness}}-bit --build-src-pkg -o artifacts HEAD &&
             cp bundle-artifacts/ver artifacts/ &&
             if test -n \"`$GPGKEY\"
             then
@@ -188,10 +197,10 @@ jobs:
         if: always()
         shell: bash
         run: rm -rf home
-      - name: Publish mingw-w64-x86_64-git
+      - name: Publish mingw-w64-${{matrix.arch.name}}-git
         uses: actions/upload-artifact@v1
         with:
-          name: pkg-x86_64
+          name: pkg-${{matrix.arch.name}}
           path: artifacts
   artifacts:
     runs-on: windows-latest
@@ -212,21 +221,27 @@ jobs:
           - name: mingit-busybox
             fileprefix: MinGit
             fileextension: zip
+        arch:
+          - name: x86_64
+            bitness: 64
+          - name: i686
+            bitness: 32
       fail-fast: false
     env:
-      MSYSTEM: MINGW64
+      MSYSTEM: MINGW${{matrix.arch.bitness}}
     steps:
-      - name: Download pkg-x86_64
+      - name: Download pkg-${{matrix.arch.name}}
         uses: actions/download-artifact@v1
         with:
-          name: pkg-x86_64
-          path: pkg-x86_64
+          name: pkg-${{matrix.arch.name}}
+          path: pkg-${{matrix.arch.name}}
       - name: Download bundle-artifacts
         uses: actions/download-artifact@v1
         with:
           name: bundle-artifacts
           path: bundle-artifacts
       - name: Download git-sdk-64-build-installers
+        if: matrix.arch.bitness == '64'
         shell: bash
         run: |
           # Use Git Bash to download and unpack the artifact
@@ -241,10 +256,27 @@ jobs:
 
           ## Unpack artifact
           unzip artifacts.zip
+      - name: Download git-sdk-32-build-installers
+        if: matrix.arch.bitness == '32'
+        shell: bash
+        run: |
+          # Use Git Bash to download and unpack the artifact
+
+          ## Get artifact
+          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
+          id=$(curl "$urlbase?definitions=30&statusFilter=completed&resultFilter=succeeded&\$top=1" |
+            jq -r '.value[0].id')
+          download_url=$(curl "$urlbase/$id/artifacts" |
+            jq -r '.value[] | select(.name == "git-sdk-32-build-installers").resource.downloadUrl')
+
+          curl -o artifacts.zip "$download_url"
+
+          ## Unpack artifact
+          unzip artifacts.zip
       - name: Clone and update build-extra
         shell: bash
         run: |
-          d=git-sdk-64-build-installers/usr/src/build-extra &&
+          d=git-sdk-${{matrix.arch.bitness}}-build-installers/usr/src/build-extra &&
           git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d &&
           git -C $d pull "$PWD"/bundle-artifacts/build-extra.bundle main
       - name: Prepare home directory for code-signing
@@ -258,12 +290,12 @@ jobs:
           echo -n "$CODESIGN_P12" | tr % '\n' | base64 -d >home/.sig/codesign.p12 &&
           echo -n "$CODESIGN_PASS" >home/.sig/codesign.pass &&
           git config --global alias.signtool '!sh "/usr/src/build-extra/signtool.sh"'
-      - name: Build 64-bit ${{matrix.artifact.name}}
+      - name: Build ${{matrix.arch.bitness}}-bit ${{matrix.artifact.name}}
         shell: powershell
         run: |
-          & .\git-sdk-64-build-installers\usr\bin\bash.exe -lc @"
+          & .\git-sdk-${{matrix.arch.bitness}}-build-installers\usr\bin\bash.exe -lc @"
             set -x
-            /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=`$(cat pkg-x86_64/ver) -o artifacts --${{matrix.artifact.name}} --pkg=pkg-x86_64/mingw-w64-x86_64-git-[0-9]*.tar.xz --pkg=pkg-x86_64/mingw-w64-x86_64-git-doc-html-[0-9]*.tar.xz &&
+            /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=`$(cat pkg-${{matrix.arch.name}}/ver) -o artifacts --${{matrix.artifact.name}} --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-[0-9]*.tar.xz --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-doc-html-[0-9]*.tar.xz &&
             if test portable = '${{matrix.artifact.name}}' && test -n \"`$(git config alias.signtool)\"
             then
               git signtool artifacts/PortableGit-*.exe
@@ -274,22 +306,22 @@ jobs:
         if: matrix.artifact.name == 'installer'
         shell: powershell
         run: |
-          & .\git-sdk-64-build-installers\usr\bin\bash.exe -lc @"
+          & .\git-sdk-${{matrix.arch.bitness}}-build-installers\usr\bin\bash.exe -lc @"
             cp /usr/src/build-extra/installer/package-versions.txt artifacts/ &&
 
             a=`$PWD/artifacts &&
-            p=`$PWD/pkg-x86_64 &&
+            p=`$PWD/pkg-${{matrix.arch.name}} &&
             (cd /usr/src/build-extra &&
             mkdir -p cached-source-packages &&
             cp \"`$p\"/*-pdb* cached-source-packages/ &&
-            GIT_CONFIG_PARAMETERS=\"'windows.sdk64.path='\" ./please.sh bundle_pdbs --arch=x86_64 --directory=\"`$a\" installer/package-versions.txt)
+            GIT_CONFIG_PARAMETERS=\"'windows.sdk${{matrix.arch.bitness}}.path='\" ./please.sh bundle_pdbs --arch=${{matrix.arch.name}} --directory=\"`$a\" installer/package-versions.txt)
           "@
       - name: Clean up temporary files
         if: always()
         shell: bash
         run: rm -rf home
-      - name: Publish ${{matrix.artifact.name}}-x86_64
+      - name: Publish ${{matrix.artifact.name}}-${{matrix.arch.name}}
         uses: actions/upload-artifact@v1
         with:
-          name: ${{matrix.artifact.name}}-x86_64
+          name: ${{matrix.artifact.name}}-${{matrix.arch.name}}
           path: artifacts

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -325,3 +325,52 @@ jobs:
         with:
           name: ${{matrix.artifact.name}}-${{matrix.arch.name}}
           path: artifacts
+  nuget:
+    runs-on: windows-latest
+    needs: pkg
+    steps:
+      - name: Download pkg-x86_64
+        uses: actions/download-artifact@v1
+        with:
+          name: pkg-x86_64
+          path: pkg-x86_64
+      - name: Download bundle-artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: bundle-artifacts
+          path: bundle-artifacts
+      - name: Download git-sdk-64-build-installers
+        shell: bash
+        run: |
+          # Use Git Bash to download and unpack the artifact
+
+          ## Get artifact
+          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
+          id=${{ needs.pkg.outputs.latest-sdk64-extra-build-id }}
+          download_url=$(curl "$urlbase/$id/artifacts" |
+            jq -r '.value[] | select(.name == "git-sdk-64-build-installers").resource.downloadUrl')
+
+          curl -o artifacts.zip "$download_url"
+
+          ## Unpack artifact
+          unzip artifacts.zip
+      - name: Clone and update build-extra
+        shell: bash
+        run: |
+          d=git-sdk-64-build-installers/usr/src/build-extra &&
+          git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d &&
+          git -C $d pull "$PWD"/bundle-artifacts/build-extra.bundle main
+      - uses: nuget/setup-nuget@v1
+      - name: Build 64-bit NuGet packages
+        shell: powershell
+        run: |
+          & .\git-sdk-64-build-installers\usr\bin\bash.exe -lc @"
+            /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=`$(cat pkg-x86_64/ver) -o artifacts --nuget --pkg=pkg-x86_64/mingw-w64-x86_64-git-[0-9]*.tar.xz --pkg=pkg-x86_64/mingw-w64-x86_64-git-doc-html-[0-9]*.tar.xz &&
+            /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=`$(cat pkg-x86_64/ver) -o artifacts --nuget-mingit &&
+            openssl dgst -sha256 artifacts/Git*.nupkg | sed \"s/.* //\" >artifacts/sha-256.txt
+          "@
+      - name: Publish nuget-x86_64
+        uses: actions/upload-artifact@v1
+        with:
+          name: nuget-x86_64
+          path: artifacts

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -3,13 +3,17 @@ name: git-artifacts
 on:
   # This workflow can be triggered manually in the Actions tab, see
   # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
-  - workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      build_only:
+        description: 'Optionally restrict what artifacts to build'
 
 env:
   GPG_OPTIONS: "--batch --yes --no-tty --list-options no-show-photos --verify-options no-show-photos --pinentry-mode loopback"
   HOME: "${{github.workspace}}\\home"
   MSYSTEM: MINGW64
   USERPROFILE: "${{github.workspace}}\\home"
+  BUILD_ONLY: "${{github.event.inputs.build_only}}"
 
 jobs:
   bundle-artifacts:
@@ -230,18 +234,28 @@ jobs:
     env:
       MSYSTEM: MINGW${{matrix.arch.bitness}}
     steps:
+      - name: Determine whether this job should be skipped
+        shell: bash
+        run: |
+          case " $BUILD_ONLY " in
+          '  ') ;; # not set; build all
+          *" ${{matrix.artifact.name}} "*|*" ${{matrix.artifact.name}}-${{matrix.arch.name}} "*) ;; # build this artifact
+          *) echo "SKIP=true" >>$GITHUB_ENV;;
+          esac
       - name: Download pkg-${{matrix.arch.name}}
+        if: env.SKIP != 'true'
         uses: actions/download-artifact@v1
         with:
           name: pkg-${{matrix.arch.name}}
           path: pkg-${{matrix.arch.name}}
       - name: Download bundle-artifacts
+        if: env.SKIP != 'true'
         uses: actions/download-artifact@v1
         with:
           name: bundle-artifacts
           path: bundle-artifacts
       - name: Download git-sdk-64-build-installers
-        if: matrix.arch.bitness == '64'
+        if: env.SKIP != 'true' && matrix.arch.bitness == '64'
         shell: bash
         run: |
           # Use Git Bash to download and unpack the artifact
@@ -257,7 +271,7 @@ jobs:
           ## Unpack artifact
           unzip artifacts.zip
       - name: Download git-sdk-32-build-installers
-        if: matrix.arch.bitness == '32'
+        if: env.SKIP != 'true' && matrix.arch.bitness == '32'
         shell: bash
         run: |
           # Use Git Bash to download and unpack the artifact
@@ -274,6 +288,7 @@ jobs:
           ## Unpack artifact
           unzip artifacts.zip
       - name: Clone and update build-extra
+        if: env.SKIP != 'true'
         shell: bash
         run: |
           d=git-sdk-${{matrix.arch.bitness}}-build-installers/usr/src/build-extra &&
@@ -283,7 +298,7 @@ jobs:
         env:
           CODESIGN_P12: ${{secrets.CODESIGN_P12}}
           CODESIGN_PASS: ${{secrets.CODESIGN_PASS}}
-        if: (matrix.artifact.name == 'installer' || matrix.artifact.name == 'portable') && env.CODESIGN_P12 != '' && env.CODESIGN_PASS != ''
+        if: env.SKIP != 'true' && (matrix.artifact.name == 'installer' || matrix.artifact.name == 'portable') && env.CODESIGN_P12 != '' && env.CODESIGN_PASS != ''
         shell: bash
         run: |
           mkdir -p home/.sig &&
@@ -291,6 +306,7 @@ jobs:
           echo -n "$CODESIGN_PASS" >home/.sig/codesign.pass &&
           git config --global alias.signtool '!sh "/usr/src/build-extra/signtool.sh"'
       - name: Build ${{matrix.arch.bitness}}-bit ${{matrix.artifact.name}}
+        if: env.SKIP != 'true'
         shell: powershell
         run: |
           & .\git-sdk-${{matrix.arch.bitness}}-build-installers\usr\bin\bash.exe -lc @"
@@ -303,7 +319,7 @@ jobs:
             openssl dgst -sha256 artifacts/${{matrix.artifact.fileprefix}}-*.${{matrix.artifact.fileextension}} | sed \"s/.* //\" >artifacts/sha-256.txt
           "@
       - name: Copy package-versions and pdbs
-        if: matrix.artifact.name == 'installer'
+        if: env.SKIP != 'true' && matrix.artifact.name == 'installer'
         shell: powershell
         run: |
           & .\git-sdk-${{matrix.arch.bitness}}-build-installers\usr\bin\bash.exe -lc @"
@@ -317,10 +333,11 @@ jobs:
             GIT_CONFIG_PARAMETERS=\"'windows.sdk${{matrix.arch.bitness}}.path='\" ./please.sh bundle_pdbs --arch=${{matrix.arch.name}} --directory=\"`$a\" installer/package-versions.txt)
           "@
       - name: Clean up temporary files
-        if: always()
+        if: always() && env.SKIP != 'true'
         shell: bash
         run: rm -rf home
       - name: Publish ${{matrix.artifact.name}}-${{matrix.arch.name}}
+        if: env.SKIP != 'true'
         uses: actions/upload-artifact@v1
         with:
           name: ${{matrix.artifact.name}}-${{matrix.arch.name}}
@@ -329,17 +346,28 @@ jobs:
     runs-on: windows-latest
     needs: pkg
     steps:
+      - name: Determine whether this job should be skipped
+        shell: bash
+        run: |
+          case " $BUILD_ONLY " in
+          '  ') ;; # not set; build all
+          *" nuget "*) ;; # build this artifact
+          *) echo "SKIP=true" >>$GITHUB_ENV;;
+          esac
       - name: Download pkg-x86_64
+        if: env.SKIP != 'true'
         uses: actions/download-artifact@v1
         with:
           name: pkg-x86_64
           path: pkg-x86_64
       - name: Download bundle-artifacts
+        if: env.SKIP != 'true'
         uses: actions/download-artifact@v1
         with:
           name: bundle-artifacts
           path: bundle-artifacts
       - name: Download git-sdk-64-build-installers
+        if: env.SKIP != 'true'
         shell: bash
         run: |
           # Use Git Bash to download and unpack the artifact
@@ -355,13 +383,16 @@ jobs:
           ## Unpack artifact
           unzip artifacts.zip
       - name: Clone and update build-extra
+        if: env.SKIP != 'true'
         shell: bash
         run: |
           d=git-sdk-64-build-installers/usr/src/build-extra &&
           git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d &&
           git -C $d pull "$PWD"/bundle-artifacts/build-extra.bundle main
       - uses: nuget/setup-nuget@v1
+        if: env.SKIP != 'true'
       - name: Build 64-bit NuGet packages
+        if: env.SKIP != 'true'
         shell: powershell
         run: |
           & .\git-sdk-64-build-installers\usr\bin\bash.exe -lc @"
@@ -370,6 +401,7 @@ jobs:
             openssl dgst -sha256 artifacts/Git*.nupkg | sed \"s/.* //\" >artifacts/sha-256.txt
           "@
       - name: Publish nuget-x86_64
+        if: env.SKIP != 'true'
         uses: actions/upload-artifact@v1
         with:
           name: nuget-x86_64

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -24,6 +24,8 @@ env:
 jobs:
   bundle-artifacts:
     runs-on: windows-latest
+    outputs:
+      latest-sdk64-extra-build-id: ${{ steps.determine-latest-sdk64-extra-build-id.outputs.id }}
     steps:
       - name: Configure user
         shell: bash
@@ -34,15 +36,31 @@ jobs:
           git config --global user.name "$USER_NAME" &&
           git config --global user.email "$USER_EMAIL" &&
           echo "PACKAGER=$USER_NAME <$USER_EMAIL>" >>$GITHUB_ENV
+      - name: Determine latest git-sdk-64-extra-artifacts build ID
+        id: determine-latest-sdk64-extra-build-id
+        shell: bash
+        run: |
+          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
+          id=$(curl "$urlbase?definitions=29&statusFilter=completed&resultFilter=succeeded&\$top=1" |
+            jq -r '.value[0].id')
+
+          echo "Latest ID is ${id}"
+          echo "::set-output name=id::$id"
+      - name: Cache git-sdk-64-build-installers
+        id: cache-sdk-build-installers
+        uses: actions/cache@v2
+        with:
+          path: git-sdk-64-build-installers
+          key: build-installers-64-${{ steps.determine-latest-sdk64-extra-build-id.outputs.id }}
       - name: Download git-sdk-64-build-installers
+        if: steps.cache-sdk-build-installers.outputs.cache-hit != 'true'
         shell: bash
         run: |
           # Use Git Bash to download and unpack the artifact
 
           ## Get artifact
           urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
-          id=$(curl "$urlbase?definitions=29&statusFilter=completed&resultFilter=succeeded&\$top=1" |
-            jq -r '.value[0].id')
+          id=${{ steps.determine-latest-sdk64-extra-build-id.outputs.id }}
           download_url=$(curl "$urlbase/$id/artifacts" |
             jq -r '.value[] | select(.name == "git-sdk-64-build-installers").resource.downloadUrl')
 
@@ -54,7 +72,13 @@ jobs:
         shell: bash
         run: |
           d=git-sdk-64-build-installers/usr/src/build-extra &&
-          git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d
+          if test ! -d $d/.git
+          then
+            git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d
+          else
+            git -C $d fetch https://github.com/git-for-windows/build-extra main &&
+            git -C $d switch -C main FETCH_HEAD
+          fi
       - name: Prepare home directory for GPG signing
         if: env.GPGKEY != ''
         shell: bash
@@ -104,6 +128,8 @@ jobs:
   pkg:
     runs-on: windows-latest
     needs: bundle-artifacts
+    outputs:
+      latest-sdk64-extra-build-id: ${{ needs.bundle-artifacts.outputs.latest-sdk64-extra-build-id }}
     strategy:
       matrix:
         arch:
@@ -262,8 +288,15 @@ jobs:
         with:
           name: bundle-artifacts
           path: bundle-artifacts
-      - name: Download git-sdk-64-build-installers
+      - name: Cache git-sdk-64-build-installers
         if: env.SKIP != 'true' && matrix.arch.bitness == '64'
+        id: cache-sdk64-build-installers
+        uses: actions/cache@v2
+        with:
+          path: git-sdk-64-build-installers
+          key: build-installers-64-${{ needs.pkg.outputs.latest-sdk64-extra-build-id }}
+      - name: Download git-sdk-64-build-installers
+        if: env.SKIP != 'true' && matrix.arch.bitness == '64' && steps.cache-sdk64-build-installers.outputs.cache-hit != 'true'
         shell: bash
         run: |
           # Use Git Bash to download and unpack the artifact
@@ -278,16 +311,33 @@ jobs:
 
           ## Unpack artifact
           unzip artifacts.zip
-      - name: Download git-sdk-32-build-installers
+      - name: Determine latest git-sdk-32-extra-artifacts build ID
         if: env.SKIP != 'true' && matrix.arch.bitness == '32'
+        id: determine-latest-sdk32-extra-build-id
+        shell: bash
+        run: |
+          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
+          id=$(curl "$urlbase?definitions=30&statusFilter=completed&resultFilter=succeeded&\$top=1" |
+            jq -r '.value[0].id')
+
+          echo "Latest ID is ${id}"
+          echo "::set-output name=id::$id"
+      - name: Cache git-sdk-32-build-installers
+        if: env.SKIP != 'true' && matrix.arch.bitness == '32'
+        id: cache-sdk32-build-installers
+        uses: actions/cache@v2
+        with:
+          path: git-sdk-32-build-installers
+          key: build-installers-32-${{ steps.determine-latest-sdk32-extra-build-id.outputs.id }}
+      - name: Download git-sdk-32-build-installers
+        if: env.SKIP != 'true' && matrix.arch.bitness == '32' && steps.cache-sdk32-build-installers.outputs.cache-hit != 'true'
         shell: bash
         run: |
           # Use Git Bash to download and unpack the artifact
 
           ## Get artifact
           urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
-          id=$(curl "$urlbase?definitions=30&statusFilter=completed&resultFilter=succeeded&\$top=1" |
-            jq -r '.value[0].id')
+          id=${{ steps.determine-latest-sdk32-extra-build-id.outputs.id }}
           download_url=$(curl "$urlbase/$id/artifacts" |
             jq -r '.value[] | select(.name == "git-sdk-32-build-installers").resource.downloadUrl')
 
@@ -300,7 +350,13 @@ jobs:
         shell: bash
         run: |
           d=git-sdk-${{matrix.arch.bitness}}-build-installers/usr/src/build-extra &&
-          git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d &&
+          if test ! -d $d/.git
+          then
+            git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d
+          else
+            git -C $d fetch https://github.com/git-for-windows/build-extra main &&
+            git -C $d switch -C main FETCH_HEAD
+          fi &&
           git -C $d pull "$PWD"/bundle-artifacts/build-extra.bundle main
       - name: Prepare home directory for code-signing
         env:
@@ -374,8 +430,15 @@ jobs:
         with:
           name: bundle-artifacts
           path: bundle-artifacts
-      - name: Download git-sdk-64-build-installers
+      - name: Cache git-sdk-64-build-installers
         if: env.SKIP != 'true'
+        id: cache-sdk-build-installers
+        uses: actions/cache@v2
+        with:
+          path: git-sdk-64-build-installers
+          key: build-installers-64-${{ needs.pkg.outputs.latest-sdk64-extra-build-id }}
+      - name: Download git-sdk-64-build-installers
+        if: env.SKIP != 'true' && steps.cache-sdk-build-installers.outputs.cache-hit != 'true'
         shell: bash
         run: |
           # Use Git Bash to download and unpack the artifact
@@ -395,7 +458,13 @@ jobs:
         shell: bash
         run: |
           d=git-sdk-64-build-installers/usr/src/build-extra &&
-          git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d &&
+          if test ! -d $d/.git
+          then
+            git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d
+          else
+            git -C $d fetch https://github.com/git-for-windows/build-extra main &&
+            git -C $d switch -C main FETCH_HEAD
+          fi &&
           git -C $d pull "$PWD"/bundle-artifacts/build-extra.bundle main
       - uses: nuget/setup-nuget@v1
         if: env.SKIP != 'true'


### PR DESCRIPTION
This workflow is a close transcription of [the Azure Pipeline we use to generate the official installer (and friends)](https://dev.azure.com/git-for-windows/git/_build?definitionId=34&_a=summary) since Git for Windows v2.25.1.

The idea is to let Git for Windows contributors generate those artifacts, without having to install _anything_ on their computer (except maybe Git for Windows, to modify the source code and to trigger the build).

With this, users can edit the file `.github/workflows/git-artifacts.yml` by uncommenting the `push:` line, push to their fork, and the artifacts will be generated and attached to the workflow run associated with the tip commit of the pushed branch.

Alternatively, users could [generate a Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) with `repo` permission and then generate e.g. a Portable Git compiled from core Git's `pu` branch by calling:

```sh
curl -i -H 'Authorization: token <PAT>' \
        -H 'Accept: application/vnd.github.everest-preview+json' \
        --request POST \
        --data '{
               "event_type": "git-artifacts",
                "client_payload": {
                       "build_only": "portable-x86_64",
                        "repository": "git/git",
                        "ref": "refs/heads/pu"
                }
        }' https://api.github.com/repos/<user>/git/dispatches
```

This would trigger a workflow run that is associated with the tip commit of the `master` branch in their fork of git-for-windows/git.

An example of this is to be found here: https://github.com/dscho/git/runs/581368323?check_suite_focus=true; it offers the 64-bit Portable Git built from 2f0419b2cefa3da712d6fba3b5cf9d0b2843adf0 as artifact.

The hope is that this workflow will empower contributors (even the ones who believe that they lack the technical expertise to work on Git for Windows' source code) to dream big and e.g. work on features they so desire, or to simply test whether a given patch will solve the bug they reported.