### PR TITLE
Remove fsmonitor check for remote (network) file systems.

### DIFF
--- a/compat/fsmonitor/fsm-settings-darwin.c
+++ b/compat/fsmonitor/fsm-settings-darwin.c
@@ -65,9 +65,6 @@ static enum fsmonitor_reason check_volume(struct repository *r)
 			 "statfs('%s') [type 0x%08x][flags 0x%08x] '%s'",
 			 r->worktree, fs.f_type, fs.f_flags, fs.f_fstypename);
 
-	if (!(fs.f_flags & MNT_LOCAL))
-		return FSMONITOR_REASON_REMOTE;
-
 	if (!strcmp(fs.f_fstypename, "msdos")) /* aka FAT32 */
 		return FSMONITOR_REASON_NOSOCKETS;
 

--- a/compat/fsmonitor/fsm-settings-win32.c
+++ b/compat/fsmonitor/fsm-settings-win32.c
@@ -111,13 +111,6 @@ static enum fsmonitor_reason check_remote(struct repository *r)
 			 "DriveType '%s' L'%ls' (%u)",
 			 r->worktree, wfullpath, driveType);
 
-	if (driveType == DRIVE_REMOTE) {
-		trace_printf_key(&trace_fsmonitor,
-				 "check_remote('%s') true",
-				 r->worktree);
-		return FSMONITOR_REASON_REMOTE;
-	}
-
 	return FSMONITOR_REASON_OK;
 }
 

--- a/fsmonitor-settings.c
+++ b/fsmonitor-settings.c
@@ -247,12 +247,6 @@ char *fsm_settings__get_incompatible_msg(const struct repository *r,
 			    r->worktree);
 		goto done;
 
-	case FSMONITOR_REASON_REMOTE:
-		strbuf_addf(&msg,
-			    _("remote repository '%s' is incompatible with fsmonitor"),
-			    r->worktree);
-		goto done;
-
 	case FSMONITOR_REASON_VFS4GIT:
 		strbuf_addf(&msg,
 			    _("virtual repository '%s' is incompatible with fsmonitor"),

--- a/fsmonitor-settings.h
+++ b/fsmonitor-settings.h
@@ -18,7 +18,6 @@ enum fsmonitor_reason {
 	FSMONITOR_REASON_OK, /* no incompatibility or when disabled */
 	FSMONITOR_REASON_BARE,
 	FSMONITOR_REASON_ERROR, /* FS error probing for compatibility */
-	FSMONITOR_REASON_REMOTE,
 	FSMONITOR_REASON_VFS4GIT, /* VFS for Git virtualization */
 	FSMONITOR_REASON_NOSOCKETS, /* NTFS,FAT32 do not support Unix sockets */
 };

--- a/po/bg.po
+++ b/po/bg.po
@@ -16445,10 +16445,6 @@ msgid "repository '%s' is incompatible with fsmonitor due to errors"
 msgstr "хранилището „%s“ е несъвместимо с fsmonitor поради грешки"
 
 #, c-format
-msgid "remote repository '%s' is incompatible with fsmonitor"
-msgstr "отдалеченото хранилище „%s“ е съвместимо с fsmonitor"
-
-#, c-format
 msgid "virtual repository '%s' is incompatible with fsmonitor"
 msgstr "виртуалното хранилище „%s“ е несъвместимо с fsmonitor"
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -16091,10 +16091,6 @@ msgid "repository '%s' is incompatible with fsmonitor due to errors"
 msgstr ""
 
 #, fuzzy, c-format
-msgid "remote repository '%s' is incompatible with fsmonitor"
-msgstr "%s és incompatible amb %s"
-
-#, fuzzy, c-format
 msgid "virtual repository '%s' is incompatible with fsmonitor"
 msgstr "%s és incompatible amb %s"
 

--- a/po/de.po
+++ b/po/de.po
@@ -16207,10 +16207,6 @@ msgid "repository '%s' is incompatible with fsmonitor due to errors"
 msgstr "Repository '%s' ist wegen Fehler inkompatibel mit fsmonitor"
 
 #, c-format
-msgid "remote repository '%s' is incompatible with fsmonitor"
-msgstr "Remote-Repository '%s' ist inkompatibel mit fsmonitor"
-
-#, c-format
 msgid "virtual repository '%s' is incompatible with fsmonitor"
 msgstr "virtuelles Repository '%s' ist inkompatibel mit fsmonitor"
 

--- a/po/es.po
+++ b/po/es.po
@@ -15917,10 +15917,6 @@ msgid "repository '%s' is incompatible with fsmonitor due to errors"
 msgstr ""
 
 #, fuzzy, c-format
-msgid "remote repository '%s' is incompatible with fsmonitor"
-msgstr "%s es incompatible con %s"
-
-#, fuzzy, c-format
 msgid "virtual repository '%s' is incompatible with fsmonitor"
 msgstr "%s es incompatible con %s"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -16203,10 +16203,6 @@ msgid "repository '%s' is incompatible with fsmonitor due to errors"
 msgstr "le dépôt '%s' est incompatible avec fsmonitor à cause d'erreurs"
 
 #, c-format
-msgid "remote repository '%s' is incompatible with fsmonitor"
-msgstr "le dépôt distant '%s' est incompatible avec fsmonitor"
-
-#, c-format
 msgid "virtual repository '%s' is incompatible with fsmonitor"
 msgstr "le dépôt virtuel '%s' est incompatible avec fsmonitor"
 

--- a/po/id.po
+++ b/po/id.po
@@ -19718,11 +19718,6 @@ msgstr ""
 
 #: fsmonitor-settings.c
 #, c-format
-msgid "remote repository '%s' is incompatible with fsmonitor"
-msgstr ""
-
-#: fsmonitor-settings.c
-#, c-format
 msgid "virtual repository '%s' is incompatible with fsmonitor"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -15472,10 +15472,6 @@ msgid "repository '%s' is incompatible with fsmonitor due to errors"
 msgstr ""
 
 #, c-format
-msgid "remote repository '%s' is incompatible with fsmonitor"
-msgstr ""
-
-#, c-format
 msgid "virtual repository '%s' is incompatible with fsmonitor"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -15694,10 +15694,6 @@ msgid "repository '%s' is incompatible with fsmonitor due to errors"
 msgstr "arkivet \"%s\" är inkompatibelt med fsmonitor på grund av fel"
 
 #, c-format
-msgid "remote repository '%s' is incompatible with fsmonitor"
-msgstr "fjärrarkivet \"%s\" är inkompatibelt med fsmonitor"
-
-#, c-format
 msgid "virtual repository '%s' is incompatible with fsmonitor"
 msgstr "det virtuella arkivet \"%s\" är inkompatibelt med fsmonitor"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -15791,10 +15791,6 @@ msgid "repository '%s' is incompatible with fsmonitor due to errors"
 msgstr "'%s' deposu, hatalardan dolayı fsmonitor ile uyumsuz"
 
 #, c-format
-msgid "remote repository '%s' is incompatible with fsmonitor"
-msgstr "uzak depo '%s', fsmonitor ile uyumsuz"
-
-#, c-format
 msgid "virtual repository '%s' is incompatible with fsmonitor"
 msgstr "sanal depo '%s', fsmonitor ile uyumsuz"
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -15840,10 +15840,6 @@ msgid "repository '%s' is incompatible with fsmonitor due to errors"
 msgstr "kho '%s' là không tương thích với fsmonitor bởi vì có lỗi"
 
 #, c-format
-msgid "remote repository '%s' is incompatible with fsmonitor"
-msgstr "kho trên mạng '%s' là không tương thích với fsmonitor"
-
-#, c-format
 msgid "virtual repository '%s' is incompatible with fsmonitor"
 msgstr "kho ảo '%s' là không tương thích với fsmonitor"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -19585,11 +19585,6 @@ msgstr "因为错误，仓库 '%s' 与 fsmonitor 不兼容"
 
 #: fsmonitor-settings.c
 #, c-format
-msgid "remote repository '%s' is incompatible with fsmonitor"
-msgstr "远程仓库 '%s' 与 fsmonitor 不兼容"
-
-#: fsmonitor-settings.c
-#, c-format
 msgid "virtual repository '%s' is incompatible with fsmonitor"
 msgstr "虚拟仓库 '%s' 与 fsmonitor 不兼容"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -19434,11 +19434,6 @@ msgstr "版本庫 “%s” 因錯誤而與 fsmonitor 不相容"
 
 #: fsmonitor-settings.c
 #, c-format
-msgid "remote repository '%s' is incompatible with fsmonitor"
-msgstr "遠端版本庫 “%s” 與 fsmonitor 不相容"
-
-#: fsmonitor-settings.c
-#, c-format
 msgid "virtual repository '%s' is incompatible with fsmonitor"
 msgstr "虛擬版本庫 “%s” 與 fsmonitor 不相容"
 


### PR DESCRIPTION
Most modern Samba-based filers have the necessary support to enable fsmonitor on network-mounted repos. Leave the check in place for reporting/logging purposes but do not have it raise an error.