### PR TITLE
ci: use upload-artifacts v1 for dockerized jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -271,7 +271,7 @@ jobs:
       if: failure()
     - name: Upload failed tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v1
       with:
         name: failed-tests-${{matrix.vector.jobname}}
         path: ${{env.FAILED_TEST_ARTIFACTS}}


### PR DESCRIPTION
This PR intends to merge early a fixup for my "speed up CI" work.

But in reality, it is only an excuse to get another snapshot so that folks can verify the fix for https://github.com/git-for-windows/git/issues/3368.