### PR TITLE
ci: pre-emptively fix the "static-analysis" job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
     if: needs.ci-config.outputs.enabled == 'yes'
     env:
       jobname: StaticAnalysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
     - run: ci/install-dependencies.sh


### PR DESCRIPTION
GitHub Actions is transitioning workflow steps that run on 'ubuntu-latest' from 18.04 to 20.04, which unfortunately does not have a `coccinelle` package yet. Let's use 18.04 for this job, then.