### PR TITLE
fixup! Add a GitHub workflow to monitor component updates

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -29,7 +29,7 @@ jobs:
           - label: git-lfs
             feed: https://github.com/git-lfs/git-lfs/tags.atom
           - label: git-credential-manager
-            feed: https://github.com/GitCredentialManager/git-credential-manager/tags.atom
+            feed: https://github.com/git-ecosystem/git-credential-manager/tags.atom
           - label: tig
             feed: https://github.com/jonas/tig/tags.atom
           - label: cygwin


### PR DESCRIPTION
The `GitCredentialManager` GitHub organization has been renamed to `git-ecosystem`. See [1]. While the old URL currently still works, it's better to update to the current URL.

[1] https://github.com/git-ecosystem/git-credential-manager/pull/1141