### PR TITLE
Fix when lazy caching of network shares tags directories were just created with previously-unhandled attributes

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -471,8 +471,8 @@ static int has_valid_directory_prefix(wchar_t *wfilename)
 		wfilename[n] = L'\0';
 		attributes = GetFileAttributesW(wfilename);
 		wfilename[n] = c;
-		if (attributes == FILE_ATTRIBUTE_DIRECTORY ||
-				attributes == FILE_ATTRIBUTE_DEVICE)
+		if (attributes &
+		    (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_DEVICE))
 			return 1;
 		if (attributes == INVALID_FILE_ATTRIBUTES)
 			switch (GetLastError()) {


### PR DESCRIPTION
This fix for the issue : https://github.com/git-for-windows/git/issues/3727

Use case :
Creation of a tag in the form "parent/child".

Exemple :
 > git tag -a -m "my message" tagdir/mytag

Context :
  $ git --version --build-options
    git version 2.35.1.windows.2
    cpu: x86_64
    built from commit: 5437f0fd368c7faf1a0b5e1fef048232c1f2a3e6
    sizeof-long: 4
    sizeof-size_t: 8
    shell-path: /bin/sh
    feature: fsmonitor--daemon
  $ cmd.exe /c ver
    Microsoft Windows [Version 10.0.17763.2565]

Error :
  fatal: cannot lock ref 'refs/tags/tagdir/mytag': unable to resolve reference 'refs/tags/tagdir/mytag': Not a directory

Problem analysis:
GetFileAttributesExW used in mingw_lstat function in git/compat/mingw.c can raise an error ERROR_PATH_NOT_FOUND.
In this case, the has_valid_directory_prefix is used to check if the parent directory exists.
So that, when the parent directory exists, mingw_lstat returns ENOTDIR.
ENOTDIR is not managed by the caller code (files_read_raw_ref in git/refs/files-backend.c).
It probably should.

Conclusion
This commit enables to take into account the case when ENOTDIR is returned by mingw_lstat.
