### PR TITLE
monitor-components: track PCRE2, too

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -70,6 +70,8 @@ jobs:
           - label: perl
             feed: https://github.com/Perl/perl5/tags.atom
             title-pattern: ^(?!.*(5\.[0-9]+[13579]|RC))
+          - label: pcre2
+            feed: https://github.com/PCRE2Project/pcre2/tags.atom
       fail-fast: false
     steps:
       - uses: git-for-windows/rss-to-issues@v0


### PR DESCRIPTION
Since PCRE2 moved to GitHub, we can use our regular workflow to monitor for PCRE2 updates, too.

Previously, we used https://github.com/git-for-windows/track-website-changes for that (scraping the website, which is actually out of date right now, still showing v10.39).