### PR TITLE
cmake(install): include vcpkg dlls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,6 +163,7 @@ jobs:
   vs-build:
     needs: ci-config
     if: needs.ci-config.outputs.enabled == 'yes'
+    timeout-minutes: 15
     env:
       MSYSTEM: MINGW64
       NO_PERL: 1
@@ -188,6 +189,11 @@ jobs:
         ## Unzip and remove the artifact
         unzip artifacts.zip
         rm artifacts.zip
+    - name: initialize vcpkg
+      uses: actions/checkout@v2
+      with:
+        repository: 'microsoft/vcpkg'
+        path: 'compat/vcbuild/vcpkg'
     - name: download vcpkg artifacts
       shell: powershell
       run: |

--- a/contrib/buildsystems/CMakeLists.txt
+++ b/contrib/buildsystems/CMakeLists.txt
@@ -58,6 +58,10 @@ if(WIN32)
 
 	# In the vcpkg edition, we need this to be able to link to libcurl
 	set(CURL_NO_CURL_CMAKE ON)
+
+	# Copy the necessary vcpkg DLLs (like iconv) to the install dir
+	set(X_VCPKG_APPLOCAL_DEPS_INSTALL ON)
+	set(CMAKE_TOOLCHAIN_FILE ${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake CACHE STRING "Vcpkg toolchain file")
 endif()
 
 find_program(SH_EXE sh PATHS "C:/Program Files/Git/bin")


### PR DESCRIPTION
Fixes https://github.com/git-for-windows/git/issues/2970 🎉 

With this PR, the DLLs are added correctly to the CMake build output:

![image](https://user-images.githubusercontent.com/17739158/104072888-ad915480-520c-11eb-89b4-8cc59a11434b.png)

![image](https://user-images.githubusercontent.com/17739158/104072939-c863c900-520c-11eb-9ca5-521c79b7102a.png)
