### PR TITLE
Drop the old-style runtime-prefix handling in `interpolate_path()`

### DIFF
--- a/path.c
+++ b/path.c
@@ -739,12 +739,6 @@ char *interpolate_path(const char *path, int real_home)
 	if (skip_prefix(path, "%(prefix)/", &path))
 		return system_path(path);
 
-#ifdef __MINGW32__
-	if (path[0] == '/') {
-		warning(_("encountered old-style '%s' that should be '%%(prefix)/%s'"), path, path);
-		return system_path(path + 1);
-	}
-#endif
 	if (path[0] == '~') {
 		const char *first_slash = strchrnul(path, '/');
 		const char *username = path + 1;


### PR DESCRIPTION
Once upon a time, Git for Windows had the need to specify paths in the config that are relative to the runtime prefix (i.e. relative to the location where Git for Windows happens to be installed). To support that, special handling was introduced to treat paths starting with a forward slash as relative to the runtime prefix. When trying to upstream this feature, it was determined that it is not portable enough, and it was deprecated in favor of the new strategy: starting paths with `%(prefix)/` would indicate that they are relative to the runtime prefix.

After deprecating the "leading slash means relative to runtime prefix" feature in v2.34.0 (released November 15th, 2021), it is time to drop it. This reverts commit 28fdfd8a4183 and addresses https://github.com/git-for-windows/git/issues/4125, at long last.