### PR TITLE
monitor-components: switch from p7zip to regular 7-Zip

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -69,8 +69,9 @@ jobs:
             feed: https://github.com/gpg/gnupg/releases.atom
           - label: mintty
             feed: https://github.com/mintty/mintty/releases.atom
-          - label: p7zip
-            feed: https://sourceforge.net/projects/p7zip/rss?path=/p7zip
+          - label: 7-zip
+            feed: https://sourceforge.net/projects/sevenzip/rss?path=/7-Zip
+            aggregate: true
           - label: bash
             feed: https://git.savannah.gnu.org/cgit/bash.git/atom/?h=master
             aggregate: true


### PR DESCRIPTION
We've switched from p7zip to regular 7-Zip recently. With that we don't need to monitor p7zip for updates anymore, but we want to stay informed about 7-Zip updates now. Change the feed accordingly. Since the new feed contains 15 different files as separate items for the latest 7-Zip update, aggregate them into a single issue.