### PR TITLE
Monitor libgpg-error and libgcrypt versions

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -51,6 +51,9 @@ jobs:
             feed: https://github.com/petervanderdoes/gitflow-avh/tags.atom
           - label: curl
             feed: https://github.com/curl/curl/tags.atom
+          - label: libgpg-error
+            feed: https://github.com/gpg/libgpg-error/releases.atom
+            title-pattern: ^libgpg-error-[0-9\.]*$
           - label: libgcrypt
             feed: https://github.com/gpg/libgcrypt/releases.atom
             title-pattern: ^libgcrypt-[0-9\.]*$

--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -51,6 +51,9 @@ jobs:
             feed: https://github.com/petervanderdoes/gitflow-avh/tags.atom
           - label: curl
             feed: https://github.com/curl/curl/tags.atom
+          - label: libgcrypt
+            feed: https://github.com/gpg/libgcrypt/releases.atom
+            title-pattern: ^libgcrypt-[0-9\.]*$
           - label: gpg
             feed: https://github.com/gpg/gnupg/releases.atom
           - label: mintty


### PR DESCRIPTION
In our GitHub workflow that notifies us about new versions of important Git for Windows components, we already watch out for new GNU Privacy Guard versions. For v2.2.28, it became painfully clear, though, that this is not enough: we also have to build the GNU Privacy Guard dependencies `libgpg-error` and `libgcrypt` ourselves. So let's watch out for new versions of those libraries, too.