### PR TITLE
winansi: check result before using Name for pty

### DIFF
--- a/compat/winansi.c
+++ b/compat/winansi.c
@@ -573,6 +573,9 @@ static void detect_msys_tty(int fd)
 	if (!NT_SUCCESS(NtQueryObject(h, ObjectNameInformation,
 			buffer, sizeof(buffer) - 2, &result)))
 		return;
+	if (result < sizeof(*nameinfo) || !nameinfo->Name.Buffer ||
+		!nameinfo->Name.Length)
+		return;
 	name = nameinfo->Name.Buffer;
 	name[nameinfo->Name.Length / sizeof(*name)] = 0;
 


### PR DESCRIPTION
NtQueryObject under Wine can return a success but fill out no name.
In those situations, Wine will set Buffer to NULL, and set result to
the sizeof(OBJECT_NAME_INFORMATION).

Running a command such as

echo "$(git.exe --version 2>/dev/null)"

will crash due to a NULL pointer dereference when the code attempts to
null terminate the buffer, although, weirdly, removing the subshell or
redirecting stdout to a file will not trigger the crash.

Alternatives include checking Buffer itself, however, I am not sure
what is the official behavior of the function due to a lack of
documentation.
Another alternative is to check the Length field, but similar to above,
I do not know what the official behavior is.

This code is based on the behavior of NtQueryObject under wine and
reactos.

Signed-off-by: Christopher Degawa <ccom@randomderp.com>

opened https://github.com/gitgitgadget/git/pull/1245 for now