### PR TITLE
mingw: increase interpreter path length even further

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1481,7 +1481,7 @@ static const char *quote_arg_msys2(const char *arg)
 
 static const char *parse_interpreter(const char *cmd)
 {
-	static char buf[248];
+	static char buf[MAX_PATH];
 	char *p, *opt;
 	int n, fd;
 


### PR DESCRIPTION
Based on a work in https://github.com/git-for-windows/git/pull/3165 this makes parse_interpreter() inline with what lookup_prog() handles.

Even better way would be to use MAX_LONG_PATH and wchar_t instead of char to allow Unicode paths, but I don't have a proper testing environment at the moment, so this will do.