### PR TITLE
fixup! mingw: ensure valid CTYPE

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -3370,7 +3370,7 @@ static void setup_windows_environment(void)
 #endif
 
 	if (!getenv("LC_ALL") && !getenv("LC_CTYPE") && !getenv("LANG"))
-		setenv("LC_CTYPE", "C", 1);
+		setenv("LC_CTYPE", "C.UTF-8", 1);
 
 	/*
 	 * Change 'core.symlinks' default to false, unless native symlinks are


### PR DESCRIPTION
This is a fix for https://github.com/git-for-windows/git/issues/2802. It simply assumes that the console output code page is UTF-8.

This PR may very well also address https://github.com/git-for-windows/git/issues/1087 and https://github.com/git-for-windows/git/issues/1682, at long last.