### PR TITLE
Teach FSCache about case-sensitive filenames

### DIFF
--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -5,6 +5,7 @@
 #include "config.h"
 #include "../../mem-pool.h"
 #include "ntifs.h"
+#include "../../dir.h"
 
 static volatile long initialized;
 static DWORD dwTlsIndex;
@@ -101,7 +102,7 @@ static int fsentry_cmp(void *unused_cmp_data,
 	/* if list parts are equal, compare len and name */
 	if (fse1->len != fse2->len)
 		return fse1->len - fse2->len;
-	return strnicmp(fse1->dirent.d_name, fse2->dirent.d_name, fse1->len);
+	return fspathncmp(fse1->dirent.d_name, fse2->dirent.d_name, fse1->len);
 }
 
 /*


### PR DESCRIPTION
As per https://devblogs.microsoft.com/commandline/per-directory-case-sensitivity-and-wsl/, it is possible to turn on case-sensitivity on a directory-by-directory basis. While Git is not really prepared for the situation that a worktree has some directories where filenames are case-sensitive and other where filenames are case-insensitive, Git should at least handle the case where the worktree has filename case-sensitivity turned on in its entirety. This actually works!

Except for FSCache. Which was [reported as a bug](https://github.com/git-for-windows/git/issues/3686), and which this here PR seems to fix.