### PR TITLE
compat/mingw: avoid implict declaration of gmtime_r, localtime_r

### DIFF
--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -203,10 +203,8 @@ int pipe(int filedes[2]);
 unsigned int sleep (unsigned int seconds);
 int mkstemp(char *template);
 int gettimeofday(struct timeval *tv, void *tz);
-#ifndef __MINGW64_VERSION_MAJOR
 struct tm *gmtime_r(const time_t *timep, struct tm *result);
 struct tm *localtime_r(const time_t *timep, struct tm *result);
-#endif
 int getpagesize(void);	/* defined in MinGW's libgcc.a */
 struct passwd *getpwuid(uid_t uid);
 int setitimer(int type, struct itimerval *in, struct itimerval *out);


### PR DESCRIPTION
This is a follow up to a long standing issue first noted on the [Google Git-for-Windows group
last year](https://groups.google.com/forum/#!msg/git-for-windows/4ZoGP6ytGbA/S_T867UYDgAJ).

At the time I was unable to follow through with the investigation. The discussion at the time had failed to notice the `ifndef` guard around the `mingw.h` lines, and the " implicit declaration" issue wasn't fully appreciated.

--
Commit 3ecd153a3b ("compat/mingw: support MSys2-based MinGW build",
2016-01-14) fixed a range of Windows build errors. However some compile
warnings were left for a future patch.

Now that all warnings being treated as errors, the conditional failure
to declare gmtime_r() and localtime_r() in mingw.h is a 'make' compilation
failure. This is the patch to fix such warnings (treated as erors).

Avoid implicit declaration by removing the inverted ifndef conditional.

Signed-off-by: Philip Oakley <philipoakley@iee.email>

---
Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Let's get an early review here.


