### PR TITLE
Include trailing slash in prefix migration instructions

### DIFF
--- a/path.c
+++ b/path.c
@@ -741,7 +741,7 @@ char *interpolate_path(const char *path, int real_home)
 
 #ifdef __MINGW32__
 	if (path[0] == '/') {
-		warning(_("encountered old-style '%s' that should be '%%(prefix)%s'"), path, path);
+		warning(_("encountered old-style '%s' that should be '%%(prefix)/%s'"), path, path);
 		return system_path(path + 1);
 	}
 #endif


### PR DESCRIPTION
After attempting to add directory on a network share to the `safe.directory` configuration with, for example:

```
git config --global --add safe.directory //servername/repos/myrepo
```

The warning about an outdated path style:

```
warning: encountered old-style '//servername/repos/myrepo' that should be '%(prefix)//servername/repos/myrepo'
```

However, the warning is missing a trailing `/` behind the prefix.

This PR fixes the warning such that the resulting configuration works.


Also see https://stackoverflow.com/a/71859164/4473230

Closes #3786