### PR TITLE
init: respect core.symlinks before copying the templates

### DIFF
--- a/builtin/clone.c
+++ b/builtin/clone.c
@@ -990,7 +990,7 @@ int cmd_clone(int argc, const char **argv, const char *prefix)
 	struct transport_ls_refs_options transport_ls_refs_options =
 		TRANSPORT_LS_REFS_OPTIONS_INIT;
 
-	git_config(platform_core_config, NULL);
+	git_config(git_default_core_config, NULL);
 
 	packet_trace_identity("clone");
 

--- a/builtin/column.c
+++ b/builtin/column.c
@@ -34,7 +34,7 @@ int cmd_column(int argc, const char **argv, const char *prefix)
 		OPT_END()
 	};
 
-	git_config(platform_core_config, NULL);
+	git_config(git_default_core_config, NULL);
 
 	/* This one is special and must be the first one */
 	if (argc > 1 && starts_with(argv[1], "--command=")) {

--- a/builtin/init-db.c
+++ b/builtin/init-db.c
@@ -410,7 +410,7 @@ int init_db(const char *git_dir, const char *real_git_dir,
 	startup_info->have_repository = 1;
 
 	/* Ensure `core.hidedotfiles` is processed */
-	git_config(platform_core_config, NULL);
+	git_config(git_default_core_config, NULL);
 
 	safe_create_dir(git_dir, 0);
 

--- a/config.c
+++ b/config.c
@@ -1295,7 +1295,7 @@ int git_config_color(char *dest, const char *var, const char *value)
 	return 0;
 }
 
-static int git_default_core_config(const char *var, const char *value, void *cb)
+int git_default_core_config(const char *var, const char *value, void *cb)
 {
 	/* This needs a better name */
 	if (!strcmp(var, "core.filemode")) {

--- a/config.h
+++ b/config.h
@@ -120,6 +120,7 @@ struct config_options {
 typedef int (*config_fn_t)(const char *, const char *, void *);
 
 int git_default_config(const char *, const char *, void *);
+int git_default_core_config(const char *var, const char *value, void *cb);
 
 /**
  * Read a specific file in git-config format.


### PR DESCRIPTION
Tentative fix for https://github.com/git-for-windows/git/issues/3414.