### PR TITLE
ci: fix the `linux-leaks` job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1323,6 +1323,7 @@ BASIC_CFLAGS += -DSHA1DC_FORCE_ALIGNED_ACCESS
 endif
 ifneq ($(filter leak,$(SANITIZERS)),)
 BASIC_CFLAGS += -DSUPPRESS_ANNOTATED_LEAKS
+BASIC_CFLAGS += -O0
 SANITIZE_LEAK = YesCompiledWithIt
 endif
 ifneq ($(filter address,$(SANITIZERS)),)


### PR DESCRIPTION
The CI builds have been seriously broken as of v2.38.1 by the constantly failing `linux-leaks` job. Let's backport the work-around that has been applied to upstream Git (but that funnily has not been based directly on top of v2.38.1).