### PR TITLE
Try to advise about core.useBuiltinFSMonitor's deprecation only once

### DIFF
--- a/fsmonitor-settings.c
+++ b/fsmonitor-settings.c
@@ -59,9 +59,12 @@ static int check_deprecated_builtin_config(struct repository *r)
 	 * the check resulted the config being set by this (deprecated) setting.
 	 */
 	if(!repo_config_get_bool(r, "core.useBuiltinFSMonitor", &core_use_builtin_fsmonitor)) {
-		advise_if_enabled(ADVICE_USE_CORE_FSMONITOR_CONFIG,
-				  _("core.useBuiltinFSMonitor will be deprecated "
-				    "soon; use core.fsmonitor instead"));
+		if (!git_env_bool("GIT_SUPPRESS_USEBUILTINFSMONITOR_ADVICE", 0)) {
+			advise_if_enabled(ADVICE_USE_CORE_FSMONITOR_CONFIG,
+					  _("core.useBuiltinFSMonitor will be deprecated "
+					    "soon; use core.fsmonitor instead"));
+			setenv("GIT_SUPPRESS_USEBUILTINFSMONITOR_ADVICE", "1", 1);
+		}
 		if (core_use_builtin_fsmonitor) {
 			fsm_settings__set_ipc(r);
 			return 1;


### PR DESCRIPTION
I noticed this a few times but was not able to come up with an easy way to trigger it, but I _think_ the code is obviously correct 😄 