### PR TITLE
git-artifacts: add ARM64 artifacts

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -253,9 +253,58 @@ jobs:
         with:
           name: pkg-${{matrix.arch.name}}
           path: artifacts
+  build-arm64:
+    needs: bundle-artifacts
+    runs-on: windows-latest
+    steps:
+    - name: Configure user
+      shell: bash
+      run:
+        USER_NAME="${{github.actor}}" &&
+        USER_EMAIL="${{github.actor}}@users.noreply.github.com" &&
+        mkdir -p "$HOME" &&
+        git config --global user.name "$USER_NAME" &&
+        git config --global user.email "$USER_EMAIL"
+    - uses: actions/checkout@v2
+    - name: initialize vcpkg
+      uses: actions/checkout@v2
+      with:
+        repository: 'microsoft/vcpkg'
+        path: 'compat/vcbuild/vcpkg'
+    - name: download vcpkg artifacts
+      shell: powershell
+      run: |
+        $urlbase = "https://dev.azure.com/git/git/_apis/build/builds"
+        $id = ((Invoke-WebRequest -UseBasicParsing "${urlbase}?definitions=9&statusFilter=completed&resultFilter=succeeded&`$top=1").content | ConvertFrom-JSON).value[0].id
+        $downloadUrl = ((Invoke-WebRequest -UseBasicParsing "${urlbase}/$id/artifacts").content | ConvertFrom-JSON).value[0].resource.downloadUrl
+        (New-Object Net.WebClient).DownloadFile($downloadUrl, "compat.zip")
+        Expand-Archive compat.zip -DestinationPath . -Force
+        Remove-Item compat.zip
+    - name: add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1
+    - name: copy dlls to root
+      shell: powershell
+      run: |
+        & compat\vcbuild\vcpkg_copy_dlls.bat release arm64-windows
+        if (!$?) { exit(1) }
+    - name: generate Visual Studio solution
+      shell: bash
+      run: |
+        cmake `pwd`/contrib/buildsystems/ -DCMAKE_PREFIX_PATH=`pwd`/compat/vcbuild/vcpkg/installed/arm64-windows \
+        -DNO_GETTEXT=YesPlease -DPERL_TESTS=OFF -DPYTHON_TESTS=OFF -DCURL_NO_CURL_CMAKE=ON -DCMAKE_GENERATOR_PLATFORM=arm64 -DVCPKG_ARCH=arm64-windows \
+        -DCMAKE_INSTALL_PREFIX="`pwd`/git-arm64"
+    - name: MSBuild
+      run: msbuild git.sln -property:Configuration=Release
+    - name: Link the Git executables
+      run: msbuild INSTALL.vcxproj -property:Configuration=Release
+    - name: upload build artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: arm64-artifacts
+        path: ./git-arm64
   artifacts:
     runs-on: windows-latest
-    needs: pkg
+    needs: [pkg, build-arm64]
     strategy:
       matrix:
         artifact:
@@ -275,8 +324,13 @@ jobs:
         arch:
           - name: x86_64
             bitness: 64
+            arm64: false
           - name: i686
             bitness: 32
+            arm64: false
+          - name: i686
+            bitness: 32
+            arm64: true
       fail-fast: false
     env:
       MSYSTEM: MINGW${{matrix.arch.bitness}}
@@ -358,6 +412,12 @@ jobs:
 
           ## Unpack artifact
           unzip artifacts.zip
+      - name: Download arm64 artifact
+        if: matrix.arch.arm64 == true
+        uses: actions/download-artifact@v1
+        with:
+          name: arm64-artifacts
+          path: ${{github.workspace}}/arm64
       - name: Clone and update build-extra
         if: env.SKIP != 'true'
         shell: bash
@@ -388,7 +448,8 @@ jobs:
         run: |
           & .\git-sdk-${{matrix.arch.bitness}}-build-installers\usr\bin\bash.exe -lc @"
             set -x
-            /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=`$(cat pkg-${{matrix.arch.name}}/ver) -o artifacts --${{matrix.artifact.name}} --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-[0-9]*.tar.xz --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-doc-html-[0-9]*.tar.xz &&
+            [[ \"${{matrix.arch.arm64}}\" = true ]] && ARM64=\"--include-arm64-artifacts=\\\"`$PWD/arm64\\\"\" || ARM64=
+            /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git `$ARM64 --version=`$(cat pkg-${{matrix.arch.name}}/ver) -o artifacts --${{matrix.artifact.name}} --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-[0-9]*.tar.xz --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-doc-html-[0-9]*.tar.xz &&
             if test portable = '${{matrix.artifact.name}}' && test -n \"`$(git config alias.signtool)\"
             then
               git signtool artifacts/PortableGit-*.exe
@@ -413,11 +474,19 @@ jobs:
         if: always() && env.SKIP != 'true'
         shell: bash
         run: rm -rf home
+
       - name: Publish ${{matrix.artifact.name}}-${{matrix.arch.name}}
-        if: env.SKIP != 'true'
+        if: env.SKIP != 'true' && matrix.arch.arm64 != true
         uses: actions/upload-artifact@v1
         with:
           name: ${{matrix.artifact.name}}-${{matrix.arch.name}}
+          path: artifacts
+
+      - name: Publish ${{matrix.artifact.name}}-arm64
+        if: env.SKIP != 'true' && matrix.arch.arm64 == true
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{matrix.artifact.name}}-arm64
           path: artifacts
   nuget:
     runs-on: windows-latest


### PR DESCRIPTION
Adds the ARM64 artifacts to the `git-artifacts` GH Actions workflow 🚀 

Full run: https://github.com/dennisameling/git/actions/runs/537829979

One thing I noticed is that the ARM64 artifacts are significantly larger than the others. There might be some things we can enable on the MSVC-size to have it generate smaller binaries, but I'm not familiar enough with that toolchain to know how to do that.