### PR TITLE
getcwd(mingw): handle the case when there is no current working directory

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1409,6 +1409,10 @@ char *mingw_getcwd(char *pointer, int len)
 			return NULL;
 		return pointer;
 	}
+	if (GetFileAttributes(pointer) == INVALID_FILE_ATTRIBUTES) {
+		errno = ENOENT;
+		return NULL;
+	}
 	if (xwcstoutf(pointer, cwd, len) < 0)
 		return NULL;
 	convert_slashes(pointer);


### PR DESCRIPTION
The bug fixed by this topic was noticed due to test failures while rebasing Microsoft's fork of Git onto v2.35.0-rc1. This is a companion to https://github.com/gitgitgadget/git/pull/1120 (with which it conflicts due to as yet unsubmitted patches in the Git for Windows code base).