### PR TITLE
ci: work around a problem with HTTP/2 vs libcurl v8.10.0

### DIFF
--- a/t/t5512-ls-remote.sh
+++ b/t/t5512-ls-remote.sh
@@ -405,6 +405,7 @@ test_expect_success 'v0 clients can handle multiple symrefs' '
 test_expect_success 'helper with refspec capability fails gracefully' '
 	mkdir test-bin &&
 	write_script test-bin/git-remote-foo <<-EOF &&
+	read capabilities
 	echo import
 	echo refspec ${SQ}*:*${SQ}
 	EOF

--- a/t/t5551-http-fetch-smart.sh
+++ b/t/t5551-http-fetch-smart.sh
@@ -381,7 +381,15 @@ test_expect_success CMDLINE_LIMIT \
 	)
 '
 
-test_expect_success 'large fetch-pack requests can be sent using chunked encoding' '
+# This is a temporary work-around for libcurl v8.10.0 on the macos-* runners;
+# see https://github.com/git-for-windows/git/issues/5159 for full details
+test_lazy_prereq UNBROKEN_HTTP2 '
+	test "$HTTP_PROTO" = HTTP/2 &&
+	test -z "$(brew info -q curl 2>/dev/null |
+		sed -n "/^Installed/{N;s/.*8\\.10\\.0.*/BROKEN HTTP2/p;}")"
+'
+
+test_expect_success UNBROKEN_HTTP2 'large fetch-pack requests can be sent using chunked encoding' '
 	GIT_TRACE_CURL=true git -c http.postbuffer=65536 \
 		clone --bare "$HTTPD_URL/smart/repo.git" split.git 2>err &&
 	{


### PR DESCRIPTION
This patch implements a work-around, basically for the sake of Git for Windows v2.46.2's CI build: The `macos-13` runner images still reference libcurl v8.10.0, which has a known flaw that breaks t5559.30. Let's detect this situation and skip that test case in that case.

While at it, also backport the work-around for a flaky test case (t5512.40 "helper with refspec capability fails gracefully").

This fixes https://github.com/git-for-windows/git/issues/5159.