### PR TITLE
Re-enable MINGW32-specific compile options

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -728,7 +728,8 @@ ifeq ($(uname_S),MINGW)
 		prefix = /mingw32
 		HOST_CPU = i686
 		BASIC_LDFLAGS += -Wl,--pic-executable,-e,_mainCRTStartup
-        else ifeq (MINGW64,$(MSYSTEM))
+        endif
+        ifeq (MINGW64,$(MSYSTEM))
 		prefix = /mingw64
 		HOST_CPU = x86_64
 		BASIC_LDFLAGS += -Wl,--pic-executable,-e,mainCRTStartup


### PR DESCRIPTION
This reverts a mistake of mine: My change to introduce an "else ifeq" in https://github.com/git-for-windows/git/pull/5439 chain missed that there is [an `else` clause](https://github.com/dscho/git/blob/31963038164d1a2d78dc46225f8441e8c0fb07a8/config.mak.uname#L739-L742) that should be used for MINGW32 and MSys (to add large-address-awareness and use 32-bit `time_t`) but not for CLANGARM64 nor for MINGW64.