### PR TITLE
git-artifacts: don't add ARM64-specific workaround for GCM Core in skipped jobs

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -385,7 +385,7 @@ jobs:
           path: ${{github.workspace}}/arm64
       # Workaround for Git Credential Manager Core on ARM64: https://github.com/git-for-windows/git/issues/3015
       - name: Create git-credential-manager-core wrapper for ARM64
-        if: matrix.arch.arm64 == true
+        if: env.SKIP != 'true' && matrix.arch.arm64 == true
         shell: bash
         run: |
           printf '%s\n' '#!/bin/sh' 'exec /mingw32/libexec/git-core/git-credential-manager-core.exe "$@"' > arm64/libexec/git-core/git-credential-manager-core


### PR DESCRIPTION
In skipped jobs, the `arm64/` directory does not exist, which would make this task fail: https://github.com/dscho/git/runs/2214202079?check_suite_focus=true

Cc: @dennisameling