### PR TITLE
A couple of compile fixes

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -3316,9 +3316,9 @@ static size_t append_system_bin_dirs(char *path, size_t size)
 
 static int is_system32_path(const char *path)
 {
-	WCHAR system32[MAX_PATH], wpath[MAX_PATH];
+	WCHAR system32[MAX_LONG_PATH], wpath[MAX_LONG_PATH];
 
-	if (xutftowcs_path(wpath, path) < 0 ||
+	if (xutftowcs_long_path(wpath, path) < 0 ||
 	    !GetSystemDirectoryW(system32, ARRAY_SIZE(system32)) ||
 	    _wcsicmp(system32, wpath))
 		return 0;


### PR DESCRIPTION
Over the course of the years, unfortunately a couple of build failures crept in, by squashing fixups (that were often necessitated by reordering commits/topics) into the wrong commits.

This PR tries to fix that, by merging in a couple of `fixup!` commits that target the correct commits instead.

Note: since the tip of the `main` branch _already_ compiles, some of these `fixup!` commits had to be done directly on top of the commits they want to be squashed into, and then they were merged on top of `main`.

The end result is _almost_ tree-same to `main`: only an extra forward declaration of `struct strbuf` is necessary. That's okay, though: it is good to have it, so that future reorganizations won't cause new build failures.