### PR TITLE
fixup! fsmonitor: reintroduce core.useBuiltinFSMonitor

### DIFF
--- a/fsmonitor-settings.c
+++ b/fsmonitor-settings.c
@@ -50,7 +50,7 @@ static int check_for_incompatible(struct repository *r)
 
 static int check_deprecated_builtin_config(struct repository *r)
 {
-	int core_use_builtin_fsmonitor;
+	int core_use_builtin_fsmonitor = 0;
 
 	/*
 	 * If 'core.useBuiltinFSMonitor' is set, print a deprecation warning
@@ -58,17 +58,16 @@ static int check_deprecated_builtin_config(struct repository *r)
 	 * set to true, set the appropriate mode and return 1 indicating that
 	 * the check resulted the config being set by this (deprecated) setting.
 	 */
-	if(!repo_config_get_bool(r, "core.useBuiltinFSMonitor", &core_use_builtin_fsmonitor)) {
+	if(!repo_config_get_bool(r, "core.useBuiltinFSMonitor", &core_use_builtin_fsmonitor) &&
+	   core_use_builtin_fsmonitor) {
 		if (!git_env_bool("GIT_SUPPRESS_USEBUILTINFSMONITOR_ADVICE", 0)) {
 			advise_if_enabled(ADVICE_USE_CORE_FSMONITOR_CONFIG,
 					  _("core.useBuiltinFSMonitor will be deprecated "
 					    "soon; use core.fsmonitor instead"));
 			setenv("GIT_SUPPRESS_USEBUILTINFSMONITOR_ADVICE", "1", 1);
 		}
-		if (core_use_builtin_fsmonitor) {
-			fsm_settings__set_ipc(r);
-			return 1;
-		}
+		fsm_settings__set_ipc(r);
+		return 1;
 	}
 
 	return 0;


### PR DESCRIPTION
This change to warn about core.useBuiltinFSMonitor is a good one, but it
is too aggressive. If a user has set core.useBuiltinFSMonitor=false,
then that warning shows up.

Perhaps there is value in warning users that their explicit disabling of
the feature will stop working. However, VFS for Git does this
assignment, so all users on those enlistments will start getting
warnings after upgrading Git. This situation is probably much more
likely than a typical user disabling the experimental feature
themselves.

Putting in this fix is easier than rereleasing VFS for Git.