### PR TITLE
git-artifacts: Remove ARM64 GCM Core workaround

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -387,13 +387,6 @@ jobs:
         with:
           name: arm64-artifacts
           path: ${{github.workspace}}/arm64
-      # Workaround for Git Credential Manager Core on ARM64: https://github.com/git-for-windows/git/issues/3015
-      - name: Create git-credential-manager-core wrapper for ARM64
-        if: matrix.arch.arm64 == true
-        shell: bash
-        run: |
-          printf '%s\n' '#!/bin/sh' 'exec /mingw32/libexec/git-core/git-credential-manager-core.exe "$@"' > arm64/bin/git-credential-manager-core
-          chmod +x arm64/bin/git-credential-manager-core
       - name: Clone and update build-extra
         if: env.SKIP != 'true'
         shell: bash


### PR DESCRIPTION
We have moved and improved this logic to `build-extra` in https://github.com/git-for-windows/build-extra/pull/331

Signed-off-by: Dennis Ameling <dennis@dennisameling.com>

Thanks for taking the time to contribute to Git!

Those seeking to contribute to the Git for Windows fork should see
http://gitforwindows.org/#contribute on how to contribute Windows specific
enhancements.

If your contribution is for the core Git functions and documentation
please be aware that the Git community does not use the github.com issues
or pull request mechanism for their contributions.

Instead, we use the Git mailing list (git@vger.kernel.org) for code and
documenatation submissions, code reviews, and bug reports. The
mailing list is plain text only (anything with HTML is sent directly
to the spam folder).

Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
