### PR TITLE
clangarm64: let the tests pass!

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -3613,6 +3613,10 @@ static size_t append_system_bin_dirs(char *path, size_t size)
 	    strip_suffix_mem(prefix, &len, "\\mingw64\\bin"))
 		off += xsnprintf(path + off, size - off,
 				 "%.*s\\mingw64\\bin;", (int)len, prefix);
+	else if (strip_suffix_mem(prefix, &len, "\\clangarm64\\libexec\\git-core") ||
+	    strip_suffix_mem(prefix, &len, "\\clangarm64\\bin"))
+		off += xsnprintf(path + off, size - off,
+				 "%.*s\\clangarm64\\bin;", (int)len, prefix);
 	else if (strip_suffix_mem(prefix, &len, "\\mingw32\\libexec\\git-core") ||
 		 strip_suffix_mem(prefix, &len, "\\mingw32\\bin"))
 		off += xsnprintf(path + off, size - off,
@@ -3718,9 +3722,13 @@ static void setup_windows_environment(void)
 		char buf[32768];
 		size_t off = 0;
 
-		xsnprintf(buf, sizeof(buf),
-			  "MINGW%d", (int)(sizeof(void *) * 8));
-		setenv("MSYSTEM", buf, 1);
+#if defined(__MINGW64__) || defined(_M_AMD64)
+		setenv("MSYSTEM", "MINGW64", 1);
+#elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+		setenv("MSYSTEM", "CLANGARM64", 1);
+#else
+		setenv("MSYSTEM", "MINGW32", 1);
+#endif
 
 		if (home)
 			off += xsnprintf(buf + off, sizeof(buf) - off,

--- a/environment.c
+++ b/environment.c
@@ -83,7 +83,19 @@ int max_allowed_tree_depth =
 	 */
 	512;
 #else
+#if defined(GIT_WINDOWS_NATIVE) && defined(__clang__) && defined(__aarch64__)
+	/*
+	 * Similar to Visual C, it seems that on Windows/ARM64 the clang-based
+	 * builds have a smaller stack space available. When running out of
+	 * that stack space, a `STATUS_STACK_OVERFLOW` is produced. When the
+	 * Git command was run from an MSYS2 Bash, this unfortunately results
+	 * in an exit code 127. Let's prevent that by lowering the maximal
+	 * tree depth; This value seems to be low enough.
+	 */
+	1280;
+#else
 	2048;
+#endif
 #endif
 
 #ifndef PROTECT_HFS_DEFAULT

--- a/t/t0060-path-utils.sh
+++ b/t/t0060-path-utils.sh
@@ -630,13 +630,11 @@ test_expect_success MINGW,RUNTIME_PREFIX 'MSYSTEM/PATH is adjusted if necessary'
 	cp "$GIT_EXEC_PATH"/git.exe pretend"$MINGW_PREFIX"/bin/ &&
 	cp "$GIT_EXEC_PATH"/git.exe pretend"$MINGW_PREFIX"/libexec/git-core/ &&
 	# copy the .dll files, if any (happens when building via CMake)
-	case "$GIT_EXEC_PATH"/*.dll in
-	*/"*.dll") ;; # no `.dll` files to be copied
-	*)
+	if test -n "$(ls "$GIT_EXEC_PATH"/*.dll 2>/dev/null)"
+	then
 		cp "$GIT_EXEC_PATH"/*.dll pretend"$MINGW_PREFIX"/bin/ &&
 		cp "$GIT_EXEC_PATH"/*.dll pretend"$MINGW_PREFIX"/libexec/git-core/
-		;;
-	esac &&
+	fi &&
 	echo "env | grep MSYSTEM=" | write_script "$HOME"/bin/git-test-home &&
 	echo "echo ${MINGW_PREFIX#/}" | write_script pretend"$MINGW_PREFIX"/bin/git-test-bin &&
 	echo "echo usr" | write_script pretend/usr/bin/git-test-bin2 &&


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a53ba143-d524-4b08-800b-eb3d885977d0)

I encountered these issues that had hitherto escaped us [when I worked on letting the `ci-artifacts` workflow in git-sdk-arm64 also build Git and run the test suite](https://github.com/git-for-windows/git-sdk-arm64/pull/37) by way of validating the `minimal-sdk` artifact.

Mind, this PR does not only adjust a test case that was previously too fixated on x86_64. There are two real issues that this PR addresses and that were found via the test suite:

- When the environment variable `MSYSTEM` is not yet set, it now is set appropriately even on Windows/ARM64 (and the `PATH` is adjusted accordingly).
- The tree traversal limit designed to avoid stack overflows needed to be adjusted for the clangarm64 builds.