### PR TITLE
Add MSIX installer to GitHub workflow

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -546,17 +546,17 @@ jobs:
       - name: Extract portable x64 artifacts
         uses: DuckSoft/extract-7z-action@v1
         with:
-          pathSource: {{ env.FILENAMEX64 }}
+          pathSource: ${{ env.FILENAMEX64 }}
           pathTarget: build
       - name: Extract portable x86 artifacts
         uses: DuckSoft/extract-7z-action@v1
         with:
-          pathSource: {{ env.FILENAMEX86 }}
+          pathSource: ${{ env.FILENAMEX86 }}
           pathTarget: build
       - name: Extract portable arm64 artifacts
         uses: DuckSoft/extract-7z-action@v1
         with:
-          pathSource: {{ env.FILENAMEARM64 }}
+          pathSource: ${{ env.FILENAMEARM64 }}
           pathTarget: build
       - name: Show content of build
         run: |

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -565,6 +565,12 @@ jobs:
         run: git clone --single-branch -b msix https://github.com/davidanthoff/build-extra build-extra
       - name: Write packaging layout file
         run: build-extra\msix\create_packaginglayout_file.ps1
+      - name: Show content of build
+        run: |
+          gci build
+      - name: Show content of build
+        run: |
+          gci build-extra\msix
       - name: Build MSIX
         run: |
           &"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\MakeAppx.exe" build /f build\PackagingLayout.xml /op build /pv 1.0.0.0 /bv 1.0.0.0

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -535,10 +535,29 @@ jobs:
         with:
           name: portable-i686
           path: portable
-      - name: Extract portable artifacts
-        uses: edgarrc/action-7z@v1
+      - name: Find filenames
+        run: |
+          $filename_arm64 = (Get-ChildItem portable\*arm64.7z.exe)[0].FullName
+          $filename_x64 = (Get-ChildItem portable\*64-bit.7z.exe)[0].FullName
+          $filename_x86 = (Get-ChildItem portable\*32-bit.7z.exe)[0].FullName
+          Write-Output "FILENAMEX64=$($filename_x64)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Output "FILENAMEX86=$($filename_x86)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Output "FILENAMEARM64=$($filename_arm64)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Extract portable x64 artifacts
+        uses: DuckSoft/extract-7z-action@v1
         with:
-          args: 7z -y x "portable/*.7z" -obuild
+          pathSource: {{ env.FILENAMEX64 }}
+          pathTarget: build
+      - name: Extract portable x86 artifacts
+        uses: DuckSoft/extract-7z-action@v1
+        with:
+          pathSource: {{ env.FILENAMEX86 }}
+          pathTarget: build
+      - name: Extract portable arm64 artifacts
+        uses: DuckSoft/extract-7z-action@v1
+        with:
+          pathSource: {{ env.FILENAMEARM64 }}
+          pathTarget: build
       - name: Show content of build
         run: |
           gci build

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -572,7 +572,7 @@ jobs:
           build-extra\msix\create_packaginglayout_file.ps1
           Write-PackageLayoutFile "1.0.0.0" "buildmsix\appxmanifest.xml"
           Write-PackageLayoutFile "1.0.0.0" "buildstore\appxmanifest.xml"
-          Write-AppxManifest "1.0.0.0" "CN=Johannes Schindelin, O=Johannes Schindelin, L=Köln, S=North Rhine-Westphalia, C=DE" "buildmsix\PackagingLayout.xml"
+          Write-AppxManifest "1.0.0.0" "CN=Johannes Schindelin,O=Johannes Schindelin,L=Köln,S=North Rhine-Westphalia,C=DE" "buildmsix\PackagingLayout.xml"
           Write-AppxManifest "1.0.0.0" "CN=82A13EFD-FE37-4EFC-8BA4-1C3E9EFE5F23" "buildstore\PackagingLayout.xml"
       - name: Delete WebView2Loader.dll
         run: |

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -516,3 +516,29 @@ jobs:
         with:
           name: nuget-x86_64
           path: artifacts
+  msix:
+    runs-on: windows-latest
+    needs: artifacts
+    steps:
+      - name: Download portable-arm64 artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: portable-arm64
+          path: portable
+      - name: Download portable-x86_64 artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: portable-x86_64
+          path: portable
+      - name: Download portable-i686 artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: portable-i686
+          path: portable
+      - name: Extract portable artifacts
+        uses: edgarrc/action-7z@v1
+        with:
+          args: 7z -y x "portable/*.7z" -obuild
+      - name: Show content of build
+        run: |
+          gci build

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -563,28 +563,40 @@ jobs:
           gci build
       - name: Clone build-extra
         run: git clone --single-branch -b msix https://github.com/davidanthoff/build-extra build-extra
-      - name: Write packaging layout file
+      - name: Create folder for store and msix version
+        run: |
+          md buildmsix
+          md buildstore
+      - name: Write packaging layout files
         run: |
           build-extra\msix\create_packaginglayout_file.ps1
-      - name: Copy appxmanifest
-        run: copy-item build-extra\msix\appxmanifest.xml build\appxmanifest.xml
-      - name: Show content of build
-        run: |
-          gci build
-      - name: Show content of build
-        run: |
-          gci build-extra\msix
+          Write-PackageLayoutFile "1.0.0.0" "buildmsix\appxmanifest.xml"
+          Write-PackageLayoutFile "1.0.0.0" "buildstore\appxmanifest.xml"
+          Write-AppxManifest "1.0.0.0" "CN=Johannes Schindelin, O=Johannes Schindelin, L=Köln, S=North Rhine-Westphalia, C=DE" "buildmsix\PackagingLayout.xml"
+          Write-AppxManifest "1.0.0.0" "CN=82A13EFD-FE37-4EFC-8BA4-1C3E9EFE5F23" "buildstore\PackagingLayout.xml"
       - name: Delete WebView2Loader.dll
         run: |
           Remove-Item build\x64\mingw64\libexec\git-core\WebView2Loader.dll
           Remove-Item build\x86\mingw32\libexec\git-core\WebView2Loader.dll
           Remove-Item build\arm64\mingw32\libexec\git-core\WebView2Loader.dll
-      - name: Build MSIX
+      - name: Build Standalone MSIX
         run: |        
-          push-location build
+          push-location buildmsix
           &"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\MakeAppx.exe" build /f PackagingLayout.xml /op . /pv 1.0.0.0 /bv 1.0.0.0
           pop-location
+      - name: Build Store MSIX
+        run: |        
+          push-location buildstore
+          &"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\MakeAppx.exe" build /f PackagingLayout.xml /op . /pv 1.0.0.0 /bv 1.0.0.0
+          pop-location
+      - name: Sign standalone MSIX
+        run: |
+          Write-Output "Here we should sign the appxbundle that is in the buildstore folder with signtool."
       - uses: actions/upload-artifact@v2
         with:
-          name: msixinstaller
-          path: build\*.appxbundle
+          name: standalonemsixinstaller
+          path: buildmsix\*.appxbundle
+      - uses: actions/upload-artifact@v2
+        with:
+          name: storemsixinstaller
+          path: buildstore\*.appxbundle

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -544,17 +544,17 @@ jobs:
           Write-Output "FILENAMEX86=$($filename_x86)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Output "FILENAMEARM64=$($filename_arm64)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Extract portable x64 artifacts
-        uses: DuckSoft/extract-7z-action@v1
+        uses: DuckSoft/extract-7z-action@v1.0
         with:
           pathSource: ${{ env.FILENAMEX64 }}
           pathTarget: build
       - name: Extract portable x86 artifacts
-        uses: DuckSoft/extract-7z-action@v1
+        uses: DuckSoft/extract-7z-action@v1.0
         with:
           pathSource: ${{ env.FILENAMEX86 }}
           pathTarget: build
       - name: Extract portable arm64 artifacts
-        uses: DuckSoft/extract-7z-action@v1
+        uses: DuckSoft/extract-7z-action@v1.0
         with:
           pathSource: ${{ env.FILENAMEARM64 }}
           pathTarget: build

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -574,8 +574,13 @@ jobs:
       - name: Show content of build
         run: |
           gci build-extra\msix
-      - name: Build MSIX
+      - name: Delete WebView2Loader.dll
         run: |
+          Remove-Item build\x64\mingw64\libexec\git-core\WebView2Loader.dll
+          Remove-Item build\x86\mingw64\libexec\git-core\WebView2Loader.dll
+          Remove-Item build\arm64\mingw64\libexec\git-core\WebView2Loader.dll
+      - name: Build MSIX
+        run: |        
           push-location build
           &"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\MakeAppx.exe" build /f PackagingLayout.xml /op . /pv 1.0.0.0 /bv 1.0.0.0
           pop-location

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -570,10 +570,10 @@ jobs:
       - name: Write packaging layout files
         run: |
           . build-extra\msix\create_packaginglayout_file.ps1
-          Write-PackageLayoutFile "1.0.0.0" "buildmsix\appxmanifest.xml"
-          Write-PackageLayoutFile "1.0.0.0" "buildstore\appxmanifest.xml"
-          Write-AppxManifest "1.0.0.0" "CN=Johannes Schindelin,O=Johannes Schindelin,L=Köln,S=North Rhine-Westphalia,C=DE" "buildmsix\PackagingLayout.xml"
-          Write-AppxManifest "1.0.0.0" "CN=82A13EFD-FE37-4EFC-8BA4-1C3E9EFE5F23" "buildstore\PackagingLayout.xml"
+          Write-PackageLayoutFile "1.0.0.0" (Join-Path -Path $pwd -ChildPath "buildmsix\PackagingLayout.xml")
+          Write-PackageLayoutFile "1.0.0.0" (Join-Path -Path $pwd -ChildPath "buildstore\PackagingLayout.xml")
+          Write-AppxManifest "1.0.0.0" "CN=Johannes Schindelin, O=Johannes Schindelin, L=Köln, S=North Rhine-Westphalia, C=DE" (Join-Path -Path $pwd -ChildPath "buildmsix\appxmanifest.xml")
+          Write-AppxManifest "1.0.0.0" "CN=82A13EFD-FE37-4EFC-8BA4-1C3E9EFE5F23" (Join-Path -Path $pwd -ChildPath "buildstore\appxmanifest.xml")
       - name: Delete WebView2Loader.dll
         run: |
           Remove-Item build\x64\mingw64\libexec\git-core\WebView2Loader.dll

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -594,9 +594,9 @@ jobs:
           Write-Output "Here we should sign the appxbundle that is in the buildstore folder with signtool."
       - uses: actions/upload-artifact@v2
         with:
-          name: standalonemsixinstaller
+          name: msixinstallerstandalone
           path: buildmsix\*.appxbundle
       - uses: actions/upload-artifact@v2
         with:
-          name: storemsixinstaller
+          name: msixinstallerstore
           path: buildstore\*.appxbundle

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -569,7 +569,7 @@ jobs:
           md buildstore
       - name: Write packaging layout files
         run: |
-          build-extra\msix\create_packaginglayout_file.ps1
+          . build-extra\msix\create_packaginglayout_file.ps1
           Write-PackageLayoutFile "1.0.0.0" "buildmsix\appxmanifest.xml"
           Write-PackageLayoutFile "1.0.0.0" "buildstore\appxmanifest.xml"
           Write-AppxManifest "1.0.0.0" "CN=Johannes Schindelin,O=Johannes Schindelin,L=Köln,S=North Rhine-Westphalia,C=DE" "buildmsix\PackagingLayout.xml"

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -547,17 +547,28 @@ jobs:
         uses: DuckSoft/extract-7z-action@v1.0
         with:
           pathSource: ${{ env.FILENAMEX64 }}
-          pathTarget: build
+          pathTarget: build/x64
       - name: Extract portable x86 artifacts
         uses: DuckSoft/extract-7z-action@v1.0
         with:
           pathSource: ${{ env.FILENAMEX86 }}
-          pathTarget: build
+          pathTarget: build/x86
       - name: Extract portable arm64 artifacts
         uses: DuckSoft/extract-7z-action@v1.0
         with:
           pathSource: ${{ env.FILENAMEARM64 }}
-          pathTarget: build
+          pathTarget: build/arm64          
       - name: Show content of build
         run: |
           gci build
+      - name: Clone build-extra
+        run: git clone --single-branch -b msix https://github.com/davidanthoff/build-extra build-extra
+      - name: Write packaging layout file
+        run: build-extra\msix\create_packaginglayout_file.ps1
+      - name: Build MSIX
+        run: |
+          &"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\MakeAppx.exe" build /f build\PackagingLayout.xml /op build /pv 1.0.0.0 /bv 1.0.0.0
+      - uses: actions/upload-artifact@v2
+        with:
+          name: msixinstaller
+          path: build\*.appxbundle

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -564,7 +564,10 @@ jobs:
       - name: Clone build-extra
         run: git clone --single-branch -b msix https://github.com/davidanthoff/build-extra build-extra
       - name: Write packaging layout file
-        run: build-extra\msix\create_packaginglayout_file.ps1
+        run: |
+          build-extra\msix\create_packaginglayout_file.ps1
+      - name: Copy appxmanifest
+        run: copy-item build-extra\msix\appxmanifest.xml build\appxmanifest.xml
       - name: Show content of build
         run: |
           gci build
@@ -573,7 +576,9 @@ jobs:
           gci build-extra\msix
       - name: Build MSIX
         run: |
-          &"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\MakeAppx.exe" build /f build\PackagingLayout.xml /op build /pv 1.0.0.0 /bv 1.0.0.0
+          push-location build
+          &"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\MakeAppx.exe" build /f PackagingLayout.xml /op . /pv 1.0.0.0 /bv 1.0.0.0
+          pop-location
       - uses: actions/upload-artifact@v2
         with:
           name: msixinstaller

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -577,8 +577,8 @@ jobs:
       - name: Delete WebView2Loader.dll
         run: |
           Remove-Item build\x64\mingw64\libexec\git-core\WebView2Loader.dll
-          Remove-Item build\x86\mingw64\libexec\git-core\WebView2Loader.dll
-          Remove-Item build\arm64\mingw64\libexec\git-core\WebView2Loader.dll
+          Remove-Item build\x86\mingw32\libexec\git-core\WebView2Loader.dll
+          Remove-Item build\arm64\mingw32\libexec\git-core\WebView2Loader.dll
       - name: Build MSIX
         run: |        
           push-location build


### PR DESCRIPTION
This is also ready now for a first go. Couple of comments:
- This now produces two installers. One with @dscho as the publisher, and a second version where we will put in the publisher name that the Windows Store submission gives us, i.e. we'll need to produce two versions, one for the store and one for the standalone MSIX.
- I put a step in there where @dscho could put in the signing step of the standalone MSIX file with his cert. We don't need to sign the store version, that will just be uploaded unsigned to the store and then get signed with an MS cert.

There are various todos still, but I think for now it would be good to merge this and test whether we can actually produce a properly signed standalone MSIX and try that out. I'll open a separate issue to track things that still need to be sorted out.