### PR TITLE
Add `contrib/subtree` test execution to CI builds

### DIFF
--- a/ci/run-build-and-tests.sh
+++ b/ci/run-build-and-tests.sh
@@ -27,13 +27,13 @@ linux-gcc)
 	export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=master
 	export GIT_TEST_WRITE_REV_INDEX=1
 	export GIT_TEST_CHECKOUT_WORKERS=2
-	make test
+	make test && make -C contrib/subtree test || exit 1
 	;;
 linux-clang)
 	export GIT_TEST_DEFAULT_HASH=sha1
 	make test
 	export GIT_TEST_DEFAULT_HASH=sha256
-	make test
+	make test && make -C contrib/subtree test || exit 1
 	;;
 linux-gcc-4.8)
 	# Don't run the tests; we only care about whether Git can be
@@ -41,7 +41,7 @@ linux-gcc-4.8)
 	# constructs that newer compilers seem to quietly accept.
 	;;
 *)
-	make test
+	make test && make -C contrib/subtree test || exit 1
 	;;
 esac
 

--- a/ci/run-test-slice.sh
+++ b/ci/run-test-slice.sh
@@ -14,4 +14,7 @@ make --quiet -C t T="$(cd t &&
 	./helper/test-tool path-utils slice-tests "$1" "$2" t[0-9]*.sh |
 	tr '\n' ' ')"
 
+# Run the git subtree tests only if main tests succeeded
+test 0 != "$1" || make -C contrib/subtree test
+
 check_unignored_build_artifacts

--- a/contrib/subtree/Makefile
+++ b/contrib/subtree/Makefile
@@ -94,7 +94,7 @@ $(GIT_SUBTREE_TEST): $(GIT_SUBTREE)
 	cp $< $@
 
 test: $(GIT_SUBTREE_TEST)
-	$(MAKE) -C t/ test
+	$(MAKE) -C t/ all
 
 clean:
 	$(RM) $(GIT_SUBTREE)


### PR DESCRIPTION
## Changes
- Subtree tests run if (and only if) `make test` passes in Windows, Linux, and Mac build/test jobs
  - For platforms that run `make test` more than once in `run-build-and-tests.sh`, subtree tests are only run after the _last_ execution of `make test`
  - Added "fail fast" `exit 1` to `run-build-and-tests.sh` - otherwise, tests failing in `make test` wouldn't always fail the test execution (this might also be because I'm not _great_ at bash scripting 😉)
- `contrib/subtree` `test` target updated to invoke `t/` directory `all` target (rather than `test` target)
  - Necessary to use the `$DEFAULT_TEST_TARGET`
  - Matches root `test` target behavior

## Testing
- CI execution with no failing tests is linked to this PR
- CI execution with forced failure in t0000: https://github.com/vdye/git/actions/runs/1102256177
  - Skips `git subtree` tests
  - Fails all test executions
- CI execution with forced failure in subtree tests: https://github.com/vdye/git/actions/runs/1102312905
  - `git subtree` tests executed only after `make test` passes
  - Fails all test executions (at least, those that run the subtree tests)