### PR TITLE
Some `clangarm64` fixes

### DIFF
--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -78,12 +78,15 @@ struct fsentry {
 };
 #pragma GCC diagnostic pop
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wflexible-array-extensions"
 struct heap_fsentry {
 	union {
 		struct fsentry ent;
 		char dummy[sizeof(struct fsentry) + MAX_LONG_PATH];
 	} u;
 };
+#pragma GCC diagnostic pop
 
 /*
  * Compares the paths of two fsentry structures for equality.
@@ -596,7 +599,10 @@ void fscache_flush(void)
 int fscache_lstat(const char *filename, struct stat *st)
 {
 	int dirlen, base, len;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wflexible-array-extensions"
 	struct heap_fsentry key[2];
+#pragma GCC diagnostic pop
 	struct fsentry *fse;
 	struct fscache *cache = fscache_getcache();
 

--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -79,7 +79,9 @@ struct fsentry {
 #pragma GCC diagnostic pop
 
 #pragma GCC diagnostic push
+#ifdef __clang__
 #pragma GCC diagnostic ignored "-Wflexible-array-extensions"
+#endif
 struct heap_fsentry {
 	union {
 		struct fsentry ent;
@@ -600,7 +602,9 @@ int fscache_lstat(const char *filename, struct stat *st)
 {
 	int dirlen, base, len;
 #pragma GCC diagnostic push
+#ifdef __clang__
 #pragma GCC diagnostic ignored "-Wflexible-array-extensions"
+#endif
 	struct heap_fsentry key[2];
 #pragma GCC diagnostic pop
 	struct fsentry *fse;

--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -670,7 +670,9 @@ int fscache_is_mount_point(struct strbuf *path)
 {
 	int dirlen, base, len;
 #pragma GCC diagnostic push
+#ifdef __clang__
 #pragma GCC diagnostic ignored "-Wflexible-array-extensions"
+#endif
 	struct heap_fsentry key[2];
 #pragma GCC diagnostic pop
 	struct fsentry *fse;

--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -665,7 +665,10 @@ int fscache_lstat(const char *filename, struct stat *st)
 int fscache_is_mount_point(struct strbuf *path)
 {
 	int dirlen, base, len;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wflexible-array-extensions"
 	struct heap_fsentry key[2];
+#pragma GCC diagnostic pop
 	struct fsentry *fse;
 	struct fscache *cache = fscache_getcache();
 

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -432,7 +432,11 @@ ifeq ($(uname_S),Windows)
         ifeq (MINGW32,$(MSYSTEM))
 		prefix = /mingw32
         else
-		prefix = /mingw64
+		ifeq (CLANGARM64,$(MSYSTEM))
+			prefix = /clangarm64
+		else
+			prefix = /mingw64
+		endif
         endif
 	# Prepend MSVC 64-bit tool-chain to PATH.
 	#

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -757,12 +757,7 @@ ifeq ($(uname_S),MINGW)
 		ETC_GITCONFIG = ../etc/gitconfig
 		ETC_GITATTRIBUTES = ../etc/gitattributes
         endif
-ifeq (i686,$(uname_M))
-	MINGW_PREFIX := mingw32
-endif
-ifeq (x86_64,$(uname_M))
-	MINGW_PREFIX := mingw64
-endif
+	MINGW_PREFIX := $(subst /,,$(prefix))
 
 	DESTDIR_WINDOWS = $(shell cygpath -aw '$(DESTDIR_SQ)')
 	DESTDIR_MIXED = $(shell cygpath -am '$(DESTDIR_SQ)')

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -728,8 +728,7 @@ ifeq ($(uname_S),MINGW)
 		prefix = /mingw32
 		HOST_CPU = i686
 		BASIC_LDFLAGS += -Wl,--pic-executable,-e,_mainCRTStartup
-        endif
-        ifeq (MINGW64,$(MSYSTEM))
+        else ifeq (MINGW64,$(MSYSTEM))
 		prefix = /mingw64
 		HOST_CPU = x86_64
 		BASIC_LDFLAGS += -Wl,--pic-executable,-e,mainCRTStartup

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -490,7 +490,7 @@ ifeq ($(uname_S),Windows)
 	NATIVE_CRLF = YesPlease
 	DEFAULT_HELP_FORMAT = html
 	SKIP_DASHED_BUILT_INS = YabbaDabbaDoo
-ifeq (/mingw64,$(subst 32,64,$(prefix)))
+ifeq (/mingw64,$(subst 32,64,$(subst clangarm,mingw,$(prefix))))
 	# Move system config into top-level /etc/
 	ETC_GITCONFIG = ../etc/gitconfig
 	ETC_GITATTRIBUTES = ../etc/gitattributes
@@ -753,7 +753,7 @@ ifeq ($(uname_S),MINGW)
 	USE_LIBPCRE = YesPlease
 	USE_MIMALLOC = YesPlease
 	NO_PYTHON =
-        ifeq (/mingw64,$(subst 32,64,$(prefix)))
+        ifeq (/mingw64,$(subst 32,64,$(subst clangarm,mingw,$(prefix))))
 		# Move system config into top-level /etc/
 		ETC_GITCONFIG = ../etc/gitconfig
 		ETC_GITATTRIBUTES = ../etc/gitattributes


### PR DESCRIPTION
Most notably, this fixes https://github.com/git-for-windows/git/issues/5431, i.e. that the ARM64 flavor of Git for Windows does not use `/etc/gitconfig` by mistake, but `/clangarm64/etc/gitconfig` instead.

My original intention was to fix only that issue, but when I fired up a Git for Windows/ARM64 SDK and tried to build, I immediately ran into trouble, then noticed places where ARM64 was not yet handled, and one thing led to another and now it's a 6-patch PR instead of a single-patch one.