### PR TITLE
Assorted fixes/enhancements for the `git-artifacts` workflow

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -224,8 +224,10 @@ jobs:
         run: |
           & git-sdk-64-build-installers\usr\bin\sh.exe -lc @"
             set -x
-            # Let `cv2pdb` find the DLLs
-            PATH=\"`$PATH:/C/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin${{matrix.arch.bin}}\"
+
+            # Restrict `PATH` to MSYS2 and to Visual Studio (to let `cv2pdb` find the relevant DLLs)
+            PATH=\"`/mingw64/bin:/usr/bin:/C/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin${{matrix.arch.bin}}:/C/Windows/system32\"
+
             type -p mspdb140.dll || exit 1
             sh -x /usr/src/build-extra/please.sh build-mingw-w64-git --only-${{matrix.arch.bitness}}-bit --build-src-pkg -o artifacts HEAD &&
             cp bundle-artifacts/ver artifacts/ &&

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -7,10 +7,13 @@ on:
     inputs:
       build_only:
         description: 'Optionally restrict what artifacts to build'
+        required: false
       ref:
         description: 'Optionally override which branch to build'
+        required: false
       repository:
         description: 'Optionally override from where to fetch the specified ref'
+        required: false
 
 env:
   GPG_OPTIONS: "--batch --yes --no-tty --list-options no-show-photos --verify-options no-show-photos --pinentry-mode loopback"

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -303,8 +303,20 @@ jobs:
           mkdir -p "$HOME" &&
           git config --global user.name "$USER_NAME" &&
           git config --global user.email "$USER_EMAIL"
-      - uses: actions/checkout@v2
+      - name: Download bundle-artifacts
         if: env.SKIP != 'true'
+        uses: actions/download-artifact@v1
+        with:
+          name: bundle-artifacts
+          path: bundle-artifacts
+      - name: Check out git/git
+        if: env.SKIP != 'true'
+        shell: bash
+        run: |
+          git -c init.defaultBranch=main init &&
+          git remote add -f origin https://github.com/git-for-windows/git &&
+          git fetch --tags bundle-artifacts/git.bundle $(cat bundle-artifacts/next_version) &&
+          git reset --hard $(cat bundle-artifacts/next_version)
       - name: initialize vcpkg
         if: env.SKIP != 'true'
         uses: actions/checkout@v2

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -342,9 +342,14 @@ jobs:
       - name: Determine whether this job should be skipped
         shell: bash
         run: |
+          suffix=${{matrix.arch.name}}
+          if test true = ${{matrix.arch.arm64}}
+          then
+            suffix=arm64
+          fi
           case " $BUILD_ONLY " in
           '  ') ;; # not set; build all
-          *" ${{matrix.artifact.name}} "*|*" ${{matrix.artifact.name}}-${{matrix.arch.name}} "*) ;; # build this artifact
+          *" ${{matrix.artifact.name}} "*|*" ${{matrix.artifact.name}}-$suffix "*) ;; # build this artifact
           *) echo "SKIP=true" >>$GITHUB_ENV;;
           esac
       - name: Download pkg-${{matrix.arch.name}}

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -140,7 +140,21 @@ jobs:
             bitness: 32
             bin: ''
     steps:
+      - name: Determine whether this job should be skipped
+        shell: bash
+        run: |
+          for e in ${BUILD_ONLY:-pkg}
+          do
+            case $e in
+            *-${{matrix.arch.name}}) exit 0;; # build this artifact
+            *-arm64) test i686 != ${{matrix.arch.name}} || exit 0;; # pkg-i686 is required for the ARM64 version
+            *-*) ;; # not this build artifact, keep looking
+            *) exit 0;; # build this artifact
+            esac
+          done
+          echo "SKIP=true" >>$GITHUB_ENV
       - name: Configure user
+        if: env.SKIP != 'true'
         shell: bash
         run:
           USER_NAME="${{github.actor}}" &&
@@ -150,13 +164,14 @@ jobs:
           git config --global user.email "$USER_EMAIL" &&
           echo "PACKAGER=$USER_NAME <$USER_EMAIL>" >>$GITHUB_ENV
       - name: Cache git-sdk-64-build-installers
+        if: env.SKIP != 'true'
         id: cache-sdk-build-installers
         uses: actions/cache@v2
         with:
           path: git-sdk-64-build-installers
           key: build-installers-64-${{ needs.bundle-artifacts.outputs.latest-sdk64-extra-build-id }}
       - name: Download git-sdk-64-build-installers
-        if: steps.cache-sdk-build-installers.outputs.cache-hit != 'true'
+        if: env.SKIP != 'true' && steps.cache-sdk-build-installers.outputs.cache-hit != 'true'
         shell: bash
         run: |
           # Use Git Bash to download and unpack the artifact
@@ -172,11 +187,13 @@ jobs:
           ## Unpack artifact
           unzip artifacts.zip
       - name: Download bundle-artifacts
+        if: env.SKIP != 'true'
         uses: actions/download-artifact@v1
         with:
           name: bundle-artifacts
           path: bundle-artifacts
       - name: Clone and update build-extra
+        if: env.SKIP != 'true'
         shell: bash
         run: |
           d=git-sdk-64-build-installers/usr/src/build-extra &&
@@ -189,6 +206,7 @@ jobs:
           fi &&
           git -C $d pull "$PWD"/bundle-artifacts/build-extra.bundle main
       - name: Check out git/git
+        if: env.SKIP != 'true'
         shell: bash
         run: |
           git -c init.defaultBranch=main init &&
@@ -199,7 +217,7 @@ jobs:
         env:
           CODESIGN_P12: ${{secrets.CODESIGN_P12}}
           CODESIGN_PASS: ${{secrets.CODESIGN_PASS}}
-        if: env.CODESIGN_P12 != '' && env.CODESIGN_PASS != ''
+        if: env.SKIP != 'true' && env.CODESIGN_P12 != '' && env.CODESIGN_PASS != ''
         shell: bash
         run: |
           cd home &&
@@ -208,7 +226,7 @@ jobs:
           echo -n "$CODESIGN_PASS" >.sig/codesign.pass
           git config --global alias.signtool '!sh "/usr/src/build-extra/signtool.sh"'
       - name: Prepare home directory for GPG signing
-        if: env.GPGKEY != ''
+        if: env.SKIP != 'true' && env.GPGKEY != ''
         shell: bash
         run: |
           echo '${{secrets.PRIVGPGKEY}}' | tr % '\n' | gpg $GPG_OPTIONS --import &&
@@ -218,6 +236,7 @@ jobs:
         env:
           GPGKEY: ${{secrets.GPGKEY}}
       - name: Build mingw-w64-${{matrix.arch.name}}-git
+        if: env.SKIP != 'true'
         env:
           GPGKEY: "${{secrets.GPGKEY}}"
         shell: powershell
@@ -247,10 +266,11 @@ jobs:
             git bundle create \"`$b\"/MINGW-packages.bundle origin/main..main)
           "@
       - name: Clean up temporary files
-        if: always()
+        if: always() && env.SKIP != 'true'
         shell: bash
         run: rm -rf home
       - name: Publish mingw-w64-${{matrix.arch.name}}-git
+        if: env.SKIP != 'true'
         uses: actions/upload-artifact@v1
         with:
           name: pkg-${{matrix.arch.name}}
@@ -259,7 +279,20 @@ jobs:
     needs: bundle-artifacts
     runs-on: windows-latest
     steps:
+      - name: Determine whether this job should be skipped
+        shell: bash
+        run: |
+          for e in ${BUILD_ONLY:-pkg}
+          do
+            case $e in
+            *-arm64) exit 0;; # build this artifact
+            *-*) ;; # not this build artifact, keep looking
+            *) exit 0;; # build this artifact
+            esac
+          done
+          echo "SKIP=true" >>$GITHUB_ENV
       - name: Configure user
+        if: env.SKIP != 'true'
         shell: bash
         run:
           USER_NAME="${{github.actor}}" &&
@@ -268,12 +301,15 @@ jobs:
           git config --global user.name "$USER_NAME" &&
           git config --global user.email "$USER_EMAIL"
       - uses: actions/checkout@v2
+        if: env.SKIP != 'true'
       - name: initialize vcpkg
+        if: env.SKIP != 'true'
         uses: actions/checkout@v2
         with:
           repository: 'microsoft/vcpkg'
           path: 'compat/vcbuild/vcpkg'
       - name: download vcpkg artifacts
+        if: env.SKIP != 'true'
         shell: powershell
         run: |
           $urlbase = "https://dev.azure.com/git/git/_apis/build/builds"
@@ -283,23 +319,29 @@ jobs:
           Expand-Archive compat.zip -DestinationPath . -Force
           Remove-Item compat.zip
       - name: add msbuild to PATH
+        if: env.SKIP != 'true'
         uses: microsoft/setup-msbuild@v1
       - name: copy dlls to root
+        if: env.SKIP != 'true'
         shell: powershell
         run: |
           & compat\vcbuild\vcpkg_copy_dlls.bat release arm64-windows
           if (!$?) { exit(1) }
       - name: generate Visual Studio solution
+        if: env.SKIP != 'true'
         shell: bash
         run: |
           cmake `pwd`/contrib/buildsystems/ -DCMAKE_PREFIX_PATH=`pwd`/compat/vcbuild/vcpkg/installed/arm64-windows \
           -DNO_GETTEXT=YesPlease -DPERL_TESTS=OFF -DPYTHON_TESTS=OFF -DCURL_NO_CURL_CMAKE=ON -DCMAKE_GENERATOR_PLATFORM=arm64 -DVCPKG_ARCH=arm64-windows \
           -DCMAKE_INSTALL_PREFIX="`pwd`/git-arm64" -DSKIP_DASHED_BUILT_INS=ON
       - name: MSBuild
+        if: env.SKIP != 'true'
         run: msbuild git.sln -property:Configuration=Release
       - name: Link the Git executables
+        if: env.SKIP != 'true'
         run: msbuild INSTALL.vcxproj -property:Configuration=Release
       - name: upload build artifacts
+        if: env.SKIP != 'true'
         uses: actions/upload-artifact@v1
         with:
           name: arm64-artifacts

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -39,42 +39,13 @@ jobs:
           git config --global user.name "$USER_NAME" &&
           git config --global user.email "$USER_EMAIL" &&
           echo "PACKAGER=$USER_NAME <$USER_EMAIL>" >>$GITHUB_ENV
-      - name: Determine latest git-sdk-64-extra-artifacts build ID
-        id: determine-latest-sdk64-extra-build-id
-        shell: bash
-        run: |
-          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
-          id=$(curl "$urlbase?definitions=29&statusFilter=completed&resultFilter=succeeded&\$top=1" |
-            jq -r '.value[0].id')
-
-          echo "Latest ID is ${id}"
-          echo "::set-output name=id::$id"
-      - name: Cache git-sdk-64-build-installers
-        id: cache-sdk-build-installers
-        uses: actions/cache@v2
+      - uses: git-for-windows/setup-git-for-windows-sdk@v0
         with:
-          path: git-sdk-64-build-installers
-          key: build-installers-64-${{ steps.determine-latest-sdk64-extra-build-id.outputs.id }}
-      - name: Download git-sdk-64-build-installers
-        if: steps.cache-sdk-build-installers.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          # Use Git Bash to download and unpack the artifact
-
-          ## Get artifact
-          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
-          id=${{ steps.determine-latest-sdk64-extra-build-id.outputs.id }}
-          download_url=$(curl "$urlbase/$id/artifacts" |
-            jq -r '.value[] | select(.name == "git-sdk-64-build-installers").resource.downloadUrl')
-
-          curl -o artifacts.zip "$download_url"
-
-          ## Unpack artifact
-          unzip artifacts.zip
+          flavor: build-installers
       - name: Clone build-extra
         shell: bash
         run: |
-          d=git-sdk-64-build-installers/usr/src/build-extra &&
+          d=/usr/src/build-extra &&
           if test ! -d $d/.git
           then
             git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d
@@ -88,7 +59,7 @@ jobs:
         run: |
           echo '${{secrets.PRIVGPGKEY}}' | tr % '\n' | gpg $GPG_OPTIONS --import &&
           mkdir -p home &&
-          git config --global gpg.program "$PWD/git-sdk-64-build-installers/usr/src/build-extra/gnupg-with-gpgkey.sh" &&
+          git config --global gpg.program "/usr/src/build-extra/gnupg-with-gpgkey.sh" &&
           info="$(gpg --list-keys --with-colons "${GPGKEY%% *}" | cut -d : -f 1,10 | sed -n '/^uid/{s|uid:||p;q}')" &&
           git config --global user.name "${info% <*}" &&
           git config --global user.email "<${info#*<}"
@@ -97,28 +68,26 @@ jobs:
       - name: Generate bundle artifacts
         env:
           GPGKEY: ${{secrets.GPGKEY}}
-        shell: powershell
+        shell: bash
         run: |
-          & .\git-sdk-64-build-installers\git-cmd.exe --command=usr\bin\bash.exe -lc @"
-            printf '#!/bin/sh\n\nexec /mingw64/bin/git.exe "`$@"\n' >/usr/bin/git &&
-            mkdir -p bundle-artifacts &&
+          printf '#!/bin/sh\n\nexec /mingw64/bin/git.exe "$@"\n' >/usr/bin/git &&
+          mkdir -p bundle-artifacts &&
 
-            { test -n \"`$REPOSITORY\" || REPOSITORY='${{github.repository}}'; } &&
-            { test -n \"`$REF\" || REF='${{github.ref}}'; } &&
-            git -c init.defaultBranch=main init --bare &&
-            git remote add -f origin https://github.com/git-for-windows/git &&
-            git fetch \"https://github.com/`$REPOSITORY\" \"`$REF:`$REF\" &&
+          { test -n "$REPOSITORY" || REPOSITORY='${{github.repository}}'; } &&
+          { test -n "$REF" || REF='${{github.ref}}'; } &&
+          git -c init.defaultBranch=main init --bare &&
+          git remote add -f origin https://github.com/git-for-windows/git &&
+          git fetch "https://github.com/$REPOSITORY" "$REF:$REF" &&
 
-            tag_name=\"`$(git describe --match 'v[0-9]*' FETCH_HEAD)-`$(date +%Y%m%d%H%M%S)\" &&
-            echo \"prerelease-`${tag_name#v}\" >bundle-artifacts/ver &&
-            echo \"`${tag_name#v}\" >bundle-artifacts/display_version &&
-            echo \"`$tag_name\" >bundle-artifacts/next_version &&
-            git tag `$(test -z \"`$GPGKEY\" || echo \" -s\") -m \"Snapshot build\" \"`$tag_name\" FETCH_HEAD &&
-            git bundle create bundle-artifacts/git.bundle origin/main..\"`$tag_name\" &&
+          tag_name="$(git describe --match 'v[0-9]*' FETCH_HEAD)-$(date +%Y%m%d%H%M%S)" &&
+          echo "prerelease-${tag_name#v}" >bundle-artifacts/ver &&
+          echo "${tag_name#v}" >bundle-artifacts/display_version &&
+          echo "$tag_name" >bundle-artifacts/next_version &&
+          git tag $(test -z "$GPGKEY" || echo " -s") -m "Snapshot build" "$tag_name" FETCH_HEAD &&
+          git bundle create bundle-artifacts/git.bundle origin/main.."$tag_name" &&
 
-            sh -x /usr/src/build-extra/please.sh mention feature \"Snapshot of `$(git show -s  --pretty='tformat:%h (%s, %ad)' --date=short FETCH_HEAD)\" &&
-            git -C /usr/src/build-extra bundle create \"`$PWD/bundle-artifacts/build-extra.bundle\" origin/main..main
-          "@
+          sh -x /usr/src/build-extra/please.sh mention feature "Snapshot of $(git show -s  --pretty='tformat:%h (%s, %ad)' --date=short FETCH_HEAD)" &&
+          git -C /usr/src/build-extra bundle create "$PWD/bundle-artifacts/build-extra.bundle" origin/main..main
       - name: Clean up temporary files
         if: always()
         shell: bash
@@ -166,29 +135,10 @@ jobs:
           git config --global user.name "$USER_NAME" &&
           git config --global user.email "$USER_EMAIL" &&
           echo "PACKAGER=$USER_NAME <$USER_EMAIL>" >>$GITHUB_ENV
-      - name: Cache git-sdk-64-build-installers
+      - uses: git-for-windows/setup-git-for-windows-sdk@v0
         if: env.SKIP != 'true'
-        id: cache-sdk-build-installers
-        uses: actions/cache@v2
         with:
-          path: git-sdk-64-build-installers
-          key: build-installers-64-${{ needs.bundle-artifacts.outputs.latest-sdk64-extra-build-id }}
-      - name: Download git-sdk-64-build-installers
-        if: env.SKIP != 'true' && steps.cache-sdk-build-installers.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          # Use Git Bash to download and unpack the artifact
-
-          ## Get artifact
-          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
-          id=${{ needs.pkg.outputs.latest-sdk64-extra-build-id }}
-          download_url=$(curl "$urlbase/$id/artifacts" |
-            jq -r '.value[] | select(.name == "git-sdk-64-build-installers").resource.downloadUrl')
-
-          curl -o artifacts.zip "$download_url"
-
-          ## Unpack artifact
-          unzip artifacts.zip
+          flavor: build-installers
       - name: Download bundle-artifacts
         if: env.SKIP != 'true'
         uses: actions/download-artifact@v1
@@ -199,7 +149,7 @@ jobs:
         if: env.SKIP != 'true'
         shell: bash
         run: |
-          d=git-sdk-64-build-installers/usr/src/build-extra &&
+          d=/usr/src/build-extra &&
           if test ! -d $d/.git
           then
             git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d
@@ -242,32 +192,33 @@ jobs:
         if: env.SKIP != 'true'
         env:
           GPGKEY: "${{secrets.GPGKEY}}"
-        shell: powershell
+        shell: bash
         run: |
-          & git-sdk-64-build-installers\usr\bin\sh.exe -lc @"
-            set -x
+          set -x
 
-            # Restrict `PATH` to MSYS2 and to Visual Studio (to let `cv2pdb` find the relevant DLLs)
-            PATH=\"`/mingw64/bin:/usr/bin:/C/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin${{matrix.arch.bin}}:/C/Windows/system32\"
+          # Make sure that there is a `/usr/bin/git` that can be used by `makepkg-mingw`
+          printf '#!/bin/sh\n\nexec /mingw64/bin/git.exe "$@"\n' >/usr/bin/git &&
 
-            type -p mspdb140.dll || exit 1
-            sh -x /usr/src/build-extra/please.sh build-mingw-w64-git --only-${{matrix.arch.bitness}}-bit --build-src-pkg -o artifacts HEAD &&
-            cp bundle-artifacts/ver artifacts/ &&
-            if test -n \"`$GPGKEY\"
-            then
-              for tar in artifacts/*.tar*
-              do
-                /usr/src/build-extra/gnupg-with-gpgkey.sh --detach-sign --no-armor `$tar
-              done
-            fi &&
+          # Restrict `PATH` to MSYS2 and to Visual Studio (to let `cv2pdb` find the relevant DLLs)
+          PATH="/mingw64/bin:/usr/bin:/C/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin${{matrix.arch.bin}}:/C/Windows/system32"
 
-            b=`$PWD/artifacts &&
-            version=`$(cat bundle-artifacts/next_version) &&
-            (cd /usr/src/MINGW-packages/mingw-w64-git &&
-            cp PKGBUILD.`$version PKGBUILD &&
-            git commit -s -m \"mingw-w64-git: new version (`$version)\" PKGBUILD &&
-            git bundle create \"`$b\"/MINGW-packages.bundle origin/main..main)
-          "@
+          type -p mspdb140.dll || exit 1
+          sh -x /usr/src/build-extra/please.sh build-mingw-w64-git --only-${{matrix.arch.bitness}}-bit --build-src-pkg -o artifacts HEAD &&
+          cp bundle-artifacts/ver artifacts/ &&
+          if test -n "$GPGKEY"
+          then
+            for tar in artifacts/*.tar*
+            do
+              /usr/src/build-extra/gnupg-with-gpgkey.sh --detach-sign --no-armor $tar
+            done
+          fi &&
+
+          b=$PWD/artifacts &&
+          version=$(cat bundle-artifacts/next_version) &&
+          (cd /usr/src/MINGW-packages/mingw-w64-git &&
+          cp PKGBUILD.$version PKGBUILD &&
+          git commit -s -m "mingw-w64-git: new version ($version)" PKGBUILD &&
+          git bundle create "$b"/MINGW-packages.bundle origin/main..main)
       - name: Clean up temporary files
         if: always() && env.SKIP != 'true'
         shell: bash
@@ -421,63 +372,15 @@ jobs:
         with:
           name: bundle-artifacts
           path: bundle-artifacts
-      - name: Cache git-sdk-64-build-installers
+      - uses: git-for-windows/setup-git-for-windows-sdk@v0
         if: env.SKIP != 'true' && matrix.arch.bitness == '64'
-        id: cache-sdk64-build-installers
-        uses: actions/cache@v2
         with:
-          path: git-sdk-64-build-installers
-          key: build-installers-64-${{ needs.pkg.outputs.latest-sdk64-extra-build-id }}
-      - name: Download git-sdk-64-build-installers
-        if: env.SKIP != 'true' && matrix.arch.bitness == '64' && steps.cache-sdk64-build-installers.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          # Use Git Bash to download and unpack the artifact
-
-          ## Get artifact
-          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
-          id=${{ needs.pkg.outputs.latest-sdk64-extra-build-id }}
-          download_url="$(curl "$urlbase/$id/artifacts" |
-            jq -r '.value[] | select(.name == "git-sdk-64-build-installers").resource.downloadUrl')"
-
-          curl -o artifacts.zip "$download_url"
-
-          ## Unpack artifact
-          unzip artifacts.zip
-      - name: Determine latest git-sdk-32-extra-artifacts build ID
+          flavor: build-installers
+      - uses: git-for-windows/setup-git-for-windows-sdk@v0
         if: env.SKIP != 'true' && matrix.arch.bitness == '32'
-        id: determine-latest-sdk32-extra-build-id
-        shell: bash
-        run: |
-          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
-          id=$(curl "$urlbase?definitions=30&statusFilter=completed&resultFilter=succeeded&\$top=1" |
-            jq -r '.value[0].id')
-
-          echo "Latest ID is ${id}"
-          echo "::set-output name=id::$id"
-      - name: Cache git-sdk-32-build-installers
-        if: env.SKIP != 'true' && matrix.arch.bitness == '32'
-        id: cache-sdk32-build-installers
-        uses: actions/cache@v2
         with:
-          path: git-sdk-32-build-installers
-          key: build-installers-32-${{ steps.determine-latest-sdk32-extra-build-id.outputs.id }}
-      - name: Download git-sdk-32-build-installers
-        if: env.SKIP != 'true' && matrix.arch.bitness == '32' && steps.cache-sdk32-build-installers.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          # Use Git Bash to download and unpack the artifact
-
-          ## Get artifact
-          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
-          id=${{ steps.determine-latest-sdk32-extra-build-id.outputs.id }}
-          download_url=$(curl "$urlbase/$id/artifacts" |
-            jq -r '.value[] | select(.name == "git-sdk-32-build-installers").resource.downloadUrl')
-
-          curl -o artifacts.zip "$download_url"
-
-          ## Unpack artifact
-          unzip artifacts.zip
+          flavor: build-installers
+          architecture: i686
       - name: Download arm64 artifact
         if: env.SKIP != 'true' && matrix.arch.arm64 == true
         uses: actions/download-artifact@v1
@@ -488,7 +391,7 @@ jobs:
         if: env.SKIP != 'true'
         shell: bash
         run: |
-          d=git-sdk-${{matrix.arch.bitness}}-build-installers/usr/src/build-extra &&
+          d=/usr/src/build-extra &&
           if test ! -d $d/.git
           then
             git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d
@@ -510,38 +413,34 @@ jobs:
           git config --global alias.signtool '!sh "/usr/src/build-extra/signtool.sh"'
       - name: Build ${{matrix.arch.bitness}}-bit ${{matrix.artifact.name}}
         if: env.SKIP != 'true'
-        shell: powershell
+        shell: bash
         run: |
-          & .\git-sdk-${{matrix.arch.bitness}}-build-installers\usr\bin\bash.exe -lc @"
-            set -x
-            if test "${{matrix.arch.arm64}}" = true
-            then
-              ARM64="--include-arm64-artifacts=\"$PWD/arm64\""
-            else
-              ARM64=
-            fi
+          set -x
+          if test "${{matrix.arch.arm64}}" = true
+          then
+            ARM64="--include-arm64-artifacts=\"$PWD/arm64\""
+          else
+            ARM64=
+          fi
 
-            eval /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git `$ARM64 --version=`$(cat pkg-${{matrix.arch.name}}/ver) -o artifacts --${{matrix.artifact.name}} --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-[0-9]*.tar.xz --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-doc-html-[0-9]*.tar.xz &&
-            if test portable = '${{matrix.artifact.name}}' && test -n \"`$(git config alias.signtool)\"
-            then
-              git signtool artifacts/PortableGit-*.exe
-            fi &&
-            openssl dgst -sha256 artifacts/${{matrix.artifact.fileprefix}}-*.${{matrix.artifact.fileextension}} | sed \"s/.* //\" >artifacts/sha-256.txt
-          "@
+          eval /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git $ARM64 --version=$(cat pkg-${{matrix.arch.name}}/ver) -o artifacts --${{matrix.artifact.name}} --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-[0-9]*.tar.xz --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-doc-html-[0-9]*.tar.xz &&
+          if test portable = '${{matrix.artifact.name}}' && test -n "$(git config alias.signtool)"
+          then
+            git signtool artifacts/PortableGit-*.exe
+          fi &&
+          openssl dgst -sha256 artifacts/${{matrix.artifact.fileprefix}}-*.${{matrix.artifact.fileextension}} | sed "s/.* //" >artifacts/sha-256.txt
       - name: Copy package-versions and pdbs
         if: env.SKIP != 'true' && matrix.artifact.name == 'installer'
-        shell: powershell
+        shell: bash
         run: |
-          & .\git-sdk-${{matrix.arch.bitness}}-build-installers\usr\bin\bash.exe -lc @"
-            cp /usr/src/build-extra/installer/package-versions.txt artifacts/ &&
+          cp /usr/src/build-extra/installer/package-versions.txt artifacts/ &&
 
-            a=`$PWD/artifacts &&
-            p=`$PWD/pkg-${{matrix.arch.name}} &&
-            (cd /usr/src/build-extra &&
-            mkdir -p cached-source-packages &&
-            cp \"`$p\"/*-pdb* cached-source-packages/ &&
-            GIT_CONFIG_PARAMETERS=\"'windows.sdk${{matrix.arch.bitness}}.path='\" ./please.sh bundle_pdbs --arch=${{matrix.arch.name}} --directory=\"`$a\" installer/package-versions.txt)
-          "@
+          a=$PWD/artifacts &&
+          p=$PWD/pkg-${{matrix.arch.name}} &&
+          (cd /usr/src/build-extra &&
+          mkdir -p cached-source-packages &&
+          cp "$p"/*-pdb* cached-source-packages/ &&
+          GIT_CONFIG_PARAMETERS="'windows.sdk${{matrix.arch.bitness}}.path='" ./please.sh bundle_pdbs --arch=${{matrix.arch.name}} --directory="$a" installer/package-versions.txt)
       - name: Clean up temporary files
         if: always() && env.SKIP != 'true'
         shell: bash
@@ -582,34 +481,15 @@ jobs:
         with:
           name: bundle-artifacts
           path: bundle-artifacts
-      - name: Cache git-sdk-64-build-installers
+      - uses: git-for-windows/setup-git-for-windows-sdk@v0
         if: env.SKIP != 'true'
-        id: cache-sdk-build-installers
-        uses: actions/cache@v2
         with:
-          path: git-sdk-64-build-installers
-          key: build-installers-64-${{ needs.pkg.outputs.latest-sdk64-extra-build-id }}
-      - name: Download git-sdk-64-build-installers
-        if: env.SKIP != 'true' && steps.cache-sdk-build-installers.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          # Use Git Bash to download and unpack the artifact
-
-          ## Get artifact
-          urlbase=https://dev.azure.com/git-for-windows/git/_apis/build/builds
-          id=${{ needs.pkg.outputs.latest-sdk64-extra-build-id }}
-          download_url=$(curl "$urlbase/$id/artifacts" |
-            jq -r '.value[] | select(.name == "git-sdk-64-build-installers").resource.downloadUrl')
-
-          curl -o artifacts.zip "$download_url"
-
-          ## Unpack artifact
-          unzip artifacts.zip
+          flavor: build-installers
       - name: Clone and update build-extra
         if: env.SKIP != 'true'
         shell: bash
         run: |
-          d=git-sdk-64-build-installers/usr/src/build-extra &&
+          d=/usr/src/build-extra &&
           if test ! -d $d/.git
           then
             git clone --single-branch -b main https://github.com/git-for-windows/build-extra $d
@@ -622,13 +502,11 @@ jobs:
         if: env.SKIP != 'true'
       - name: Build 64-bit NuGet packages
         if: env.SKIP != 'true'
-        shell: powershell
+        shell: bash
         run: |
-          & .\git-sdk-64-build-installers\usr\bin\bash.exe -lc @"
-            /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=`$(cat pkg-x86_64/ver) -o artifacts --nuget --pkg=pkg-x86_64/mingw-w64-x86_64-git-[0-9]*.tar.xz --pkg=pkg-x86_64/mingw-w64-x86_64-git-doc-html-[0-9]*.tar.xz &&
-            /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=`$(cat pkg-x86_64/ver) -o artifacts --nuget-mingit &&
-            openssl dgst -sha256 artifacts/Git*.nupkg | sed \"s/.* //\" >artifacts/sha-256.txt
-          "@
+          /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=$(cat pkg-x86_64/ver) -o artifacts --nuget --pkg=pkg-x86_64/mingw-w64-x86_64-git-[0-9]*.tar.xz --pkg=pkg-x86_64/mingw-w64-x86_64-git-doc-html-[0-9]*.tar.xz &&
+          /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=$(cat pkg-x86_64/ver) -o artifacts --nuget-mingit &&
+          openssl dgst -sha256 artifacts/Git*.nupkg | sed "s/.* //" >artifacts/sha-256.txt
       - name: Publish nuget-x86_64
         if: env.SKIP != 'true'
         uses: actions/upload-artifact@v1

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -450,7 +450,13 @@ jobs:
         run: |
           & .\git-sdk-${{matrix.arch.bitness}}-build-installers\usr\bin\bash.exe -lc @"
             set -x
-            [[ \"${{matrix.arch.arm64}}\" = true ]] && ARM64=\"--include-arm64-artifacts=\\\"`$PWD/arm64\\\"\" || ARM64=
+            if test "${{matrix.arch.arm64}}" = true
+            then
+              ARM64="--include-arm64-artifacts=\"$PWD/arm64\""
+            else
+              ARM64=
+            fi
+
             /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git `$ARM64 --version=`$(cat pkg-${{matrix.arch.name}}/ver) -o artifacts --${{matrix.artifact.name}} --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-[0-9]*.tar.xz --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-doc-html-[0-9]*.tar.xz &&
             if test portable = '${{matrix.artifact.name}}' && test -n \"`$(git config alias.signtool)\"
             then

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -415,7 +415,7 @@ jobs:
           ## Unpack artifact
           unzip artifacts.zip
       - name: Download arm64 artifact
-        if: matrix.arch.arm64 == true
+        if: env.SKIP != 'true' && matrix.arch.arm64 == true
         uses: actions/download-artifact@v1
         with:
           name: arm64-artifacts

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -257,51 +257,51 @@ jobs:
     needs: bundle-artifacts
     runs-on: windows-latest
     steps:
-    - name: Configure user
-      shell: bash
-      run:
-        USER_NAME="${{github.actor}}" &&
-        USER_EMAIL="${{github.actor}}@users.noreply.github.com" &&
-        mkdir -p "$HOME" &&
-        git config --global user.name "$USER_NAME" &&
-        git config --global user.email "$USER_EMAIL"
-    - uses: actions/checkout@v2
-    - name: initialize vcpkg
-      uses: actions/checkout@v2
-      with:
-        repository: 'microsoft/vcpkg'
-        path: 'compat/vcbuild/vcpkg'
-    - name: download vcpkg artifacts
-      shell: powershell
-      run: |
-        $urlbase = "https://dev.azure.com/git/git/_apis/build/builds"
-        $id = ((Invoke-WebRequest -UseBasicParsing "${urlbase}?definitions=9&statusFilter=completed&resultFilter=succeeded&`$top=1").content | ConvertFrom-JSON).value[0].id
-        $downloadUrl = ((Invoke-WebRequest -UseBasicParsing "${urlbase}/$id/artifacts").content | ConvertFrom-JSON).value[0].resource.downloadUrl
-        (New-Object Net.WebClient).DownloadFile($downloadUrl, "compat.zip")
-        Expand-Archive compat.zip -DestinationPath . -Force
-        Remove-Item compat.zip
-    - name: add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1
-    - name: copy dlls to root
-      shell: powershell
-      run: |
-        & compat\vcbuild\vcpkg_copy_dlls.bat release arm64-windows
-        if (!$?) { exit(1) }
-    - name: generate Visual Studio solution
-      shell: bash
-      run: |
-        cmake `pwd`/contrib/buildsystems/ -DCMAKE_PREFIX_PATH=`pwd`/compat/vcbuild/vcpkg/installed/arm64-windows \
-        -DNO_GETTEXT=YesPlease -DPERL_TESTS=OFF -DPYTHON_TESTS=OFF -DCURL_NO_CURL_CMAKE=ON -DCMAKE_GENERATOR_PLATFORM=arm64 -DVCPKG_ARCH=arm64-windows \
-        -DCMAKE_INSTALL_PREFIX="`pwd`/git-arm64" -DSKIP_DASHED_BUILT_INS=ON
-    - name: MSBuild
-      run: msbuild git.sln -property:Configuration=Release
-    - name: Link the Git executables
-      run: msbuild INSTALL.vcxproj -property:Configuration=Release
-    - name: upload build artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: arm64-artifacts
-        path: ./git-arm64
+      - name: Configure user
+        shell: bash
+        run:
+          USER_NAME="${{github.actor}}" &&
+          USER_EMAIL="${{github.actor}}@users.noreply.github.com" &&
+          mkdir -p "$HOME" &&
+          git config --global user.name "$USER_NAME" &&
+          git config --global user.email "$USER_EMAIL"
+      - uses: actions/checkout@v2
+      - name: initialize vcpkg
+        uses: actions/checkout@v2
+        with:
+          repository: 'microsoft/vcpkg'
+          path: 'compat/vcbuild/vcpkg'
+      - name: download vcpkg artifacts
+        shell: powershell
+        run: |
+          $urlbase = "https://dev.azure.com/git/git/_apis/build/builds"
+          $id = ((Invoke-WebRequest -UseBasicParsing "${urlbase}?definitions=9&statusFilter=completed&resultFilter=succeeded&`$top=1").content | ConvertFrom-JSON).value[0].id
+          $downloadUrl = ((Invoke-WebRequest -UseBasicParsing "${urlbase}/$id/artifacts").content | ConvertFrom-JSON).value[0].resource.downloadUrl
+          (New-Object Net.WebClient).DownloadFile($downloadUrl, "compat.zip")
+          Expand-Archive compat.zip -DestinationPath . -Force
+          Remove-Item compat.zip
+      - name: add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1
+      - name: copy dlls to root
+        shell: powershell
+        run: |
+          & compat\vcbuild\vcpkg_copy_dlls.bat release arm64-windows
+          if (!$?) { exit(1) }
+      - name: generate Visual Studio solution
+        shell: bash
+        run: |
+          cmake `pwd`/contrib/buildsystems/ -DCMAKE_PREFIX_PATH=`pwd`/compat/vcbuild/vcpkg/installed/arm64-windows \
+          -DNO_GETTEXT=YesPlease -DPERL_TESTS=OFF -DPYTHON_TESTS=OFF -DCURL_NO_CURL_CMAKE=ON -DCMAKE_GENERATOR_PLATFORM=arm64 -DVCPKG_ARCH=arm64-windows \
+          -DCMAKE_INSTALL_PREFIX="`pwd`/git-arm64" -DSKIP_DASHED_BUILT_INS=ON
+      - name: MSBuild
+        run: msbuild git.sln -property:Configuration=Release
+      - name: Link the Git executables
+        run: msbuild INSTALL.vcxproj -property:Configuration=Release
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: arm64-artifacts
+          path: ./git-arm64
   artifacts:
     runs-on: windows-latest
     needs: [pkg, build-arm64]

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -457,7 +457,7 @@ jobs:
               ARM64=
             fi
 
-            /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git `$ARM64 --version=`$(cat pkg-${{matrix.arch.name}}/ver) -o artifacts --${{matrix.artifact.name}} --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-[0-9]*.tar.xz --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-doc-html-[0-9]*.tar.xz &&
+            eval /usr/src/build-extra/please.sh make_installers_from_mingw_w64_git `$ARM64 --version=`$(cat pkg-${{matrix.arch.name}}/ver) -o artifacts --${{matrix.artifact.name}} --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-[0-9]*.tar.xz --pkg=pkg-${{matrix.arch.name}}/mingw-w64-${{matrix.arch.name}}-git-doc-html-[0-9]*.tar.xz &&
             if test portable = '${{matrix.artifact.name}}' && test -n \"`$(git config alias.signtool)\"
             then
               git signtool artifacts/PortableGit-*.exe

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -309,6 +309,8 @@ jobs:
       matrix:
         artifact:
           - name: installer
+            fileprefix: Git
+            fileextension: exe
           - name: portable
             fileprefix: PortableGit
             fileextension: exe

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -482,14 +482,12 @@ jobs:
         if: always() && env.SKIP != 'true'
         shell: bash
         run: rm -rf home
-
       - name: Publish ${{matrix.artifact.name}}-${{matrix.arch.name}}
         if: env.SKIP != 'true' && matrix.arch.arm64 != true
         uses: actions/upload-artifact@v1
         with:
           name: ${{matrix.artifact.name}}-${{matrix.arch.name}}
           path: artifacts
-
       - name: Publish ${{matrix.artifact.name}}-arm64
         if: env.SKIP != 'true' && matrix.arch.arm64 == true
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
The `git-artifacts` workflow can be used to generate Git for Windows installers, MinGits, etc.

The improvements in this PR mostly revolve around two topics: actually make the ARM64 stuff work (it didn't work when I tried it), and accelerate the entire thing, mostly by using the shiny new [`setup-git-for-windows-sdk` GitHub Action](https://github.com/git-for-windows/setup-git-for-windows-sdk).