### PR TITLE
FSMonitor fixes

### DIFF
--- a/builtin/fsmonitor--daemon.c
+++ b/builtin/fsmonitor--daemon.c
@@ -694,7 +694,6 @@ static int do_handle_client(struct fsmonitor_daemon_state *state,
 					 "fsmonitor: invalid V2 protocol token '%s'",
 					 command);
 			do_trivial = 1;
-			do_cookie = 1;
 
 		} else {
 			/*

--- a/builtin/fsmonitor--daemon.c
+++ b/builtin/fsmonitor--daemon.c
@@ -672,7 +672,6 @@ static int do_handle_client(struct fsmonitor_daemon_state *state,
 		 */
 		do_flush = 1;
 		do_trivial = 1;
-		do_cookie = 1;
 
 	} else if (!skip_prefix(command, "builtin:", &p)) {
 		/* assume V1 timestamp or garbage */

--- a/builtin/fsmonitor--daemon.c
+++ b/builtin/fsmonitor--daemon.c
@@ -685,7 +685,6 @@ static int do_handle_client(struct fsmonitor_daemon_state *state,
 				  "fsmonitor: unsupported V1 protocol '%s'"),
 				 command);
 		do_trivial = 1;
-		do_cookie = 1;
 
 	} else {
 		/* We have "builtin:*" */

--- a/fsmonitor-ipc.c
+++ b/fsmonitor-ipc.c
@@ -44,7 +44,7 @@ int fsmonitor_ipc__send_query(const char *since_token,
 	trace2_region_enter("fsm_client", "query", NULL);
 
 	trace2_data_string("fsm_client", NULL, "query/command",
-			   since_token ? since_token : "(null-token)");
+			   since_token);
 
 try_again:
 	state = ipc_client_try_connect(fsmonitor_ipc__get_path(), &options,
@@ -53,7 +53,7 @@ try_again:
 	switch (state) {
 	case IPC_STATE__LISTENING:
 		ret = ipc_client_send_command_to_connection(
-			connection, since_token, since_token ? strlen(since_token) : 0, answer);
+			connection, since_token, strlen(since_token), answer);
 		ipc_client_close_connection(connection);
 
 		trace2_data_intmax("fsm_client", NULL,

--- a/fsmonitor.c
+++ b/fsmonitor.c
@@ -290,8 +290,9 @@ void refresh_fsmonitor(struct index_state *istate)
 	trace_printf_key(&trace_fsmonitor, "refresh fsmonitor");
 
 	if (r->settings.use_builtin_fsmonitor > 0) {
-		query_success = !fsmonitor_ipc__send_query(
-			istate->fsmonitor_last_update, &query_result);
+		query_success = istate->fsmonitor_last_update &&
+			!fsmonitor_ipc__send_query(istate->fsmonitor_last_update,
+						   &query_result);
 		if (query_success) {
 			/*
 			 * The response contains a series of nul terminated


### PR DESCRIPTION
While Git's test suite did not report any regressions, I had to hunt for a few days to figure out why Scalar's Functional Tests were still unhappy with the new FSMonitor patch series.

This PR is the culmination of those efforts, and a sibling to https://github.com/microsoft/git/pull/371 (which not only integrates these patches, but makes sure that Scalar's Functional Tests are run in `microsoft/git` as part of the CI).