### PR TITLE
Use env as interpreter for all exe and scripts.

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1530,41 +1530,6 @@ static const char *quote_arg_msys2(const char *arg)
 	return strbuf_detach(&buf, 0);
 }
 
-static const char *parse_interpreter(const char *cmd)
-{
-	static char buf[MAX_PATH];
-	char *p, *opt;
-	int n, fd;
-
-	/* don't even try a .exe */
-	n = strlen(cmd);
-	if (n >= 4 && !strcasecmp(cmd+n-4, ".exe"))
-		return NULL;
-
-	fd = open(cmd, O_RDONLY);
-	if (fd < 0)
-		return NULL;
-	n = read(fd, buf, sizeof(buf)-1);
-	close(fd);
-	if (n < 4)	/* at least '#!/x' and not error */
-		return NULL;
-
-	if (buf[0] != '#' || buf[1] != '!')
-		return NULL;
-	buf[n] = '\0';
-	p = buf + strcspn(buf, "\r\n");
-	if (!*p)
-		return NULL;
-
-	*p = '\0';
-	if (!(p = strrchr(buf+2, '/')) && !(p = strrchr(buf+2, '\\')))
-		return NULL;
-	/* strip options */
-	if ((opt = strchr(p+1, ' ')))
-		*opt = '\0';
-	return p+1;
-}
-
 /*
  * exe_only means that we only want to detect .exe files, but not scripts
  * (which do not have an extension)
@@ -2151,26 +2116,20 @@ pid_t mingw_spawnvpe(const char *cmd, const char **argv, char **deltaenv,
 		pid = -1;
 	}
 	else {
-		const char *interpr = parse_interpreter(prog);
-
-		if (interpr) {
-			const char *argv0 = argv[0];
-			char *iprog = path_lookup(interpr, 1);
+		const char *interpr = "env.exe";
+		const char *argv0 = argv[0];
+		char *iprog = path_lookup(interpr, 1);
+		if (!iprog) {
+			errno = ENOENT;
+			pid = -1;
+		}
+		else {
 			argv[0] = prog;
-			if (!iprog) {
-				errno = ENOENT;
-				pid = -1;
-			}
-			else {
-				pid = mingw_spawnve_fd(iprog, argv, deltaenv, dir, interpr,
-						       fhin, fhout, fherr);
-				free(iprog);
-			}
+			pid = mingw_spawnve_fd(iprog, argv, deltaenv, dir, interpr,
+							fhin, fhout, fherr);
+			free(iprog);
 			argv[0] = argv0;
 		}
-		else
-			pid = mingw_spawnve_fd(prog, argv, deltaenv, dir, NULL,
-					       fhin, fhout, fherr);
 		free(prog);
 	}
 	return pid;
@@ -2178,12 +2137,10 @@ pid_t mingw_spawnvpe(const char *cmd, const char **argv, char **deltaenv,
 
 static int try_shell_exec(const char *cmd, char *const *argv)
 {
-	const char *interpr = parse_interpreter(cmd);
+	const char *interpr = "env.exe";
 	char *prog;
 	int pid = 0;
 
-	if (!interpr)
-		return 0;
 	prog = path_lookup(interpr, 1);
 	if (prog) {
 		int exec_id;


### PR DESCRIPTION
Git uses a lot scripts which requires bash, perl, and python. The interpreter is specified by shebang. However, Windows don't know about shebang, and `CreateProcess` could not spawn a script file.

Therefore, git chose to parse the shebang and find the interpreter itself. The interpreter is found in `PATH`. It is reasonable because git is a Windows native program, and doesn't know anything about POSIX path. However, the method is not that perfect.

Git requires a MSYS2 perl. However, MSYS2 also provides a MinGW perl. If both perl are installed (for example, `texlive` requires a MinGW perl), git will mistakenly find the MinGW perl, and scripts require perl (e.g. `git-send-email`) will raise errors. The shebang is right `#!/usr/bin/perl`, but actually git only recognizes `perl` and finds the first one in the `PATH`.

Luckily there's a program in MSYS2 called `env`. It is commonly used in *NIX systems to find the right environment. The MSYS2 `env` could not only parse the shebang, but also recognize all kinds of path: POSIX path, Windows path, and even mixed path (`C:/msys64/usr/bin\less.exe`). Technically, it could be the interpreter for all executables and scripts.

This pull request removes the naïve parser of shebang, and just finds `env.exe` as the interpreter. It should be in the `PATH` in MSYS2 environment. I don't open this one to the upstream `git/git` because it assumes MSYS2 env.