### PR TITLE
[bugfix] fix wsl mode bits error in subdir

### DIFF
--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -238,9 +238,20 @@ static struct fsentry *fseentry_create_entry(struct fscache *cache,
 			     &(fse->u.s.st_mtim));
 	filetime_to_timespec((FILETIME *)&(fdata->CreationTime),
 			     &(fse->u.s.st_ctim));
-	if (fdata->EaSize > 0 && are_wsl_compatible_mode_bits_enabled()) {
-		copy_wsl_mode_bits_from_disk(fdata->FileName,
-			fdata->FileNameLength / sizeof(wchar_t), &fse->st_mode);
+	if (fdata->EaSize > 0 &&
+	    sizeof(buf) >= (list ? list->len+1 : 0) + fse->len+1 &&
+	    are_wsl_compatible_mode_bits_enabled()) {
+		size_t off = 0;
+		wchar_t wpath[MAX_LONG_PATH];
+		if (list) {
+			memcpy(buf, list->dirent.d_name, list->len);
+			buf[list->len] = '/';
+			off = list->len + 1;
+		}
+		memcpy(buf + off, fse->dirent.d_name, fse->len);
+		buf[off + fse->len] = '\0';
+		if (xutftowcs_long_path(wpath, path) >= 0)
+			copy_wsl_mode_bits_from_disk(wpath, -1, &fse->st_mode);
 	}
 
 	return fse;


### PR DESCRIPTION
Support for wsl mode bits was previously added to git, but there was a bug because the filenames provided by fscache did not contain paths.

This commit fixes the issue.

the previous feature is added in PR https://github.com/git-for-windows/git/pull/4438
but at that time I didn't tested so much.
Sorry to have this bug.

To test this feature, set core.wslcompat to ture and core.filemode to true and make sure repo is on NTFS.
