### PR TITLE
cmake: work around recent `vcpkg` update

### DIFF
--- a/contrib/buildsystems/CMakeLists.txt
+++ b/contrib/buildsystems/CMakeLists.txt
@@ -814,14 +814,18 @@ list(TRANSFORM git_shell_scripts PREPEND "${CMAKE_BINARY_DIR}/")
 list(TRANSFORM git_perl_scripts PREPEND "${CMAKE_BINARY_DIR}/")
 
 #install
-install(TARGETS git git-shell
+foreach(program ${PROGRAMS_BUILT})
+if(${program} STREQUAL git OR ${program} STREQUAL git-shell)
+install(TARGETS ${program}
 	RUNTIME DESTINATION bin)
+else()
+install(TARGETS ${program}
+	RUNTIME DESTINATION libexec/git-core)
+endif()
+endforeach()
+
 install(PROGRAMS ${CMAKE_BINARY_DIR}/git-cvsserver
 	DESTINATION bin)
-
-list(REMOVE_ITEM PROGRAMS_BUILT git git-shell)
-install(TARGETS ${PROGRAMS_BUILT}
-	RUNTIME DESTINATION libexec/git-core)
 
 set(bin_links
 	git-receive-pack git-upload-archive git-upload-pack)


### PR DESCRIPTION
For a couple of days now, all of Git for Windows' CI builds all fail in the `vs-build` jobs, while trying to configure the Visual Studio projects. The culprit is a recent change in `vcpkg`, and this PR fixes it.

cc @dennisameling (FYI)