### PR TITLE
Adjust monitor-components workflow for new mingw-w64-clang name

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -80,8 +80,8 @@ jobs:
             title-pattern: ^(?!.*(5\.[0-9]+[13579]|RC))
           - label: pcre2
             feed: https://github.com/PCRE2Project/pcre2/tags.atom
-          - label: mingw-w64-clang
-            feed: https://github.com/msys2/MINGW-packages/commits/master/mingw-w64-clang.atom
+          - label: mingw-w64-llvm
+            feed: https://github.com/msys2/MINGW-packages/commits/master/mingw-w64-llvm.atom
       fail-fast: false
     steps:
       - uses: git-for-windows/rss-to-issues@v0


### PR DESCRIPTION
MSYS2 [renamed the mingw-w64-clang folder to mingw-w64-llvm](https://github.com/msys2/MINGW-packages/commit/2ad570ca96fbb35cc408763f1a4d421801466fb8), adjust the monitor-components workflow accordingly.