### PR TITLE
Teach our CMake configuration to optionally skip hard-linking the dashed built-ins

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -292,7 +292,7 @@ jobs:
       run: |
         cmake `pwd`/contrib/buildsystems/ -DCMAKE_PREFIX_PATH=`pwd`/compat/vcbuild/vcpkg/installed/arm64-windows \
         -DNO_GETTEXT=YesPlease -DPERL_TESTS=OFF -DPYTHON_TESTS=OFF -DCURL_NO_CURL_CMAKE=ON -DCMAKE_GENERATOR_PLATFORM=arm64 -DVCPKG_ARCH=arm64-windows \
-        -DCMAKE_INSTALL_PREFIX="`pwd`/git-arm64"
+        -DCMAKE_INSTALL_PREFIX="`pwd`/git-arm64" -DSKIP_DASHED_BUILT_INS=ON
     - name: MSBuild
       run: msbuild git.sln -property:Configuration=Release
     - name: Link the Git executables

--- a/contrib/buildsystems/CMakeLists.txt
+++ b/contrib/buildsystems/CMakeLists.txt
@@ -685,13 +685,17 @@ endif()
 
 parse_makefile_for_executables(git_builtin_extra "BUILT_INS")
 
+option(SKIP_DASHED_BUILT_INS "Skip hardlinking the dashed versions of the built-ins")
+
 #Creating hardlinks
+if(NOT SKIP_DASHED_BUILT_INS)
 foreach(s ${git_SOURCES} ${git_builtin_extra})
 	string(REPLACE "${CMAKE_SOURCE_DIR}/builtin/" "" s ${s})
 	string(REPLACE ".c" "" s ${s})
 	file(APPEND ${CMAKE_BINARY_DIR}/CreateLinks.cmake "file(CREATE_LINK git${EXE_EXTENSION} git-${s}${EXE_EXTENSION})\n")
 	list(APPEND git_links ${CMAKE_BINARY_DIR}/git-${s}${EXE_EXTENSION})
 endforeach()
+endif()
 
 if(CURL_FOUND)
 	set(remote_exes


### PR DESCRIPTION
The fact that `git-add.exe` (and over a hundred more commands) are still hard-linked in `libexec/git-core/` is more a historical than a useful thing. In particular when bundling MinGit, that's just useless weight, and we exclude it.

Except in the ARM64 variant, as it is built via `git-artifacts`, it does not work: our CMake-based build did not know how to exclude the dashed built-ins, and `mingit/release.sh` simply copies the entire ARM64 artifacts it was given, dashed built-ins or not.

Let's teach our CMake configuration to be helpful in this instance, by optionally skip those usually unwanted files.