### PR TITLE
Address a problem reported by the new `check-whitespace` workflow

### DIFF
--- a/t/t7522-status-show-ignored-directory.sh
+++ b/t/t7522-status-show-ignored-directory.sh
@@ -148,4 +148,3 @@ test_expect_success 'Verify status on folder with tracked & ignored files' '
 '
 
 test_done
-


### PR DESCRIPTION
As of v2.30.0-rc0, Git has a new `check-whitespace` workflow, and [it picked up on an issue](https://github.com/git-for-windows/git/runs/1553266276?check_suite_focus=true) that has been in Git for Windows for several ages. Let's address it.