### PR TITLE
ci: avoid `set-env` construct in print-test-failures.sh

### DIFF
--- a/ci/print-test-failures.sh
+++ b/ci/print-test-failures.sh
@@ -48,7 +48,7 @@ do
 			;;
 		github-actions)
 			mkdir -p failed-test-artifacts
-			echo "::set-env name=FAILED_TEST_ARTIFACTS::t/failed-test-artifacts"
+			echo "FAILED_TEST_ARTIFACTS=t/failed-test-artifacts" >>$GITHUB_ENV
 			cp "${TEST_EXIT%.exit}.out" failed-test-artifacts/
 			tar czf failed-test-artifacts/"$test_name".trash.tar.gz "$trash_dir"
 			continue


### PR DESCRIPTION
This backports `jc/ci-github-set-env` (but not `js/ci-github-set-env`, because `whitespace.yml` has not been introduced into Git for Windows' `main` branch yet).