### PR TITLE
Fix parallel checkout with FSCache

### DIFF
--- a/parallel-checkout.c
+++ b/parallel-checkout.c
@@ -633,6 +633,7 @@ static void write_items_sequentially(struct checkout *state)
 {
 	size_t i;
 
+	flush_fscache();
 	for (i = 0; i < parallel_checkout.nr; i++) {
 		struct parallel_checkout_item *pc_item = &parallel_checkout.items[i];
 		write_pc_item(pc_item, state);


### PR DESCRIPTION
This actually targets the parallel checkout that is not parallel, which is the case when not enough work is to be done to justify fanning out into multiple workers.

This addresses https://github.com/git-for-windows/git/issues/3904