### PR TITLE
mingw: special-case index entries for symlinks with buggy size

### DIFF
--- a/read-cache.c
+++ b/read-cache.c
@@ -451,6 +451,17 @@ int ie_modified(struct index_state *istate,
 	 * then we know it is.
 	 */
 	if ((changed & DATA_CHANGED) &&
+#ifdef GIT_WINDOWS_NATIVE
+	    /*
+	     * Work around Git for Windows v2.27.0 fixing a bug where symlinks'
+	     * target path lengths were not read at all, and instead recorded
+	     * as 4096: now, all symlinks would appear as modified.
+	     *
+	     * So let's just special-case symlinks with a target path length
+	     * (i.e. `sd_size`) of 4096 and force them to be re-checked.
+	     */
+	    (!S_ISLNK(st->st_mode) || ce->ce_stat_data.sd_size != MAX_LONG_PATH) &&
+#endif
 	    (S_ISGITLINK(ce->ce_mode) || ce->ce_stat_data.sd_size != 0))
 		return changed;
 


### PR DESCRIPTION
Let's not mark symbolic links as modified _always_ when upgrading to v2.27.0: we can detect that situation and simply
pretend that a symbolic link with a known bad size was just checked it out, and therefore needs to be re-checked.

This will help people who upgrade from pre-v2.27.0 versions to post-v2.27.0 versions (but unfortunately not when upgrading to v2.27.0).

Cc: @billziss-gh