### PR TITLE
FSMonitor v2: fix another fall-out of `since_token` being potentially `NULL`

### DIFF
--- a/fsmonitor-ipc.c
+++ b/fsmonitor-ipc.c
@@ -44,7 +44,7 @@ int fsmonitor_ipc__send_query(const char *since_token,
 	trace2_region_enter("fsm_client", "query", NULL);
 
 	trace2_data_string("fsm_client", NULL, "query/command",
-			   since_token);
+			   since_token ? since_token : "(null-token)");
 
 try_again:
 	state = ipc_client_try_connect(fsmonitor_ipc__get_path(), &options,


### PR DESCRIPTION
I should have looked much more closely when crafting #3241: there was one other instance where `since_token` was not expected to be `NULL`: the Trace2 call. This only showed up in Scalar's Functional Tests because it created the situation where a new Git index is initialized (obviously, without a valid FSMonitor token) _and_ all of the Trace2 knobs are turned on.