### PR TITLE
mingw: set $env:TERM=xterm-256color for newer OSes

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -3378,9 +3378,20 @@ static void setup_windows_environment(void)
 		convert_slashes(tmp);
 	}
 
-	/* simulate TERM to enable auto-color (see color.c) */
-	if (!getenv("TERM"))
-		setenv("TERM", "cygwin", 1);
+
+	/*
+	 * Make sure TERM is set up correctly to enable auto-color
+	 * (see color.c .) Use "cygwin" for older OS releases which
+	 * works correctly with MSYS2 utilities on older consoles.
+	 */
+	if (!getenv("TERM")) {
+		if ((GetVersion() >> 16) < 15063)
+			setenv("TERM", "cygwin", 0);
+		else {
+			setenv("TERM", "xterm-256color", 0);
+			setenv("COLORTERM", "truecolor", 0);
+		}
+	}
 
 	/* calculate HOME if not set */
 	if (!getenv("HOME")) {


### PR DESCRIPTION
@dscho @phil-blain @rimrul 

Hi guys, this is half of my fix for #3629.

Once this is done I will try to fix quoting/escaping in `$env:EDITOR` which was the other problem there.