### PR TITLE
gpg-interface: trim CR from ssh-keygen -Y find-principals

### DIFF
--- a/gpg-interface.c
+++ b/gpg-interface.c
@@ -497,7 +497,7 @@ static int verify_ssh_signed_buffer(struct signature_check *sigc,
 			if (!*line)
 				break;
 
-			trust_size = strcspn(line, "\n");
+			trust_size = strcspn(line, "\r\n");
 			principal = xmemdupz(line, trust_size);
 
 			child_process_init(&ssh_keygen);


### PR DESCRIPTION
It looks like we need to trim `\r` from the output of `ssh-keygen -Y find-principals`'s on Windows, or we end up calling `ssh-keygen -Y verify` with a bogus signer identity, as per screenshot. [ssh-keygen.c:2841](https://github.com/openssh/openssh-portable/blob/master/ssh-keygen.c#L2841) seems to confirm this hypothesis. Signature verification passes with the fix.

Apologies if this isn't the appropriate forum, and thank you for your work on Git for Windows!

-p.

<img width="960" alt="screenshot" src="https://user-images.githubusercontent.com/1391312/143610486-03c40776-42af-401f-8078-4c8c0758c35a.png">
