### PR TITLE
Fix MSVC builds to handle headless-git.exe

### DIFF
--- a/compat/vcbuild/scripts/clink.pl
+++ b/compat/vcbuild/scripts/clink.pl
@@ -67,7 +67,11 @@ while (@ARGV) {
 		}
 		push(@args, $lib);
 	} elsif ("$arg" eq "-lexpat") {
+	    if ($is_debug) {
+		push(@args, "libexpatd.lib");
+	    } else {
 		push(@args, "libexpat.lib");
+	    }
 	} elsif ("$arg" =~ /^-L/ && "$arg" ne "-LTCG") {
 		$arg =~ s/^-L/-LIBPATH:/;
 		push(@lflags, $arg);

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -456,7 +456,14 @@ endif
 		compat/win32/trace2_win32_process_info.o \
 		compat/win32/dirent.o compat/win32/fscache.o
 	COMPAT_CFLAGS = -D__USE_MINGW_ACCESS -DDETECT_MSYS_TTY -DENSURE_MSYSTEM_IS_SET -DNOGDI -DHAVE_STRING_H -Icompat -Icompat/regex -Icompat/win32 -DSTRIP_EXTENSION=\".exe\"
-	BASIC_LDFLAGS = -IGNORE:4217 -IGNORE:4049 -NOLOGO -ENTRY:wmainCRTStartup -SUBSYSTEM:CONSOLE
+
+	BASIC_LDFLAGS += -IGNORE:4217 -IGNORE:4049 -NOLOGO
+	CONSOLE_LDFLAGS = -ENTRY:wmainCRTStartup -SUBSYSTEM:CONSOLE
+	GUI_LDFLAGS = -ENTRY:wWinMainCRTStartup -SUBSYSTEM:WINDOWS
+
+	GITLIBS += git.res
+	RC = "C:/Program Files (x86)/Windows Kits/10/bin/x86/rc.exe"
+
 	# invalidcontinue.obj allows Git's source code to close the same file
 	# handle twice, or to access the osfhandle of an already-closed stdout
 	# See https://msdn.microsoft.com/en-us/library/ms235330.aspx
@@ -639,6 +646,8 @@ ifneq (,$(findstring MINGW,$(uname_S)))
 	NATIVE_CRLF = YesPlease
 	X = .exe
 	EXTRA_PROGRAMS += headless-git$X
+	GUI_CFLAGS = -fno-stack-protector
+	GUI_LDFLAGS = -mwindows
 ifneq (,$(wildcard ../THIS_IS_MSYSGIT))
 	htmldir = doc/git/html/
 	prefix =


### PR DESCRIPTION
Fixup the Makefile to handle `make MSVC=1 [DEBUG=1]` builds after `headless-git.exe` was added.

I also tweaked the Makefile dependencies and cleanup rules for `headless.c` and the .o and .pdb files.

