### PR TITLE
git-artifacts: Update ARM64 GCM Core workaround

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -425,8 +425,8 @@ jobs:
         if: matrix.arch.arm64 == true
         shell: bash
         run: |
-          printf '%s\n' '#!/bin/sh' 'exec /mingw32/libexec/git-core/git-credential-manager-core.exe "$@"' > arm64/bin/git-credential-manager-core
-          chmod +x arm64/bin/git-credential-manager-core
+          printf '%s\n' '#!/bin/sh' 'exec /mingw32/libexec/git-core/git-credential-manager-core.exe "$@"' > arm64/libexec/git-core/git-credential-manager-core
+          chmod +x arm64/libexec/git-core/git-credential-manager-core
       - name: Clone and update build-extra
         if: env.SKIP != 'true'
         shell: bash


### PR DESCRIPTION
We have moved and improved this logic to `build-extra` in https://github.com/git-for-windows/build-extra/pull/331. More details in that PR.