### PR TITLE
Offer more details to users about the ownership check on FAT32

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -3486,6 +3486,22 @@ static PSID get_current_user_sid(void)
 	return result;
 }
 
+static int acls_supported(const char *path)
+{
+	size_t offset = offset_1st_component(path);
+	WCHAR wroot[MAX_PATH];
+	DWORD file_system_flags;
+
+	if (offset &&
+	    xutftowcs_path_ex(wroot, path, MAX_PATH, offset,
+			      MAX_PATH, 0) > 0 &&
+	    GetVolumeInformationW(wroot, NULL, 0, NULL, NULL,
+				  &file_system_flags, NULL, 0))
+		return !!(file_system_flags & FILE_PERSISTENT_ACLS);
+
+	return 0;
+}
+
 int is_path_owned_by_current_sid(const char *path)
 {
 	WCHAR wpath[MAX_PATH];
@@ -3541,7 +3557,14 @@ int is_path_owned_by_current_sid(const char *path)
 			 * okay, too.
 			 */
 			result = 1;
-		else if (git_env_bool("GIT_TEST_DEBUG_UNSAFE_DIRECTORIES", 0)) {
+		else if (IsWellKnownSid(sid, WinWorldSid) &&
+			 git_env_bool("GIT_TEST_DEBUG_UNSAFE_DIRECTORIES", 0) &&
+			 !acls_supported(path)) {
+			/*
+			 * On FAT32 volumes, ownership is not actually recorded.
+			 */
+			warning("'%s' is on a file system that does not record ownership", path);
+		} else if (git_env_bool("GIT_TEST_DEBUG_UNSAFE_DIRECTORIES", 0)) {
 			LPSTR str1, str2, to_free1 = NULL, to_free2 = NULL;
 
 			if (ConvertSidToStringSidA(sid, &str1))

--- a/setup.c
+++ b/setup.c
@@ -1385,10 +1385,17 @@ const char *setup_git_directory_gently(int *nongit_ok)
 		if (!nongit_ok) {
 			struct strbuf prequoted = STRBUF_INIT;
 			struct strbuf quoted = STRBUF_INIT;
+			struct strbuf hint = STRBUF_INIT;
 
 #ifdef __MINGW32__
 			if (dir.buf[0] == '/')
 				strbuf_addstr(&prequoted, "%(prefix)/");
+			if (!git_env_bool("GIT_TEST_DEBUG_UNSAFE_DIRECTORIES", 0))
+				strbuf_addstr(&hint,
+					      _("\n\nSet the environment variable "
+						"GIT_TEST_DEBUG_UNSAFE_DIRECTORIES=true "
+						"and run\n"
+						"again for more information."));
 #endif
 
 			strbuf_add(&prequoted, dir.buf, dir.len);
@@ -1397,8 +1404,8 @@ const char *setup_git_directory_gently(int *nongit_ok)
 			die(_("unsafe repository ('%s' is owned by someone else)\n"
 			      "To add an exception for this directory, call:\n"
 			      "\n"
-			      "\tgit config --global --add safe.directory %s"),
-			    dir.buf, quoted.buf);
+			      "\tgit config --global --add safe.directory %s%s"),
+			    dir.buf, quoted.buf, hint.buf);
 		}
 		*nongit_ok = 1;
 		break;


### PR DESCRIPTION
Since FAT cannot store ownership information, users cannot do anything about "unsafe ownership" there. Except exempt the directory via the `safe.directory` mechanism. Inform the users about this (rather than the bogus "World owns this" message).

Since we cannot know at the time the ownership check is performed whether Git will require a valid repository or not, we keep mum in the general case, and only say something if the `GIT_TEST_DEBUG_UNSAFE_DIRECTORIES` knob is on.

Speaking of that knob, we now hint to the users that they can use this knob to find out more, in case that the ownership fails (and Git absolutely requires a valid repository).

This addresses https://github.com/git-for-windows/git/issues/3886