### PR TITLE
Allow specifying at runtime which POSIX shell to use

### DIFF
--- a/Documentation/config/core.adoc
+++ b/Documentation/config/core.adoc
@@ -807,3 +807,7 @@ core.WSLCompat::
 	The default value is false. When set to true, Git will set the mode
 	bits of the file in the way of wsl, so that the executable flag of
 	files can be set or read correctly.
+
+core.shell::
+	Set the absolute path to the executable to use as a POSIX shell;
+	This will also set/override the environment variable `SHELL`.

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2000,6 +2000,10 @@ static char *path_lookup(const char *cmd, int exe_only)
 	if (strpbrk(cmd, "/\\"))
 		return xstrdup(cmd);
 
+	if (!strcmp(cmd, "sh") &&
+	    (prog = xstrdup_or_null(get_shell_path(NULL))))
+		return prog;
+
 	path = mingw_getenv("PATH");
 	if (!path)
 		return NULL;
@@ -2192,6 +2196,12 @@ static int is_msys2_sh(const char *cmd)
 
 		if (ret >= 0)
 			return ret;
+
+		if (get_shell_path(NULL)) {
+			/* Assume an overridden shell is not MSYS2 */
+			ret = 0;
+			return ret;
+		}
 
 		p = path_lookup(cmd, 0);
 		if (!p)

--- a/help.c
+++ b/help.c
@@ -793,7 +793,7 @@ void get_version_info(struct strbuf *buf, int show_build_options)
 			strbuf_addstr(buf, "no commit associated with this build\n");
 		strbuf_addf(buf, "sizeof-long: %d\n", (int)sizeof(long));
 		strbuf_addf(buf, "sizeof-size_t: %d\n", (int)sizeof(size_t));
-		strbuf_addf(buf, "shell-path: %s\n", SHELL_PATH);
+		strbuf_addf(buf, "shell-path: %s\n", get_shell_path(SHELL_PATH));
 		/* NEEDSWORK: also save and output GIT-BUILD_OPTIONS? */
 
 #if defined WITH_RUST

--- a/run-command.c
+++ b/run-command.c
@@ -1,4 +1,5 @@
 #define DISABLE_SIGN_COMPARE_WARNINGS
+#define USE_THE_REPOSITORY_VARIABLE
 
 #include "git-compat-util.h"
 #include "run-command.h"
@@ -17,6 +18,20 @@
 #include "config.h"
 #include "packfile.h"
 #include "compat/nonblock.h"
+
+const char *get_shell_path(const char *fallback)
+{
+	static char *shell;
+	static int initialized;
+
+	if (!initialized) {
+		if (!repo_config_get_pathname(the_repository, "core.shell", &shell))
+			setenv("SHELL", shell, 1);
+		initialized = 1;
+	}
+
+	return shell ? shell : fallback;
+}
 
 void child_process_init(struct child_process *child)
 {
@@ -276,12 +291,19 @@ int sane_execvp(const char *file, char * const argv[])
 
 char *git_shell_path(void)
 {
+	const char *shell = get_shell_path(NULL);
+
+	if (shell)
+		return xstrdup(shell);
+
 #ifndef GIT_WINDOWS_NATIVE
 	return xstrdup(SHELL_PATH);
 #else
-	char *p = locate_in_PATH("sh");
-	convert_slashes(p);
-	return p;
+	{
+		char *p = locate_in_PATH("sh");
+		convert_slashes(p);
+		return p;
+	}
 #endif
 }
 
@@ -416,7 +438,7 @@ static int prepare_cmd(struct strvec *out, const struct child_process *cmd)
 	 * Add SHELL_PATH so in the event exec fails with ENOEXEC we can
 	 * attempt to interpret the command with 'sh'.
 	 */
-	strvec_push(out, SHELL_PATH);
+	strvec_push(out, get_shell_path(SHELL_PATH));
 
 	if (cmd->git_cmd) {
 		prepare_git_cmd(out, cmd->args.v);

--- a/run-command.h
+++ b/run-command.h
@@ -616,4 +616,9 @@ enum start_bg_result start_bg_command(struct child_process *cmd,
 
 int sane_execvp(const char *file, char *const argv[]);
 
+/*
+ * Get the path of the POSIX shell to use in `start_command()`.
+ */
+const char *get_shell_path(const char *fallback);
+
 #endif

--- a/t/t0061-run-command.sh
+++ b/t/t0061-run-command.sh
@@ -298,4 +298,11 @@ test_expect_success 'core.shell' '
 	grep "${SQ}a.b=c${SQ} is not a git command" actual
 '
 
+test_expect_success MINGW 'core.shell executes scripts' '
+	test_config_global core.shell "$GIT_EXEC_PATH/git$X" &&
+	echo "#!/bin/sh" >script &&
+	test_must_fail git -c alias.s="!./script" s 2>actual &&
+	grep "${SQ}./script${SQ} is not a git command" actual
+'
+
 test_done

--- a/t/t0061-run-command.sh
+++ b/t/t0061-run-command.sh
@@ -291,4 +291,11 @@ test_expect_success MINGW 'can spawn .bat with argv[0] containing spaces' '
 	test_grep "arg with spaces" out
 '
 
+SQ="'"
+test_expect_success 'core.shell' '
+	test_config_global core.shell "$GIT_EXEC_PATH/git$X" &&
+	test_must_fail git -c alias.eq="!a.b=c" eq 2>actual &&
+	grep "${SQ}a.b=c${SQ} is not a git command" actual
+'
+
 test_done


### PR DESCRIPTION
We already have the `SHELL_PATH` variable, but that is a build-time setting.

In Git for Windows' context, that is not good enough: we want to use the very same Git artifacts both in the regular MinGit flavor as well as in the BusyBox one.

So let's introduce support for the config setting `core.shell`, which is interpreted as the absolute path of the POSIX-compliant shell to use to execute hooks, scripted Git commands, complex aliases, etc.

We also set the environment variable `SHELL` if `core.shell` was configured. This helps the scenario where OpenSSH is called in a BusyBox variant of MinGit (which comes without any MSYS2 shell): OpenSSH looks at that variable to run commands such as ones specified via the `ProxyCommand` setting in the SSH config.

Note: in the BusyBox variant of MinGit, we will want to set this in the system config, to a path relative to the runtime prefix. For that reason, we will need to address https://github.com/gitgitgadget/git/pull/66 rather sooner than later, before going through with this here PR.