### PR TITLE
git add -i: handle CR/LF line endings in the interactive input

### DIFF
--- a/prompt.c
+++ b/prompt.c
@@ -80,7 +80,7 @@ int git_read_line_interactively(struct strbuf *line)
 	int ret;
 
 	fflush(stdout);
-	ret = strbuf_getline_lf(line, stdin);
+	ret = strbuf_getline(line, stdin);
 	if (ret != EOF)
 		strbuf_trim_trailing_newline(line);
 


### PR DESCRIPTION
As of Git for Windows v2.27.0, there is an option to use Windows' newly-introduced Pseudo Console support. When running an interactive add operation with this support enabled, Git will receive CR/LF line
endings.

Therefore, let's not pretend that we are expecting Unix line endings.

This fixes https://github.com/git-for-windows/git/issues/2729