### PR TITLE
mingw: allow for longer paths in `parse_interpreter()`

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1481,7 +1481,7 @@ static const char *quote_arg_msys2(const char *arg)
 
 static const char *parse_interpreter(const char *cmd)
 {
-	static char buf[100];
+	static char buf[248];
 	char *p, *opt;
 	int n, fd;
 


### PR DESCRIPTION
As reported in https://github.com/newren/git-filter-repo/pull/225, it looks like 99 bytes is not really sufficient to represent e.g. the full path to Python when installed via Windows Store (and this path is used in the hasb bang line when installing scripts via `pip`).

Let's increase it to what is probably the maximum sensible path size: 248 (the same as for `CreateDirectory()`).