### PR TITLE
Two `monitor-components` fixes

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -16,6 +16,8 @@ env:
 
 jobs:
   job:
+    # Only run this in Git for Windows' fork
+    if: github.event.repository.owner.login == 'git-for-windows'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -28,8 +28,8 @@ jobs:
             feed: https://github.com/git/git/tags.atom
           - label: git-lfs
             feed: https://github.com/git-lfs/git-lfs/tags.atom
-          - label: gcm-core
-            feed: https://github.com/microsoft/git-credential-manager-core/tags.atom
+          - label: git-credential-manager
+            feed: https://github.com/GitCredentialManager/git-credential-manager/tags.atom
           - label: tig
             feed: https://github.com/jonas/tig/tags.atom
           - label: cygwin


### PR DESCRIPTION
The `monitor-components` workflow's purpose is to notify the Git for Windows maintainers when new package versions are published and may need to be integrated into Git for Windows.

This PR brings two improvements to this workflow:

- We now explicitly disable the workflow everywhere but the Git for Windows fork of Git, instead of relying on scheduled workflows being disabled in forks (of the fork) by default.
- The label and the URL of the Git Credential Manager part was fixed. I noticed that the label was wrong when https://github.com/git-for-windows/build-extra/pull/451 was opened but failed to mention that it would close the issue (https://github.com/git-for-windows/git/issues/4166)