### PR TITLE
ci: fix `windows-build` with GCC v12.x

### DIFF
--- a/Documentation/RelNotes/2.36.1.txt
+++ b/Documentation/RelNotes/2.36.1.txt
@@ -1,0 +1,33 @@
+Git v2.36.1 Release Notes
+=========================
+
+Fixes since v2.36
+-----------------
+
+ * "git submodule update" without pathspec should silently skip an
+   uninitialized submodule, but it started to become noisy by mistake.
+
+ * "diff-tree --stdin" has been broken for about a year, but 2.36
+   release broke it even worse by breaking running the command with
+   <pathspec>, which in turn broke "gitk" and got noticed.  This has
+   been corrected by aligning its behaviour to that of "log".
+
+ * Regression fix for 2.36 where "git name-rev" started to sometimes
+   reference strings after they are freed.
+
+ * "git show <commit1> <commit2>... -- <pathspec>" lost the pathspec
+   when showing the second and subsequent commits, which has been
+   corrected.
+
+ * "git fast-export -- <pathspec>" lost the pathspec when showing the
+   second and subsequent commits, which has been corrected.
+
+ * "git format-patch <args> -- <pathspec>" lost the pathspec when
+   showing the second and subsequent commits, which has been
+   corrected.
+
+ * Get rid of a bogus and over-eager coccinelle rule.
+
+ * Correct choices of C compilers used in various CI jobs.
+
+Also contains minor documentation updates and code clean-ups.

--- a/GIT-VERSION-GEN
+++ b/GIT-VERSION-GEN
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 GVF=GIT-VERSION-FILE
-DEF_VER=v2.36.0
+DEF_VER=v2.36.1
 
 LF='
 '

--- a/RelNotes
+++ b/RelNotes
@@ -1,1 +1,1 @@
-Documentation/RelNotes/2.36.0.txt
+Documentation/RelNotes/2.36.1.txt


### PR DESCRIPTION
A recent update of GCC in Git for Windows' SDK (a subset of which is used in Git's CI/PR builds) broke the build. Lets' fix it.

This is a companion of https://github.com/gitgitgadget/git/pull/1238.