### PR TITLE
Additional error checks for issuing the windows.appendAtomically warning

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -948,7 +948,7 @@ ssize_t mingw_write(int fd, const void *buf, size_t len)
 {
 	ssize_t result = write(fd, buf, len);
 
-	if (result < 0 && errno == EINVAL && buf) {
+	if (result < 0 && (errno == EINVAL || errno == EBADF) && buf) {
 		/* check if fd is a pipe */
 		HANDLE h = (HANDLE) _get_osfhandle(fd);
 		if (GetFileType(h) == FILE_TYPE_PIPE)


### PR DESCRIPTION
Another (hopefully clean) PR for showing the error warning about atomic append on windows after failure on APFS, which returns EBADF not EINVAL.

Signed-off-by: David Lomas <dl3@pale-eds.co.uk>