### PR TITLE
monitor-components: add InnoSetup

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -82,6 +82,8 @@ jobs:
             feed: https://github.com/PCRE2Project/pcre2/tags.atom
           - label: mingw-w64-llvm
             feed: https://github.com/msys2/MINGW-packages/commits/master/mingw-w64-llvm.atom
+          - label: innosetup
+            feed: https://github.com/jrsoftware/issrc/tags.atom
       fail-fast: false
     steps:
       - uses: git-for-windows/rss-to-issues@v0


### PR DESCRIPTION
Let's also keep an eye out for new InnoSetup versions, as we rely on using reasonable secure versions of it.