### PR TITLE
Update the die() preserve-merges messages to help some users

### DIFF
--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1179,7 +1179,10 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 			     builtin_rebase_usage, 0);
 
 	if (preserve_merges_selected)
-		die(_("--preserve-merges was replaced by --rebase-merges"));
+		die(_("--preserve-merges was replaced by --rebase-merges\n"
+			"Also, check your `pull` configuration settings\n"
+			"`git config --show-scope --show-origin --get-regexp 'pull.*'`\n"
+			"which may also invoke this option."));
 
 	if (action != ACTION_NONE && total_argc != 2) {
 		usage_with_options(builtin_rebase_usage,

--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1155,7 +1155,9 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 		strbuf_reset(&buf);
 		strbuf_addf(&buf, "%s/rewritten", merge_dir());
 		if (is_directory(buf.buf)) {
-			die("`rebase -p` is no longer supported");
+			die("`rebase --preserve-merges` (-p) is no longer supported.\n"
+			"You still have a `.git/rebase-merge/rewritten` directory, \n"
+			"indicating a `rebase preserve-merge` is still in progress.\n");
 		} else {
 			strbuf_reset(&buf);
 			strbuf_addf(&buf, "%s/interactive", merge_dir());


### PR DESCRIPTION
Hi,

This small update to the die() preserve-merges messages is a response to the reported edge case in the Git-for-Windows [googlegroups thread ](https://groups.google.com/g/git-for-windows/c/3jMWbBlXXHM) where even `git rebase --continue` would die.

The `preserve` option is still offered in the latest editions of Visual Studio (*), despite being deprecated for a long time, so the potential for unfamiliar users to fall into the same possible traps of running a pull-preserve (then with conflicts) on mixed Git versions could still occur. E.g. if the repo is on a network drive, and different users, with different Git versions collaborate on fixing conflicts. 

Let's beef up the die messages to point users toward these resolutions.

(*) I have logged a [feedback ](https://developercommunity.visualstudio.com/t/Git-no-longer-supports-preserve-merges/1671071)with Visual Studio that the Preserve setting should be removed, but initially they redirected it to different issue. I've responded.

Philip