### PR TITLE
survey: default to --top=10

### DIFF
--- a/builtin/survey.c
+++ b/builtin/survey.c
@@ -869,7 +869,7 @@ int cmd_survey(int argc, const char **argv, const char *prefix, struct repositor
 		.opts = {
 			.verbose = 0,
 			.show_progress = -1, /* defaults to isatty(2) */
-			.top_nr = 100,
+			.top_nr = 10,
 
 			.refs.want_all_refs = -1,
 


### PR DESCRIPTION
Currently, it defaults to 100, which is a bit excessive given that there are multiple tables with that maximum row count.

Let's default to 10 instead. It's easy enough to increase the limit via command-line or config.