### PR TITLE
Replace the superseded wiki URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ you want to extend the functional tests to be sure no one breaks your feature in
 ### Functional Tests
 
 Navigate to the `t/` directory and type `make` to run all tests or use `prove` as
-[described in the Git for Windows wiki](https://gitforwindows.org/building-git):
+[described on this Git for Windows page](https://gitforwindows.org/building-git):
 
 ```
 prove -j12 --state=failed,save ./t[0-9]*.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,8 @@ When running `make`, you can use `-j$(nproc)` to automatically use the number of
 on your machine as the number of concurrent build processes.
 
 You can go deeper on the Windows-specific build process by reading the
-[technical overview](https://github.com/git-for-windows/git/wiki/Technical-overview) or the
-[guide to compiling Git with Visual Studio](https://github.com/git-for-windows/git/wiki/Compiling-Git-with-Visual-Studio).
+[technical overview](https://gitforwindows.org/technical-overview) or the
+[guide to compiling Git with Visual Studio](https://gitforwindows.org/compiling-git-with-visual-studio).
 
 ## Building `git` on Windows with Visual Studio
 
@@ -120,7 +120,7 @@ you want to extend the functional tests to be sure no one breaks your feature in
 ### Functional Tests
 
 Navigate to the `t/` directory and type `make` to run all tests or use `prove` as
-[described in the Git for Windows wiki](https://github.com/git-for-windows/git/wiki/Building-Git):
+[described in the Git for Windows wiki](https://gitforwindows.org/building-git):
 
 ```
 prove -j12 --state=failed,save ./t[0-9]*.sh

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ encounter problems, you can report them as [GitHub
 issues](https://github.com/git-for-windows/git/issues), discuss them in Git
 for Windows' [Discussions](https://github.com/git-for-windows/git/discussions)
 or on the [Git mailing list](mailto:git@vger.kernel.org), and [contribute bug
-fixes](https://github.com/git-for-windows/git/wiki/How-to-participate).
+fixes](https://gitforwindows.org/how-to-participate).
 
 To build Git for Windows, please either install [Git for Windows'
 SDK](https://gitforwindows.org/#download-sdk), start its `git-bash.exe`, `cd`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,7 @@ Git for Windows is a "friendly fork" of [Git](https://git-scm.com/), i.e. change
 
 While Git maintains several release trains (when v2.19.1 was released, there were updates to v2.14.x-v2.18.x, too, for example), Git for Windows follows only the latest Git release. For example, there is no Git for Windows release corresponding to Git v2.16.5 (which was released after v2.19.0).
 
-One exception is [MinGit for Windows](https://github.com/git-for-windows/git/wiki/MinGit) (a minimal subset of Git for Windows, intended for bundling with third-party applications that do not need any interactive commands nor support for `git svn`): critical security fixes are backported to the v2.11.x, v2.14.x, v2.19.x, v2.21.x and v2.23.x release trains.
+One exception is [MinGit for Windows](https://gitforwindows.org/mingit) (a minimal subset of Git for Windows, intended for bundling with third-party applications that do not need any interactive commands nor support for `git svn`): critical security fixes are backported to the v2.11.x, v2.14.x, v2.19.x, v2.21.x and v2.23.x release trains.
 
 ## Version number scheme
 


### PR DESCRIPTION
This is a follow-up for https://github.com/git-for-windows/git-for-windows.github.io/pull/59.