### PR TITLE
mingw_rename: support ReFS on Windows 2022

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2891,7 +2891,7 @@ repeat:
 		 * current system doesn't support FileRenameInfoEx. Keep us
 		 * from using it in future calls and retry.
 		 */
-		if (gle == ERROR_INVALID_PARAMETER) {
+		if (gle == ERROR_INVALID_PARAMETER || gle == ERROR_NOT_SUPPORTED) {
 			supports_file_rename_info_ex = 0;
 			goto repeat;
 		}


### PR DESCRIPTION
Git on Windows 2022 fails to write config files on ReFS with the error message "Function not implemented". The reason is that `ERROR_NOT_SUPPORTED` is reported (not `ERROR_INVALID_PARAMETER`, as expected). Let's handle both errors the same: by falling back to the best-effort option, namely to rename without POSIX semantics.

This fixes https://github.com/git-for-windows/git/issues/5427