### PR TITLE
mimalloc: suppress some non-critical compiler warnings (or: prepare for v2.39.0(2))

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2075,15 +2075,17 @@ ifdef USE_MIMALLOC
 
 $(MIMALLOC_OBJS): COMPAT_CFLAGS += -DBANNED_H
 
-ifdef DEVELOPER
 $(MIMALLOC_OBJS): COMPAT_CFLAGS += \
 	-Wno-attributes \
-	-Wno-pedantic \
 	-Wno-unknown-pragmas \
+	-Wno-array-bounds
+
+ifdef DEVELOPER
+$(MIMALLOC_OBJS): COMPAT_CFLAGS += \
+	-Wno-pedantic \
 	-Wno-declaration-after-statement \
 	-Wno-old-style-definition \
-	-Wno-missing-prototypes \
-	-Wno-array-bounds
+	-Wno-missing-prototypes
 endif
 endif
 


### PR DESCRIPTION
When compiling in non-DEVELOPER mode, we currently do not suppress any warnings about the mimalloc code. And there are [a ton of them](https://dev.azure.com/git-for-windows/git/_build/results?buildId=111244&view=logs&j=31a7ecae-43f3-5669-2a92-3fc5c046b795&t=2b55ac6e-fb99-5b86-1bfa-7cc690d62aa6&l=1592).

Since none of them point out critical mistakes in the code, and since mimalloc is an upstream project, we already suppress these warnings in DEVELOPER mode. Let's suppress even the ones that only appear in non-DEVELOPER mode.