### PR TITLE
rmdir: align behavior on Windows when called on symlinks

### DIFF
--- a/t/t3400-rebase.sh
+++ b/t/t3400-rebase.sh
@@ -406,4 +406,14 @@ test_expect_success 'refuse to switch to branch checked out elsewhere' '
 	test_i18ngrep "already checked out" err
 '
 
+test_expect_success MINGW,SYMLINKS_WINDOWS 'rebase when .git/logs is a symlink' '
+	git checkout main &&
+	mv .git/logs actual_logs &&
+	cmd //c "mklink /D .git\logs ..\actual_logs" &&
+	git rebase -f HEAD^ &&
+	test -L .git/logs &&
+	rm .git/logs &&
+	mv actual_logs .git/logs
+'
+
 test_done

--- a/t/test-lib.sh
+++ b/t/test-lib.sh
@@ -1536,6 +1536,12 @@ test_lazy_prereq SYMLINKS '
 	ln -s x y && test -h y
 '
 
+test_lazy_prereq SYMLINKS_WINDOWS '
+	# test whether symbolic links are enabled on Windows
+	test_have_prereq MINGW &&
+	cmd //c "mklink y x" &> /dev/null && test -h y
+'
+
 test_lazy_prereq FILEMODE '
 	test "$(git config --bool core.filemode)" = true
 '


### PR DESCRIPTION
Fixes #2967 

When performing a rebase, `rmdir()` is called on the folder `.git/logs`. On Linux `rmdir()` exits without deleting anything in case `.git/logs` is a symbolic link but the Windows equivalent (`_rmdir`) does not behave the same and removes the folder if it is symlink which generates issues especially when Repo is used.
This commit updates `mingw_rmdir()` so that its behavior is the same as Linux `rmdir()` in case of symbolic links.

Some remarks:
* I asked confirmation to Microsoft about the actual behavior of `_rmdir()` with symlinks but I didn't get an answer yet so my conclusions are only based on what I saw while debugging on Windows 10 with Git Bash.
* I created a "rebase" test case because this problem was found initially when performing "git rebase" but in the end the commit applies to `mingw_rmdir()` in general. Moreover I think it is in line with this part of the contribution guidelines: `The Git community prefers functional tests using the full git executable, so try to exercise your new code using git commands before creating a test helper.` But if you think a test case dedicated to `mingw_rmdir()` should be created, please let me know.
* Kudos to @rimrul for helping me choose the correct value for `errno` :)