### PR TITLE
Fix custom date formats in i686 builds

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -13,6 +13,8 @@
 #include "win32/fscache.h"
 #include "../attr.h"
 #include "../string-list.h"
+#define SECURITY_WIN32
+#include <sspi.h>
 
 #define HCAST(type, handle) ((type)(intptr_t)handle)
 
@@ -1214,7 +1216,7 @@ size_t mingw_strftime(char *s, size_t max,
 	/* a pointer to the original strftime in case we can't find the UCRT version */
 	static size_t (*fallback)(char *, size_t, const char *, const struct tm *) = strftime;
 	size_t ret;
-	DECLARE_PROC_ADDR(ucrtbase.dll, size_t, strftime, char *, size_t,
+	DECLARE_PROC_ADDR(ucrtbase.dll, size_t, __cdecl, strftime, char *, size_t,
 		const char *, const struct tm *);
 
 	if (INIT_PROC_ADDR(strftime))
@@ -2675,7 +2677,7 @@ enum EXTENDED_NAME_FORMAT {
 
 static char *get_extended_user_info(enum EXTENDED_NAME_FORMAT type)
 {
-	DECLARE_PROC_ADDR(secur32.dll, BOOL, GetUserNameExW,
+	DECLARE_PROC_ADDR(secur32.dll, BOOL, SEC_ENTRY, GetUserNameExW,
 		enum EXTENDED_NAME_FORMAT, LPCWSTR, PULONG);
 	static wchar_t wbuffer[1024];
 	DWORD len;

--- a/compat/win32/flush.c
+++ b/compat/win32/flush.c
@@ -8,7 +8,7 @@ int win32_fsync_no_flush(int fd)
 
 #define FLUSH_FLAGS_FILE_DATA_ONLY 1
 
-       DECLARE_PROC_ADDR(ntdll.dll, NTSTATUS, NtFlushBuffersFileEx,
+       DECLARE_PROC_ADDR(ntdll.dll, NTSTATUS, NTAPI, NtFlushBuffersFileEx,
 			 HANDLE FileHandle, ULONG Flags, PVOID Parameters, ULONG ParameterSize,
 			 PIO_STATUS_BLOCK IoStatusBlock);
 

--- a/compat/win32/lazyload.h
+++ b/compat/win32/lazyload.h
@@ -4,7 +4,7 @@
 /*
  * A pair of macros to simplify loading of DLL functions. Example:
  *
- *   DECLARE_PROC_ADDR(kernel32.dll, BOOL, CreateHardLinkW,
+ *   DECLARE_PROC_ADDR(kernel32.dll, BOOL, WINAPI, CreateHardLinkW,
  *                     LPCWSTR, LPCWSTR, LPSECURITY_ATTRIBUTES);
  *
  *   if (!INIT_PROC_ADDR(CreateHardLinkW))
@@ -25,10 +25,10 @@ struct proc_addr {
 };
 
 /* Declares a function to be loaded dynamically from a DLL. */
-#define DECLARE_PROC_ADDR(dll, rettype, function, ...) \
+#define DECLARE_PROC_ADDR(dll, rettype, convention, function, ...) \
 	static struct proc_addr proc_addr_##function = \
 	{ #dll, #function, NULL, 0 }; \
-	typedef rettype (WINAPI *proc_type_##function)(__VA_ARGS__); \
+	typedef rettype (convention *proc_type_##function)(__VA_ARGS__); \
 	static proc_type_##function function
 
 /*

--- a/compat/win32/trace2_win32_process_info.c
+++ b/compat/win32/trace2_win32_process_info.c
@@ -143,8 +143,8 @@ static void get_is_being_debugged(void)
  */
 static void get_peak_memory_info(void)
 {
-	DECLARE_PROC_ADDR(psapi.dll, BOOL, GetProcessMemoryInfo, HANDLE,
-			  PPROCESS_MEMORY_COUNTERS, DWORD);
+	DECLARE_PROC_ADDR(psapi.dll, BOOL, WINAPI, GetProcessMemoryInfo,
+			  HANDLE, PPROCESS_MEMORY_COUNTERS, DWORD);
 
 	if (INIT_PROC_ADDR(GetProcessMemoryInfo)) {
 		PROCESS_MEMORY_COUNTERS pmc;

--- a/compat/winansi.c
+++ b/compat/winansi.c
@@ -45,8 +45,9 @@ typedef struct _CONSOLE_FONT_INFOEX {
 static void warn_if_raster_font(void)
 {
 	DWORD fontFamily = 0;
-	DECLARE_PROC_ADDR(kernel32.dll, BOOL, GetCurrentConsoleFontEx,
-			HANDLE, BOOL, PCONSOLE_FONT_INFOEX);
+	DECLARE_PROC_ADDR(kernel32.dll, BOOL, WINAPI,
+			GetCurrentConsoleFontEx, HANDLE, BOOL,
+			PCONSOLE_FONT_INFOEX);
 
 	/* don't bother if output was ascii only */
 	if (!non_ascii_used)

--- a/t/helper/test-drop-caches.c
+++ b/t/helper/test-drop-caches.c
@@ -3,6 +3,7 @@
 
 #if defined(GIT_WINDOWS_NATIVE)
 #include "lazyload.h"
+#include <winnt.h>
 
 static int cmd_sync(void)
 {
@@ -86,7 +87,8 @@ static int cmd_dropcaches(void)
 {
 	HANDLE hProcess = GetCurrentProcess();
 	HANDLE hToken;
-	DECLARE_PROC_ADDR(ntdll.dll, DWORD, NtSetSystemInformation, INT, PVOID, ULONG);
+	DECLARE_PROC_ADDR(ntdll.dll, DWORD, NTAPI, NtSetSystemInformation, INT, PVOID,
+		ULONG);
 	SYSTEM_MEMORY_LIST_COMMAND command;
 	int status;
 


### PR DESCRIPTION
In i686 builds, this will crash with a segmentation fault:

```sh
git log --date='format:%Y-%m-%d %H:%M' --pretty='format:%cd'
```

(Note that if you try to reproduce this in a regular Git for Windows SDK, you will have to call `make NDEBUG=1` to be able to reproduce the segmentation fault.)

The reason is that the `strftime()` function is imported with an incorrect calling convention. It is _quite_ timely that Matthias Aßauer submitted [a patch](https://github.com/git/git/pull/1181) to address precisely this bug, and that contribution already made it into upstream's `seen` branch as the `ma/windows-dynload-fix` topic (and is [slated to be fast-tracked into v2.35.0](https://lore.kernel.org/git/nycvar.QRO.7.76.6.2201111412300.1081@tvgsbejvaqbjf.bet/)). This PR backports that topic, along with a fix-up for a patch that has not landed upstream yet so that the result still builds.

This fixes https://github.com/git-for-windows/git/issues/3624