### PR TITLE
mingw: Define _POSIX_C_SOURCE

### DIFF
--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -6,11 +6,6 @@ typedef _sigset_t sigset_t;
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
-/* MinGW-w64 reports to have flockfile, but it does not actually have it. */
-#ifdef __MINGW64_VERSION_MAJOR
-#undef _POSIX_THREAD_SAFE_FUNCTIONS
-#endif
-
 extern int core_fscache;
 extern int core_long_paths;
 

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -633,7 +633,7 @@ ifneq (,$(findstring MINGW,$(uname_S)))
 		compat/win32/path-utils.o \
 		compat/win32/pthread.o compat/win32/syslog.o \
 		compat/win32/dirent.o compat/win32/fscache.o
-	BASIC_CFLAGS += -DWIN32
+	BASIC_CFLAGS += -DWIN32 -D_POSIX_C_SOURCE
 	EXTLIBS += -lws2_32
 	GITLIBS += git.res
 	PTHREAD_LIBS =

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -1281,7 +1281,7 @@ int open_nofollow(const char *path, int flags);
 # define SHELL_PATH "/bin/sh"
 #endif
 
-#ifndef _POSIX_THREAD_SAFE_FUNCTIONS
+#if !defined(_POSIX_THREAD_SAFE_FUNCTIONS) || defined(WIN32)
 static inline void flockfile(FILE *fh)
 {
 	; /* nothing */


### PR DESCRIPTION
Fixes "implicit declaration of function 'localtime_r'" (and friends)
warnings.

Also remove undef of _POSIX_THREAD_SAFE_FUNCTIONS. flockfile is not
defined indeed, but it never was defined. Add a WIN32 condition for the
static function instead.
