### PR TITLE
monitor components: monitor mingw-w64-clang

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -79,6 +79,8 @@ jobs:
             title-pattern: ^(?!.*(5\.[0-9]+[13579]|RC))
           - label: pcre2
             feed: https://github.com/PCRE2Project/pcre2/tags.atom
+          - label: mingw-w64-clang
+            feed: https://github.com/msys2/MINGW-packages/commits/master/mingw-w64-clang.atom
       fail-fast: false
     steps:
       - uses: git-for-windows/rss-to-issues@v0


### PR DESCRIPTION
after merging https://github.com/git-for-windows/MINGW-packages/pull/75 we'll want to be notified when Msys2 updates their mingw-w64-clang package.