### PR TITLE
Let the documentation reflect that there is no vs/master anymore

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,22 +78,12 @@ release MSVC builds):
     make MSVC=1 DEBUG=1 -j12 clean
 ```
 
-### Using `vs/master` Solution
+### Using the IDE
 
-If you prefer working in Visual Studio with a solution full of projects, then there is a
-branch in Git for Windows called [`vs/master`](https://github.com/git-for-windows/git/branches).
-This branch is kept up-to-date with the `master` branch, except it has one more commit that
-contains the solution and project files. Read [the wiki page on this approach](https://github.com/git-for-windows/git/wiki/Compiling-Git-with-Visual-Studio) for more information.
-
-I want to make a small warning before you start working on the `vs/master` branch. If you
-create a new topic branch based on `vs/master`, you will need to rebase onto `master` before
-you can submit a pull request. The commit at the tip of `vs/master` is not intended to ever
-become part of the `master` branch. If you created a branch, `myTopic` based on `vs/master`,
-then use the following rebase command to move it onto the `master` branch:
-
-```
-git rebase --onto master vs/master myTopic
-```
+If you prefer working in Visual Studio with a solution full of projects, then you can use
+CMake, either by letting Visual Studio configure it automatically (simply open Git's
+top-level directory via `File>Open>Folder...`) or by (downloading and) running
+[CMake](https://cmake.org) manually.
 
 What to Change?
 ---------------

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,8 +62,4 @@ Note: even if those builds are not exactly "nightly", they are sometimes referre
 
 ## Following upstream's developments
 
-The [gitforwindows/git repository](https://github.com/git-for-windows/git) also provides the `shears/*` and `vs/master` branches. The `shears/*` branches reflect Git for Windows' patches, rebased onto the upstream integration branches, [updated (mostly) via automated CI builds](https://dev.azure.com/git-for-windows/git/_build?definitionId=25).
-
-# Other special branches
-
-Currently, there is only one other special-purpose branch in Git for Windows: the `vs/master` branch. It adds a commit on top of git-for-Windows/git's `master`, providing the project files ready to build Git in Visual Studio using the MSVC tool chain, [also updated via automated builds](https://dev.azure.com/git-for-windows/git/_build?definitionId=27).
+The [gitforwindows/git repository](https://github.com/git-for-windows/git) also provides the `shears/*` branches. The `shears/*` branches reflect Git for Windows' patches, rebased onto the upstream integration branches, [updated (mostly) via automated CI builds](https://dev.azure.com/git-for-windows/git/_build?definitionId=25).

--- a/compat/vcbuild/README
+++ b/compat/vcbuild/README
@@ -41,27 +41,17 @@ The Steps to Build Git with VS2015 or VS2017 from the command line.
 
 ================================================================
 
-Alternatively, run `make vcxproj` and then load the generated `git.sln` in
-Visual Studio. The initial build will install the vcpkg system and build the
+Alternatively, just open Git's top-level directory in Visual Studio, via
+`File>Open>Folder...`. This will use CMake internally to generate the
+project definitions. It will also install the vcpkg system and build the
 dependencies automatically. This will take a while.
 
-Instead of generating the `git.sln` file yourself (which requires a full Git
-for Windows SDK), you may want to consider fetching the `vs/master` branch of
-https://github.com/git-for-windows/git instead (which is updated automatically
-via CI running `make vcxproj`). The `vs/master` branch does not require a Git
-for Windows to build, but you can run the test scripts in a regular Git Bash.
+You can also generate the Visual Studio solution manually by downloading
+and running CMake explicitly rather than letting Visual Studio doing
+that implicitly.
 
-Note that `make vcxproj` will automatically add and commit the generated `.sln`
-and `.vcxproj` files to the repo. This is necessary to allow building a
-fully-testable Git in Visual Studio, where a regular Git Bash can be used to
-run the test scripts (as opposed to a full Git for Windows SDK): a number of
-build targets, such as Git commands implemented as Unix shell scripts (where
-`@@SHELL_PATH@@` and other placeholders are interpolated) require a full-blown
-Git for Windows SDK (which is about 10x the size of a regular Git for Windows
-installation).
-
-If your plan is to open a Pull Request with Git for Windows, it is a good idea
-to drop this commit before submitting.
+Another, deprecated option is to run `make vcxproj`. This option is
+superseded by the CMake-based build, and will be removed at some point.
 
 ================================================================
 The Steps of Build Git with VS2008


### PR DESCRIPTION
While rebasing Git for Windows onto v2.32.0-rc0, I noticed that the documentation was stale: `vs/master` (or more appropriately, `vs/main`) is no longer updated, and was deprecated in favor of using CMake already a long time ago.