### PR TITLE
monitor-components: switch to a faster Action

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch:
 
 env:
-  CHARACTER_LIMIT: "5000"
-  LAST_TIME: "48h"
+  CHARACTER_LIMIT: 5000
+  MAX_AGE: 48h
 
 jobs:
   job:
@@ -30,7 +30,7 @@ jobs:
             feed: https://github.com/jonas/tig/tags.atom
           - label: cygwin
             feed: https://github.com/cygwin/cygwin/releases.atom
-            titleFilter: newlib
+            title-pattern: ^(?!.*newlib)
           - label: msys2-runtime-package
             feed: https://github.com/msys2/MSYS2-packages/commits/master/msys2-runtime.atom
           - label: msys2-runtime
@@ -40,7 +40,7 @@ jobs:
             feed: https://github.com/openssh/openssh-portable/tags.atom
           - label: openssl
             feed: https://github.com/openssl/openssl/tags.atom
-            titleFilter: alpha
+            title-pattern: ^(?!.*alpha)
           - label: gnutls
             feed: https://gnutls.org/news.atom
           - label: heimdal
@@ -62,16 +62,16 @@ jobs:
             aggregate: true
           - label: perl
             feed: https://github.com/Perl/perl5/tags.atom
-            titleFilter: (5\.[0-9]+[13579])|(RC)
+            title-pattern: ^(?!.*(5\.[0-9]+[13579]|RC))
       fail-fast: false
     steps:
-      - uses: guilhem/rss-issues-action@cadba1e05ad93613180979261b7e05cee1a9b282
+      - uses: git-for-windows/rss-to-issues@v0
         with:
           feed: ${{matrix.component.feed}}
           prefix: "[New ${{matrix.component.label}} version]"
           labels: component-update
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          characterLimit: ${{ env.CHARACTER_LIMIT }}
-          lastTime: ${{ env.LAST_TIME }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          character-limit: ${{ env.CHARACTER_LIMIT }}
+          max-age: ${{ env.MAX_AGE }}
           aggregate: ${{matrix.component.aggregate}}
-          titleFilter: ${{matrix.component.titleFilter}}
+          title-pattern: ${{matrix.component.title-pattern}}


### PR DESCRIPTION
The Action we used required over a minute (because it has to fetch a Docker container). I ported it to Javascript, and that Action runs much faster. Let's use it.

The most notable change is that the Javascript Action uses different (hopefully more intuitive) input names, and that the title filter is _inclusive_ rather than exclusive, i.e. feed items that match are converted to issues, not feed items that _don't_ match.