### PR TITLE
fixup! Add a GitHub workflow to generate Git for Windows' Pacman package

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -196,7 +196,7 @@ jobs:
           printf '#!/bin/sh\n\nexec /mingw64/bin/git.exe "$@"\n' >/usr/bin/git &&
 
           # Restrict `PATH` to MSYS2 and to Visual Studio (to let `cv2pdb` find the relevant DLLs)
-          PATH="/mingw64/bin:/usr/bin:/C/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin${{matrix.arch.bin}}:/C/Windows/system32"
+          PATH="/mingw64/bin:/usr/bin:/c/Program Files/Microsoft Visual Studio/2022/Enterprise/Common7/IDE/:/C/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin${{matrix.arch.bin}}:/C/Windows/system32"
 
           type -p mspdb140.dll || exit 1
           sh -x /usr/src/build-extra/please.sh build-mingw-w64-git --only-${{matrix.arch.bitness}}-bit --build-src-pkg -o artifacts HEAD &&


### PR DESCRIPTION
While this is needed to future-proof the `git-artifacts` workflow, it is not crucial to Do It Right Now. However, it presents a perfect excuse to build a new [snapshot](https://wingit.blob.core.windows.net/files/index.html) once [v3.3.4 of the MSYS2 runtime has been built](https://dev.azure.com/Git-for-Windows/git/_build/results?buildId=94421&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a).