### PR TITLE
Fix global repository field not being cleared

### DIFF
--- a/repository.c
+++ b/repository.c
@@ -46,7 +46,7 @@ static void repo_set_commondir(struct repository *repo,
 {
 	struct strbuf sb = STRBUF_INIT;
 
-	free(repo->commondir);
+	FREE_AND_NULL(repo->commondir);
 
 	if (commondir) {
 		repo->different_commondir = 1;


### PR DESCRIPTION
It is checked for w.r.t. global repository struct down in the callstack in compatibility layer for MinGW before being assigned in the function that `free()`'d it.