### PR TITLE
monitor-updates: add libfido2 and libcbor

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -39,6 +39,10 @@ jobs:
             aggregate: true
           - label: openssh
             feed: https://github.com/openssh/openssh-portable/tags.atom
+          - label: libfido2
+            feed: https://github.com/Yubico/libfido2/tags.atom
+          - label: libcbor
+            feed: https://github.com/PJK/libcbor/tags.atom
           - label: openssl
             feed: https://github.com/openssl/openssl/tags.atom
             title-pattern: ^(?!.*alpha)


### PR DESCRIPTION
We also need to monitor libfido2 (and its dependency libcbor) because that library is responsible for support of security keys in OpenSSH, e.g. making it work with Windows Hello.