### PR TITLE
CMake: sanitise Visual Studio's compile_commands.json for use by Clang

### DIFF
--- a/contrib/buildsystems/sanitise_compile_commands.sh
+++ b/contrib/buildsystems/sanitise_compile_commands.sh
@@ -11,7 +11,7 @@
 
 # run in, e.g., the /contrib/buildsystems/ folder
 
-find . -type f -name "compile_commands*" | xargs sed --in-place=.tmp 's: /: -:g; s/ -Od//g; s/ -Ob0//g; s/ -Zi//g'
+find . -type f -name "compile_commands.json" | xargs sed --in-place=.tmp 's: /: -:g; s/ -Od//g; s/ -Ob0//g; s/ -Zi//g'
 
 # references
 # https://github.com/git/git/commit/409047a2b3fabb6a5f3fdbb28d93a5db3a7de28c

--- a/contrib/buildsystems/sanitise_compile_commands.sh
+++ b/contrib/buildsystems/sanitise_compile_commands.sh
@@ -1,0 +1,19 @@
+#!bin/sh
+# sanitise_compile_commands.sh
+
+# Sanitise the `compile_commands.json` file produced by the
+# Visual Studio defaults to be compatible with Clang,
+# as used in Sourcetrail's interactive dependency graph viewer.
+# I.e. convert the slash '/' options to dashed versions, and
+# remove the VS specific /Od, /Ob0 and /Zi options.
+# Note the leading space to select the options, rather than any
+# Posix directory separators.
+
+# run in, e.g., the /contrib/buildsystems/ folder
+
+find . -type f -name "compile_commands*" | xargs sed --in-place=.tmp 's: /: -:g; s/ -Od//g; s/ -Ob0//g; s/ -Zi//g'
+
+# references
+# https://github.com/git/git/commit/409047a2b3fabb6a5f3fdbb28d93a5db3a7de28c
+# 'create compile_commands.json by default'
+# https://www.sourcetrail.com/


### PR DESCRIPTION
The Visual Studio command line saved by commit 409047a2b3 (cmake: create
compile_commands.json by default, 2021-06-06) is not compatible with
tools that use Clang for their code analysis.

Provide a shell script that will sanitise the compile_commands.json file.

Signed-off-by: Philip Oakley <philipoakley@iee.email>

---
This is should be useful to potential Git-for-Windows contributors who wish to
browse the code with the open source Sourcetrail interactive dependency graph
viewer https://www.sourcetrail.com/

If there are no issues I'll also send it upstream (GitGitGadget or Patches)