### PR TITLE
monitor-components: ignore GNU Privacy Guard's testing-only versions

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -53,6 +53,7 @@ jobs:
             feed: https://github.com/curl/curl/tags.atom
           - label: gpg
             feed: https://github.com/gpg/gnupg/releases.atom
+            title-pattern: ^gnupg-[0-9]+\.[0-9]*[02468]\.
           - label: mintty
             feed: https://github.com/mintty/mintty/releases.atom
           - label: p7zip


### PR DESCRIPTION
As mentioned [here](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=tag;h=5757baba343c19319b3f2eaf8110d914f75998e5), the v2.3.x releases are meant for testing only, not for general consumption.