### PR TITLE
git-artifacts: remove stale outputs

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -27,8 +27,6 @@ env:
 jobs:
   bundle-artifacts:
     runs-on: windows-latest
-    outputs:
-      latest-sdk64-extra-build-id: ${{ steps.determine-latest-sdk64-extra-build-id.outputs.id }}
     steps:
       - name: Configure user
         shell: bash
@@ -100,8 +98,6 @@ jobs:
   pkg:
     runs-on: windows-latest
     needs: bundle-artifacts
-    outputs:
-      latest-sdk64-extra-build-id: ${{ needs.bundle-artifacts.outputs.latest-sdk64-extra-build-id }}
     strategy:
       matrix:
         arch:


### PR DESCRIPTION
Some clean-ups based on running the workflow definition through https://rhysd.github.io/actionlint/