### PR TITLE
Fix segmentation fault in the FSMonitor v2 series

### DIFF
--- a/fsmonitor-ipc.c
+++ b/fsmonitor-ipc.c
@@ -53,7 +53,7 @@ try_again:
 	switch (state) {
 	case IPC_STATE__LISTENING:
 		ret = ipc_client_send_command_to_connection(
-			connection, since_token, strlen(since_token), answer);
+			connection, since_token, since_token ? strlen(since_token) : 0, answer);
 		ipc_client_close_connection(connection);
 
 		trace2_data_intmax("fsm_client", NULL,


### PR DESCRIPTION
After upgrading to v2.32.0-rc2, I just ran `git rebase --autostash -i HEAD~2` and ran into a segmentation fault. Running this in the debugger reveals that v2 of the FSMonitor series introduced a `strlen(since_token)`, but `since_token` can be `NULL`.

It might look like an error to pass `NULL` here, but it is not because `write_packetized_from_buf_no_flush()` does not even attempt to look at that pointer if the number of remaining bytes to write is 0.