### PR TITLE
run-command: refine Git LFS check on Windows 7

### DIFF
--- a/compat/win32/path-utils.c
+++ b/compat/win32/path-utils.c
@@ -221,14 +221,18 @@ void win32_warn_about_git_lfs_on_windows7(int exit_code, const char *argv0)
 	 * Git LFS v3.5.1 fails with an Access Violation on Windows 7; That
 	 * would usually show up as an exit code 0xc0000005. For some reason
 	 * (probably because at this point, we no longer have the _original_
-	 * HANDLE that was returned by `CreateProcess()`) we get 0xb00 instead.
+	 * HANDLE that was returned by `CreateProcess()`) we observe other
+	 * values like 0xb00 and 0x2 instead. Since the exact exit code
+	 * seems to be inconsistent, we check for a non-zero exit status.
 	 */
-	if (exit_code != 0x0b00)
+	if (exit_code == 0)
 		return;
 	if (GetVersion() >> 16 > 7601)
 		return; /* Warn only on Windows 7 or older */
-	if (!starts_with(argv0, "git-lfs ") ||
-	    !(git_lfs = locate_in_PATH("git-lfs")))
+	if (!istarts_with(argv0, "git-lfs ") &&
+	    strcasecmp(argv0, "git-lfs"))
+		return;
+	if (!(git_lfs = locate_in_PATH("git-lfs")))
 		return;
 	if (get_go_version(git_lfs, buffer, sizeof(buffer)) > 0 &&
 	    skip_prefix(buffer, "go", &p) &&


### PR DESCRIPTION
In commit git-for-windows/git@46d14a6f7189a604a0812b143dc5c51488a01895 of PR git-for-windows/git#5042 the `wait_or_whine()` function in `run-command.c` was revised to [call](https://github.com/git-for-windows/git/blob/b105301ef9107c8c2980a24eca89a2992a1c074b/run-command.c#L571) a new function in the case where an executable fails to run, to check whether this was caused by a Git LFS binary compiled with a version of the Go language that no longer supports Windows 7. This change was made to address the issue reported in git-for-windows/git#4996.

The new function, `win32_warn_about_git_lfs_on_windows7()`, [performs](https://github.com/git-for-windows/git/blob/b105301ef9107c8c2980a24eca89a2992a1c074b/compat/win32/path-utils.c#L226-L232) several initial checks to test whether the failed executable returned the exit code `0x0b00` and is named `git-lfs`, and whether we are running Windows 7 or not.  Only if all these conditions are met does it then proceed to try to extract the Go language version from the binary file and check whether it is 1.21.0 or higher.

However, these initial checks may not cover all possible use and failure cases.

First, when running in Git Bash (in a Windows 7 SP1 virtual machine), the exit code seen from a recent Git LFS executable was `0x02`, so we also want to check for that value as well as `0x0b00`.

Second, the name of the executable may not always be entirely lowercase, since it is possible to invoke Git LFS through Git by running, for example, `git LFS ls-files` (at least, on Windows, and with a case-insensitive filesystem).  We therefore need to ignore case when checking the executable's name.

And third, the name of the executable may not have a trailing space character, so we also need to check for the case where the name in `argv0` is simply `git-lfs`.

With these changes, we can more reliably detect a failure of the Git LFS executable in a wider range of circumstances.
