### PR TITLE
mingw: lstat: compute correct size for symlinks

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -969,10 +969,14 @@ static int has_valid_directory_prefix(wchar_t *wfilename)
 	return 1;
 }
 
+static int readlink_1(const WCHAR *wpath, BOOL fail_on_unknown_tag,
+		      char *tmpbuf, int *plen, DWORD *ptag);
+
 int mingw_lstat(const char *file_name, struct stat *buf)
 {
 	WIN32_FILE_ATTRIBUTE_DATA fdata;
-	WIN32_FIND_DATAW findbuf = { 0 };
+	DWORD reparse_tag = 0;
+	int link_len = 0;
 	wchar_t wfilename[MAX_LONG_PATH];
 	int wlen = xutftowcs_long_path(wfilename, file_name);
 	if (wlen < 0)
@@ -987,20 +991,21 @@ int mingw_lstat(const char *file_name, struct stat *buf)
 	}
 
 	if (GetFileAttributesExW(wfilename, GetFileExInfoStandard, &fdata)) {
-		/* for reparse points, use FindFirstFile to get the reparse tag */
+		/* for reparse points, get the link tag and length */
 		if (fdata.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
-			HANDLE handle = FindFirstFileW(wfilename, &findbuf);
-			if (handle == INVALID_HANDLE_VALUE)
-				goto error;
-			FindClose(handle);
+			char tmpbuf[MAX_LONG_PATH];
+
+			if (readlink_1(wfilename, FALSE, tmpbuf, &link_len,
+				       &reparse_tag) < 0)
+				return -1;
 		}
 		buf->st_ino = 0;
 		buf->st_gid = 0;
 		buf->st_uid = 0;
 		buf->st_nlink = 1;
 		buf->st_mode = file_attr_to_st_mode(fdata.dwFileAttributes,
-				findbuf.dwReserved0, file_name);
-		buf->st_size = S_ISLNK(buf->st_mode) ? MAX_LONG_PATH :
+				reparse_tag, file_name);
+		buf->st_size = S_ISLNK(buf->st_mode) ? link_len :
 			fdata.nFileSizeLow | (((off_t) fdata.nFileSizeHigh) << 32);
 		buf->st_dev = buf->st_rdev = 0; /* not used by Git */
 		filetime_to_timespec(&(fdata.ftLastAccessTime), &(buf->st_atim));
@@ -1008,7 +1013,7 @@ int mingw_lstat(const char *file_name, struct stat *buf)
 		filetime_to_timespec(&(fdata.ftCreationTime), &(buf->st_ctim));
 		return 0;
 	}
-error:
+
 	switch (GetLastError()) {
 	case ERROR_ACCESS_DENIED:
 	case ERROR_SHARING_VIOLATION:
@@ -2968,17 +2973,13 @@ typedef struct _REPARSE_DATA_BUFFER {
 } REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
 #endif
 
-int readlink(const char *path, char *buf, size_t bufsiz)
+static int readlink_1(const WCHAR *wpath, BOOL fail_on_unknown_tag,
+		      char *tmpbuf, int *plen, DWORD *ptag)
 {
 	HANDLE handle;
-	WCHAR wpath[MAX_LONG_PATH], *wbuf;
+	WCHAR *wbuf;
 	REPARSE_DATA_BUFFER *b = alloca(MAXIMUM_REPARSE_DATA_BUFFER_SIZE);
 	DWORD dummy;
-	char tmpbuf[MAX_LONG_PATH];
-	int len;
-
-	if (xutftowcs_long_path(wpath, path) < 0)
-		return -1;
 
 	/* read reparse point data */
 	handle = CreateFileW(wpath, 0,
@@ -2998,7 +2999,7 @@ int readlink(const char *path, char *buf, size_t bufsiz)
 	CloseHandle(handle);
 
 	/* get target path for symlinks or mount points (aka 'junctions') */
-	switch (b->ReparseTag) {
+	switch ((*ptag = b->ReparseTag)) {
 	case IO_REPARSE_TAG_SYMLINK:
 		wbuf = (WCHAR*) (((char*) b->SymbolicLinkReparseBuffer.PathBuffer)
 				+ b->SymbolicLinkReparseBuffer.SubstituteNameOffset);
@@ -3012,9 +3013,33 @@ int readlink(const char *path, char *buf, size_t bufsiz)
 				+ b->MountPointReparseBuffer.SubstituteNameLength) = 0;
 		break;
 	default:
-		errno = EINVAL;
-		return -1;
+		if (fail_on_unknown_tag) {
+			errno = EINVAL;
+			return -1;
+		} else {
+			*plen = MAX_LONG_PATH;
+			return 0;
+		}
 	}
+
+	if ((*plen =
+	     xwcstoutf(tmpbuf, normalize_ntpath(wbuf), MAX_LONG_PATH)) <  0)
+		return -1;
+	return 0;
+}
+
+int readlink(const char *path, char *buf, size_t bufsiz)
+{
+	WCHAR wpath[MAX_LONG_PATH];
+	char tmpbuf[MAX_LONG_PATH];
+	int len;
+	DWORD tag;
+
+	if (xutftowcs_long_path(wpath, path) < 0)
+		return -1;
+
+	if (readlink_1(wpath, TRUE, tmpbuf, &len, &tag) < 0)
+		return -1;
 
 	/*
 	 * Adapt to strange readlink() API: Copy up to bufsiz *bytes*, potentially
@@ -3023,8 +3048,6 @@ int readlink(const char *path, char *buf, size_t bufsiz)
 	 * so convert to a (hopefully large enough) temporary buffer, then memcpy
 	 * the requested number of bytes (including '\0' for robustness).
 	 */
-	if ((len = xwcstoutf(tmpbuf, normalize_ntpath(wbuf), MAX_LONG_PATH)) < 0)
-		return -1;
 	memcpy(buf, tmpbuf, min(bufsiz, len + 1));
 	return min(bufsiz, len);
 }


### PR DESCRIPTION
This PR includes a single commit that fixes the `mingw_lstat` function to return correct size for symlinks on Windows. Prior to this commit the function returned a fixed size of 4096, which caused problems for repositories that were accessed using git from different platforms.

For example, if using both git for WSL and git for Windows the problem that I describe below could arise.

Consider a git repository accessed using git for WSL:

<img width="519" alt="wsl" src="https://user-images.githubusercontent.com/15330948/82990914-bf8df200-9fb1-11ea-8a94-6d9da2563433.png">

Now consider the same repository accessed using git for Windows:

<img width="520" alt="ps" src="https://user-images.githubusercontent.com/15330948/82991077-fb28bc00-9fb1-11ea-82c7-48a04922ca78.png">

Notice that `RelNotes`, which is a symbolic link, appears modified. This happened because `mingw_lstat` returned `st_size == 4096`, which then git for Windows compared to the index prepared by git for WSL and found a size mismatch.

Finally, using the commit in this PR, a patched `git-status.exe` reports correctly that there are no changes found.

<img width="457" alt="mingw" src="https://user-images.githubusercontent.com/15330948/82991571-b94c4580-9fb2-11ea-8dcf-ab2d03bc2f26.png">
