### PR TITLE
Reset read-only attributes during rename operation

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2687,7 +2687,8 @@ int mingw_accept(int sockfd1, struct sockaddr *sa, socklen_t *sz)
 #undef rename
 int mingw_rename(const char *pold, const char *pnew)
 {
-	DWORD attrs = INVALID_FILE_ATTRIBUTES, gle;
+	DWORD attrs = INVALID_FILE_ATTRIBUTES, gle, attrsold;
+	bool resetattrs;
 	int tries = 0;
 	wchar_t wpold[MAX_LONG_PATH], wpnew[MAX_LONG_PATH];
 	if (xutftowcs_long_path(wpold, pold) < 0 ||
@@ -2695,8 +2696,18 @@ int mingw_rename(const char *pold, const char *pnew)
 		return -1;
 
 repeat:
+	/* check if file is read-only and change if necessary */
+	resetattrs = false;
+	attrsold = GetFileAttributesW(wpold);
+	if (attrsold & FILE_ATTRIBUTE_READONLY) {
+    SetFileAttributesW(wpold, attrsold & ~FILE_ATTRIBUTE_READONLY);
+		/* flag to change back after rename */
+    resetattrs = true;
+	}
 	if (MoveFileExW(wpold, wpnew,
 			MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED))
+		if (resetattrs) 
+	    SetFileAttributesW(wpnew, attrsold);
 		return 0;
 	gle = GetLastError();
 
@@ -2719,7 +2730,7 @@ repeat:
 	if (attrs == INVALID_FILE_ATTRIBUTES &&
 	    (attrs = GetFileAttributesW(wpnew)) != INVALID_FILE_ATTRIBUTES) {
 		if (attrs & FILE_ATTRIBUTE_DIRECTORY) {
-			DWORD attrsold = GetFileAttributesW(wpold);
+			attrsold = GetFileAttributesW(wpold);
 			if (attrsold == INVALID_FILE_ATTRIBUTES ||
 			    !(attrsold & FILE_ATTRIBUTE_DIRECTORY))
 				errno = EISDIR;


### PR DESCRIPTION
OK, this is an edge case as discussed [here](https://github.com/git-for-windows/git/issues/4482). Running git on windows for a repo that is mounted on an APFS filesystem fails, as it's not possible to rename a 'locked' (read only) file on APFS. This workaround checks if the rename fails, and if `FILE_ATTRIBUTE_READONLY` is set, resets it before attempting the rename again. If that succeeds, `FILE_ATTRIBUTE_READONLY` is applied to the renamed file.