### PR TITLE
[NEW FEATURE] make git-for-windows supports posix file mode bits in WSL's way

### DIFF
--- a/compat/win32/fscache.h
+++ b/compat/win32/fscache.h
@@ -33,4 +33,7 @@ struct fscache *fscache_getcache(void);
 void fscache_merge(struct fscache *dest);
 #define merge_fscache(dest) fscache_merge(dest)
 
+int copy_file_mode(HANDLE hd, struct stat * buf);
+int set_file_mode(HANDLE hd, struct stat * st);
+
 #endif


### PR DESCRIPTION
In WSL(2), we can set the mode for an NTFS file, for example:

$ chmod 0755 /mnt/d/test/a.sh

provided that WSL has enabled metadata mounting NTFS volumes.

In order to facilitate better collaboration between the Windows
version of Git and the WSL version of Git, we can make the Windows
version of Git also support reading and writing NTFS file modes
in a manner compatible with WSL.

In this pull request, I've incorporated two commits. The initial commit
introduces two helper functions for reading and writing file mode bits.
The subsequent commit enhances Git with WSL compatibility for 
improved collaboration.

