### PR TITLE
GitHub workflow: automatically follow minor updates of setup-msbuild

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,7 +154,7 @@ jobs:
         Expand-Archive compat.zip -DestinationPath . -Force
         Remove-Item compat.zip
     - name: add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
     - name: copy dlls to root
       shell: powershell
       run: |


### PR DESCRIPTION
This is a companion to https://github.com/gitgitgadget/git/pull/744, squashing a warning in the workflow runs that cropped up beginning of this month.