### PR TITLE
Backport CI fix

### DIFF
--- a/GIT-VERSION-GEN
+++ b/GIT-VERSION-GEN
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 GVF=GIT-VERSION-FILE
-DEF_VER=v2.41.0-rc2
+DEF_VER=v2.41.0
 
 LF='
 '


### PR DESCRIPTION
Seems that we're being hit by a test failure due to too-stringent assumptions on Git's part about cURL's error messages.