### PR TITLE
Redefine PATH_MAX to allow all Git operations to take advantage of Windows long path support.

### DIFF
--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -430,6 +430,20 @@ char *gitdirname(char *);
 #define NI_MAXSERV 32
 #endif
 
+/* PATH_MAX is inherited from mingw64/include/limits.h, with a value of 260.
+ * The problem is that even after enabling Windows long path support and
+ * 'core.longpaths' there are still some Git operations that will fail, such
+ * as cloning a submodule (see setup_explicit_git_dir).
+ *
+ * I've observed some CI runners that have temp clones in a deeply nested
+ * path which will break even some medium sized repository paths.
+ *
+ * Redefining this macro addresses that issue.
+ */
+#if defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW32__)
+#undef PATH_MAX
+#endif
+
 /* On most systems <limits.h> would have given us this, but
  * not on some systems (e.g. GNU/Hurd).
  */


### PR DESCRIPTION
PATH_MAX is inherited from mingw64/include/limits.h, with a value of 260.
The problem is that even after enabling Windows long path support and 'core.longpaths' there are still some Git operations that will fail, such as cloning a submodule (see setup_explicit_git_dir).

I've observed some CI runners that have temp clones in a deeply nested path which will break even some medium sized repository paths.

Redefining this macro addresses that issue.


This does seem very hacky, but it was a big issue for my Windows Bitbucket runner which clones into a ridiculously long path of: `C:/Windows/System32/atlassian-bitbucket-pipelines-runner/temp/b00863ba-0d50-5cf5-91e6-452e9580164b/1709559465808/build`. This caused some of my dependent submodules to fail initialisation.

Examples of the same issue:
https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/157
https://github.com/gruntwork-io/terragrunt/issues/2343

If there's another possible way to implement this - I'm open to ideas. Would just like to see this issue go away :)