### PR TITLE
SECURITY.md: use the new Git for Windows snapshots URL

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,7 +56,7 @@ Note: there is currently a bug in the "Check daily for updates" code, where it m
 
 ## Snapshot versions ('nightly builds')
 
-Git for Windows also provides snapshots (these are not releases) of the current development as per git-for-Windows/git's `master` branch at the [Snapshots](https://wingit.blob.core.windows.net/files/index.html) page. This link is also listed in the footer of the [Git for Windows](https://gitforwindows.org/) home page.
+Git for Windows also provides snapshots (these are not releases) of the current development as per git-for-Windows/git's `master` branch at the [Snapshots](https://gitforwindows.org/git-snapshots/) page. This link is also listed in the footer of the [Git for Windows](https://gitforwindows.org/) home page.
 
 Note: even if those builds are not exactly "nightly", they are sometimes referred to as "nightly builds" to keep with other projects' nomenclature.
 


### PR DESCRIPTION
The `SECURITY.md` document mentions Git for Windows' snapshots and helpfully provides a link.

For almost eight years, Git for Windows' snapshots were hosted [on Azure Blobs](https://wingit.blob.core.windows.net/files/index.html).

As of a combination of PRs (https://github.com/git-for-windows/git-for-windows-automation/pull/109, https://github.com/git-for-windows/gfw-helper-github-app/pull/117), snapshots are not only now built and deployed via GitHub Actions instead of Azure Pipelines (and ARM64 artifacts are now included, too), they are also hosted [on GitHub](https://github.com/git-for-windows/git-snapshots/releases/), with the main page being hosted [on GitHub Pages](https://github.com/git-for-windows/git-snapshots/commits/gh-pages).

Therefore, the original link now redirects to a new location (which is also a lot easier to remember): http://gitforwindows.org/git-snapshots. Let's adjust the link to link there directly.

This is a companion PR of https://github.com/git-for-windows/git-for-windows-automation/pull/111 and of https://github.com/git-for-windows/build-extra/pull/589.