### PR TITLE
git-artifacts: add workaround for GCM Core on ARM64

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -418,6 +418,13 @@ jobs:
         with:
           name: arm64-artifacts
           path: ${{github.workspace}}/arm64
+      # Workaround for Git Credential Manager Core on ARM64: https://github.com/git-for-windows/git/issues/3015
+      - name: Create git-credential-manager-core wrapper for ARM64
+        if: matrix.arch.arm64 == true
+        shell: bash
+        run: |
+          printf '%s\n' '#!/bin/sh' 'exec /mingw32/libexec/git-core/git-credential-manager-core.exe "$@"' > arm64/bin/git-credential-manager-core
+          chmod +x arm64/bin/git-credential-manager-core
       - name: Clone and update build-extra
         if: env.SKIP != 'true'
         shell: bash


### PR DESCRIPTION
Closes https://github.com/git-for-windows/git/issues/3015

Adds a workaround for Git Credential Manager Core to the `git-artifacts.yml` CI workflow, as discussed in https://github.com/git-for-windows/git/issues/3015#issuecomment-771585483

Test run in progress: https://github.com/dennisameling/git/actions/runs/617373202