### PR TITLE
Open tickets for new `gnutls` versions

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -7,7 +7,7 @@ name: Monitor component updates
 
 on:
   schedule:
-    - cron: "11,31,51 * * * *"
+    - cron: "* 8,11,14,17 * * *"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -38,6 +38,8 @@ jobs:
             feed: https://github.com/openssh/openssh-portable/tags.atom
           - label: openssl
             feed: https://github.com/openssl/openssl/tags.atom
+          - label: gnutls
+            feed: https://gnutls.org/news.atom
           - label: heimdal
             feed: https://github.com/heimdal/heimdal/tags.atom
           - label: git-sizer


### PR DESCRIPTION
We had to start building our own versions of the i686 `gnutls` package. Let's get notified when we have to re-build.