### PR TITLE
Load `libcurl-4.dll` correctly even when there are umlauts in its absolute path

### DIFF
--- a/compat/lazyload-curl.c
+++ b/compat/lazyload-curl.c
@@ -57,7 +57,9 @@ static void *load_library(const char *name)
 			memcpy(dll_path + len + 1, name, name_size);
 
 			if (!access(dll_path, R_OK)) {
-				void *res = (void *)LoadLibraryExA(dll_path, NULL, 0);
+				wchar_t wpath[MAX_PATH];
+				int wlen = MultiByteToWideChar(CP_UTF8, 0, dll_path, -1, wpath, ARRAY_SIZE(wpath));
+				void *res = wlen ? (void *)LoadLibraryExW(wpath, NULL, 0) : NULL;
 				if (!res) {
 					DWORD err = GetLastError();
 					char buf[1024];
@@ -68,7 +70,7 @@ static void *load_library(const char *name)
 							    NULL, err, LANG_NEUTRAL,
 							    buf, sizeof(buf) - 1, NULL))
 						xsnprintf(buf, sizeof(buf), "last error: %ld", err);
-					error("LoadLibraryExA() failed with: %s", buf);
+					error("LoadLibraryExW() failed with: %s", buf);
 				}
 				return res;
 			}


### PR DESCRIPTION
For historical reasons, the Win32 API provides `*A()` and `*W()` versions of many functions, e.g. `LoadLibraryExA()` and `LoadLibraryExW()`. The difference between these two function families is that the latter works on wide-character Unicode strings while the former accepts localized single- and multi-byte character sequences.

In Git for Windows's source code, we should not use the `*A()` family of functions at all because we use UTF-8 internally, which is not typically the current locale, and therefore the `*A()` functions will most often do unintended things. However, that's exactly what I did in https://github.com/git-for-windows/git/pull/4410: using `LoadLibraryExA()` (I do not remember why, but can guess that I used it for testing and intended to replace it with the `*W()` invocation once everything works).

In this instance, the use of an `*A()` function prevents the `libcurl-4.dll` from being loaded correctly if its absolute path contains non-ASCII characters.

Let's fix this, and for good measure offer _some_ sort of error message.

This fixes https://github.com/git-for-windows/git/issues/4573.