### PR TITLE
Git GUI: fix Repository>Explore Working Copy

### DIFF
--- a/git-gui/git-gui.sh
+++ b/git-gui/git-gui.sh
@@ -108,6 +108,9 @@ proc _which {what args} {
 
 	if {[is_Windows] && [lsearch -exact $args -script] >= 0} {
 		set suffix {}
+	} elseif {[string match *$_search_exe $what]} {
+		# The search string already has the file extension
+		set suffix {}
 	} else {
 		set suffix $_search_exe
 	}


### PR DESCRIPTION
This is a companion PR of https://github.com/prati0100/git-gui/pull/95

Since Git v2.39.1, we are a bit more stringent in searching the PATH. In particular, we specifically require the `.exe` suffix.

However, the `Repository>Explore Working Copy` command asks for `explorer.exe` to be found on the `PATH`, which _already_ has that suffix.

Let's unstartle the PATH-finding logic about this scenario.

This fixes https://github.com/git-for-windows/git/issues/4356