### PR TITLE
cmake: set correct path to gitconfig on Windows

### DIFF
--- a/contrib/buildsystems/CMakeLists.txt
+++ b/contrib/buildsystems/CMakeLists.txt
@@ -200,8 +200,6 @@ list(APPEND compat_SOURCES sha1dc_git.c sha1dc/sha1.c sha1dc/ubc_check.c block-s
 
 
 add_compile_definitions(PAGER_ENV="LESS=FRX LV=-c"
-			ETC_GITATTRIBUTES="etc/gitattributes"
-			ETC_GITCONFIG="etc/gitconfig"
 			GIT_EXEC_PATH="libexec/git-core"
 			GIT_LOCALE_PATH="share/locale"
 			GIT_MAN_PATH="share/man"
@@ -216,10 +214,15 @@ add_compile_definitions(PAGER_ENV="LESS=FRX LV=-c"
 
 if(WIN32)
 	set(FALLBACK_RUNTIME_PREFIX /mingw64)
-	add_compile_definitions(FALLBACK_RUNTIME_PREFIX="${FALLBACK_RUNTIME_PREFIX}")
+	# Move system config into top-level /etc/
+	add_compile_definitions(FALLBACK_RUNTIME_PREFIX="${FALLBACK_RUNTIME_PREFIX}"
+		ETC_GITATTRIBUTES="../etc/gitattributes"
+		ETC_GITCONFIG="../etc/gitconfig")
 else()
 	set(FALLBACK_RUNTIME_PREFIX /home/$ENV{USER})
-	add_compile_definitions(FALLBACK_RUNTIME_PREFIX="${FALLBACK_RUNTIME_PREFIX}")
+	add_compile_definitions(FALLBACK_RUNTIME_PREFIX="${FALLBACK_RUNTIME_PREFIX}"
+		ETC_GITATTRIBUTES="etc/gitattributes"
+		ETC_GITCONFIG="etc/gitconfig")
 endif()
 
 


### PR DESCRIPTION
Closes https://github.com/git-for-windows/git/issues/3071

Currently, when Git for Windows is built with CMake, the `gitconfig` system-level file can't be read by Git. Because of this, things like `git clone` don't work correctly. More details in https://github.com/git-for-windows/git/issues/3071#issuecomment-789261386. This PR fixes that behavior by mimicking [what was already done in `config.mak.uname`](https://github.com/git-for-windows/git/blob/c1778565869b74b2c0ac225802a53f7b8a4133ec/config.mak.uname#L436-L440), but then slightly changed to work correctly with CMake.

Note: this applies to **all** CMake builds [where Windows is targeted](https://cmake.org/cmake/help/v3.0/variable/WIN32.html) (WIN32).

Before applying this PR:

```
denni@DESKTOP-8HTP3NV ARM64 /
$ git config --list --system
fatal: unable to read config file 'C:/Program Files (x86)/Git/arm64/etc/gitconfig': No such file or directory
```

After applying this PR:

```
denni@DESKTOP-8HTP3NV ARM64 /
$ git config --list --system
pack.packsizelimit=2g
diff.astextplain.textconv=astextplain
filter.lfs.clean=git-lfs clean -- %f
filter.lfs.smudge=git-lfs smudge -- %f
filter.lfs.process=git-lfs filter-process
filter.lfs.required=true
http.sslbackend=openssl
http.sslcainfo=C:/Program Files (x86)/Git/mingw32/ssl/certs/ca-bundle.crt
core.autocrlf=true
core.fscache=true
core.symlinks=true
pull.rebase=false
credential.helper=manager-core
credential.https://dev.azure.com.usehttppath=true
init.defaultbranch=main
```