### PR TITLE
compat/mingw: rename the symlink, not the target

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2926,7 +2926,9 @@ repeat:
 
 		old_handle = CreateFileW(wpold, DELETE,
 					 FILE_SHARE_WRITE | FILE_SHARE_READ | FILE_SHARE_DELETE,
-					 NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+					 NULL, OPEN_EXISTING,
+					 FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+					 NULL);
 		if (old_handle == INVALID_HANDLE_VALUE) {
 			errno = err_win_to_posix(GetLastError());
 			return -1;


### PR DESCRIPTION
This fixes #5436. I've tried to write the commit message (6a994b2) in such a way that it would be suitable both here and upstream, but I do not know if I succeeded at that. As noted in the commit message, and in the issue, existing tests are able to detect the bug this is fixing, so at least for now I have not written any tests.

The code this modifies is also present upstream, but my understanding of the contribution guidelines is that I should open this PR here rather than submitting a patch to the Git mailing list, because the effect of this change is entirely Windows-specific. If this instead needs to be submitted to the mailing list, then I could try and do that. The change here is also rather simple, and I would certainly have no objection to it being integrated in some other way that doesn't involve merging this in any form, if that is more convenient.