### PR TITLE
.github/ISSUE_TEMPLATE.md: add PowerShell syntax for install options

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -26,6 +26,7 @@ $ cmd.exe /c ver
 > type "C:\Program Files\Git\etc\install-options.txt"
 > type "C:\Program Files (x86)\Git\etc\install-options.txt"
 > type "%USERPROFILE%\AppData\Local\Programs\Git\etc\install-options.txt"
+> type "$env:USERPROFILE\AppData\Local\Programs\Git\etc\install-options.txt"
 $ cat /etc/install-options.txt
 
 ** insert your machine's response here **


### PR DESCRIPTION
PowerShell does not understand the Command Prompt `%ENV_VAR%` syntax, it
uses `$env:ENV_VAR` instead. Offer such an invocation to the reader in
the "What options did you set as part of the installation" question.