### PR TITLE
ci: cache vcpkg artifacts

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -276,14 +276,10 @@ jobs:
           path: 'compat/vcbuild/vcpkg'
       - name: download vcpkg artifacts
         if: env.SKIP != 'true'
-        shell: powershell
-        run: |
-          $urlbase = "https://dev.azure.com/git/git/_apis/build/builds"
-          $id = ((Invoke-WebRequest -UseBasicParsing "${urlbase}?definitions=9&statusFilter=completed&resultFilter=succeeded&`$top=1").content | ConvertFrom-JSON).value[0].id
-          $downloadUrl = ((Invoke-WebRequest -UseBasicParsing "${urlbase}/$id/artifacts").content | ConvertFrom-JSON).value[0].resource.downloadUrl
-          (New-Object Net.WebClient).DownloadFile($downloadUrl, "compat.zip")
-          Expand-Archive compat.zip -DestinationPath . -Force
-          Remove-Item compat.zip
+        uses: git-for-windows/get-azure-pipelines-artifact@v0
+        with:
+          repository: git/git
+          definitionId: 9
       - name: add msbuild to PATH
         if: env.SKIP != 'true'
         uses: microsoft/setup-msbuild@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,14 +146,10 @@ jobs:
         repository: 'microsoft/vcpkg'
         path: 'compat/vcbuild/vcpkg'
     - name: download vcpkg artifacts
-      shell: powershell
-      run: |
-        $urlbase = "https://dev.azure.com/git/git/_apis/build/builds"
-        $id = ((Invoke-WebRequest -UseBasicParsing "${urlbase}?definitions=9&statusFilter=completed&resultFilter=succeeded&`$top=1").content | ConvertFrom-JSON).value[0].id
-        $downloadUrl = ((Invoke-WebRequest -UseBasicParsing "${urlbase}/$id/artifacts").content | ConvertFrom-JSON).value[0].resource.downloadUrl
-        (New-Object Net.WebClient).DownloadFile($downloadUrl, "compat.zip")
-        Expand-Archive compat.zip -DestinationPath . -Force
-        Remove-Item compat.zip
+      uses: git-for-windows/get-azure-pipelines-artifact@v0
+      with:
+        repository: git/git
+        definitionId: 9
     - name: add msbuild to PATH
       uses: microsoft/setup-msbuild@v1
     - name: copy dlls to root

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: git-for-windows/setup-git-for-windows-sdk@v0
+    - uses: git-for-windows/setup-git-for-windows-sdk@v1
     - name: build
       shell: bash
       env:
@@ -112,7 +112,7 @@ jobs:
     - name: extract tracked files and build artifacts
       shell: bash
       run: tar xf artifacts.tar.gz && tar xf tracked.tar.gz
-    - uses: git-for-windows/setup-git-for-windows-sdk@v0
+    - uses: git-for-windows/setup-git-for-windows-sdk@v1
     - name: test
       shell: bash
       run: ci/run-test-slice.sh ${{matrix.nr}} 10
@@ -139,7 +139,7 @@ jobs:
         arch: [x64, arm64]
     steps:
     - uses: actions/checkout@v2
-    - uses: git-for-windows/setup-git-for-windows-sdk@v0
+    - uses: git-for-windows/setup-git-for-windows-sdk@v1
     - name: initialize vcpkg
       uses: actions/checkout@v2
       with:
@@ -189,7 +189,7 @@ jobs:
       matrix:
         nr: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
-    - uses: git-for-windows/setup-git-for-windows-sdk@v0
+    - uses: git-for-windows/setup-git-for-windows-sdk@v1
     - name: download tracked files and build artifacts
       uses: actions/download-artifact@v2
       with:


### PR DESCRIPTION
We now have the shiny new `get-azure-pipelines-artifact` GitHub Action to help us.

This is a companion PR to https://github.com/gitgitgadget/git/pull/879.