### PR TITLE
t/t0014: fix: eliminate additional lines from trace

### DIFF
--- a/t/t0014-alias.sh
+++ b/t/t0014-alias.sh
@@ -38,10 +38,10 @@ test_expect_success 'looping aliases - internal execution' '
 #'
 
 test_expect_success 'run-command formats empty args properly' '
-    test_must_fail env GIT_TRACE=1 git frotz a "" b " " c 2>actual.raw &&
-    sed -ne "/run_command:/s/.*trace: run_command: //p" actual.raw >actual &&
-    echo "git-frotz a '\'''\'' b '\'' '\'' c" >expect &&
-    test_cmp expect actual
+	test_must_fail env GIT_TRACE=1 git frotz a "" b " " c 2>actual.raw &&
+	sed -ne "/run_command:/s/.*trace: run_command: //p" actual.raw >actual &&
+	echo "git-frotz a '\'''\'' b '\'' '\'' c" >expect &&
+	test_cmp expect actual
 '
 
 test_done

--- a/t/t0014-alias.sh
+++ b/t/t0014-alias.sh
@@ -39,7 +39,7 @@ test_expect_success 'looping aliases - internal execution' '
 
 test_expect_success 'run-command formats empty args properly' '
 	test_must_fail env GIT_TRACE=1 git frotz a "" b " " c 2>actual.raw &&
-	sed -ne "/run_command:/s/.*trace: run_command: //p" actual.raw >actual &&
+	sed -ne "/run_command: git-frotz/s/.*trace: run_command: //p" actual.raw >actual &&
 	echo "git-frotz a '\'''\'' b '\'' '\'' c" >expect &&
 	test_cmp expect actual
 '


### PR DESCRIPTION
trace on git for windows delivers extra info which makes test
'run-command formats empty args properly' fail:

$ cat actual.raw
10:49:28.858579 exec-cmd.c:237          trace: resolved executable dir: C:/git-sdk-64/mingw64/bin
10:49:28.872991 git.c:702               trace: exec: git-frotz a '' b ' ' c
10:49:28.872991 run-command.c:663       trace: run_command: git-frotz a '' b ' ' c
10:49:28.872991 run-command.c:663       trace: run_command: 'C:\git-sdk-64\mingw64\bin\busybox.exe' --help
git: 'frotz' ist kein Git-Befehl. Siehe 'git --help'.

sed delivers 2 lines back. increase the recognition string
