### PR TITLE
Redo fix for FSMonitor

### DIFF
--- a/fsmonitor.c
+++ b/fsmonitor.c
@@ -290,9 +290,10 @@ void refresh_fsmonitor(struct index_state *istate)
 	trace_printf_key(&trace_fsmonitor, "refresh fsmonitor");
 
 	if (r->settings.use_builtin_fsmonitor > 0) {
-		query_success = istate->fsmonitor_last_update &&
-			!fsmonitor_ipc__send_query(istate->fsmonitor_last_update,
-						   &query_result);
+		query_success = !fsmonitor_ipc__send_query(
+			istate->fsmonitor_last_update ?
+			istate->fsmonitor_last_update : "builtin:fake",
+			&query_result);
 		if (query_success) {
 			/*
 			 * The response contains a series of nul terminated


### PR DESCRIPTION
In #3263, I fixed the issue where `fsmonitor_ipc__send_query()` was called with `NULL` as `last_token`, by simply not calling that function.

That works, but it is undesirable: it means that we do not even query the FSMonitor, and therefore do not get a token back, but instead store a dummy token and do a full scan. The next time we hit this code path, we do query the FSMonitor, but with a dummy token, and therefore cause _another_ full scan.

By instead calling that function with a dummy token right away we _do_ get back a valid token, and the second time we hit that code path we can reap the full benefit of the FSMonitor.

This is a companion of https://github.com/microsoft/git/pull/385.