### PR TITLE
Add support for CLANGARM64 target

### DIFF
--- a/.github/workflows/clangarm64-build.yml
+++ b/.github/workflows/clangarm64-build.yml
@@ -1,0 +1,25 @@
+name: CLANG build ARM64
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  clang-build:
+    runs-on: [Windows, ARM64]
+    env:
+      NO_PERL: 1
+    steps:
+      - uses: actions/checkout@v3
+      - uses: git-for-windows/setup-git-for-windows-sdk@v1
+        with:
+          flavor: makepkg-git
+          architecture: aarch64
+          # This assumes that the job is running on a self-hosted runner,
+          # in which case we need to cleanup SDK files.
+          cleanup: true
+      - name: Build Git CLANGARM64
+        run: make -j`nproc`

--- a/compat/bswap.h
+++ b/compat/bswap.h
@@ -35,7 +35,19 @@ static inline uint64_t default_bswap64(uint64_t val)
 #undef bswap32
 #undef bswap64
 
-#if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+/**
+ * __has_builtin is available since Clang 10 and GCC 10.
+ * Below is a fallback for older compilers.
+ */
+#ifndef __has_builtin
+	#define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(__builtin_bswap32) && __has_builtin(__builtin_bswap64)
+#define bswap32(x) __builtin_bswap32((x))
+#define bswap64(x) __builtin_bswap64((x))
+
+#elif defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
 
 #define bswap32 git_bswap32
 static inline uint32_t git_bswap32(uint32_t x)

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -706,6 +706,10 @@ else
 			prefix = /mingw64
 			HOST_CPU = x86_64
 			BASIC_LDFLAGS += -Wl,--pic-executable,-e,mainCRTStartup
+		else ifeq (CLANGARM64,$(MSYSTEM))
+			prefix = /clangarm64
+			HOST_CPU = aarch64
+			BASIC_LDFLAGS += -Wl,--pic-executable,-e,mainCRTStartup
 		else
 			COMPAT_CFLAGS += -D_USE_32BIT_TIME_T
 			BASIC_LDFLAGS += -Wl,--large-address-aware


### PR DESCRIPTION
**This requires an ARM64-machine with Windows 11 installed (which supports x64 emulation for MSYS2)**

This is basically a successor of #3427 but stays _very_ close to Git for Windows's SDK and integration with MSYS2. Thanks to the work the MSYS2 team did on `clangarm64`, this actually becomes very easy to do now!

### The main idea

- Use the main MSYS2/git-sdk-64 setup, which works on Windows 11 on ARM thanks to x64-emulation
- Configure the official `clangarm64` MSYS2 repo
- Install `mingw-w64-clang-aarch64-toolchain` which contains the ARM64-native Clang compiler

### CI results

Successful CI run on my ARM64 machine: https://github.com/dennisameling/git/actions/runs/2557291542. The `make -j8` command took 3m9s on my machine, which I think is very decent.

Just to be 100% clear that the compiler itself is indeed ARM64-native:

![image](https://user-images.githubusercontent.com/17739158/175617625-e3026942-be98-493a-96e3-cb4648a7d8f8.png)

Note that `gcc.exe` is basically a link to `clang.exe` on MSYS2 `clangarm64`.

### Remarks/questions

- Shall I leave out the CI pipeline from this PR (or make it a manual job through [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) so folks can run it from their forks), as it requires a native ARM64 device? Note that Azure [now has ARM64 VMs in public preview](https://azure.microsoft.com/en-us/blog/now-in-preview-azure-virtual-machines-with-ampere-altra-armbased-processors/) -  including Windows 11 Pro/Enterprise - so self-hosted GitHub Runners on Azure ARM64 VMs are theoretically possible already. I simply installed a self-hosted runner on my Surface Pro X in a VM.
- Would it make sense to create a `git-sdk-ARM64` with x64 MSYS2 and the `clangarm64` packages shown in the attached workflow? I [updated](https://github.com/dennisameling/setup-git-for-windows-sdk/commit/01872063f7b133eae0732176f08e309a69c22b4d) `setup-git-for-windows-sdk` with some basic support for this scenario (as a POC).
- I disabled `USE_NED_ALLOCATOR` on `CLANGARM64` as I ran into errors. The resulting binary works just fine in my limited testing - would you consider a build without `nedmalloc` a feasible option for a "first version with ARM64 support"? Happy to do some performance testing if you could point me to some commands I can test.
- I'll need to do quite some updates to `build-extra` in order to add support for building the release packages (mingit, installer, etc.). As mentioned in [this issue](https://github.com/git-for-windows/git/issues/3107) before, MSVC builds are problematic [due to the VC++ redistributable requirement](https://github.com/git-for-windows/git/issues/3107#issuecomment-877770526). Should we consider that option "off the table" and work towards this MSYS2/`clangarm64` solution instead? Just want to make sure that I'm implementing a clean solution in `build-extra` and leaving the MSVC-scenario out of that would probably make things a bit simpler.

```
$ /clangarm64/bin/git --version --build-options
git version 2.37.0.rc2.windows.1.7.g45a475aeb8.dirty
cpu: aarch64
built from commit: 45a475aeb84a53a6432b1ede716a4b6f05e11947
sizeof-long: 4
sizeof-size_t: 8
shell-path: /bin/sh
feature: fsmonitor--daemon
```