### PR TITLE
difftool: support user-defined Beyond Compare setups correctly again

### DIFF
--- a/git-mergetool--lib.sh
+++ b/git-mergetool--lib.sh
@@ -138,6 +138,10 @@ setup_user_tool () {
 	merge_cmd () {
 		( eval $merge_tool_cmd )
 	}
+
+	list_tool_variants () {
+		echo "$tool"
+	}
 }
 
 setup_tool () {

--- a/mergetools/bc
+++ b/mergetools/bc
@@ -25,4 +25,5 @@ translate_merge_tool_path() {
 list_tool_variants () {
 	echo bc
 	echo bc3
+	echo bc4
 }


### PR DESCRIPTION
This fixes the issue where a user-supplied `bc4` difftool configuration was mishandled and would result in no tool to be shown, even if the exit status would suggest that everything is fine and dandy.

This fixes https://github.com/git-for-windows/git/issues/2893 and is a companion PR to https://github.com/gitgitgadget/git/pull/787.