### PR TITLE
fixup for the vimdiff regression tests

### DIFF
--- a/mergetools/vimdiff
+++ b/mergetools/vimdiff
@@ -623,7 +623,7 @@ run_unit_tests () {
 		done
 	}
 
-	base_present=1
+	base_present=false
 	LOCAL='lo cal'
 	BASE='ba se'
 	REMOTE="' '"


### PR DESCRIPTION
Whoops. The final version that made it into upstream had this change, but I forgot to include it when opening [the Git for Windows PR](https://github.com/git-for-windows/git/pull/3960)... 

Technically, it is not all that crucial to get this fixup into Git for Windows, but it provides a fine excuse for building a new [snapshot](https://wingit.blob.core.windows.net/files/index.html) that includes Bash v5.1...