### PR TITLE
Fix t0060.221 on Windows/ARM64

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -3722,10 +3722,10 @@ static void setup_windows_environment(void)
 		char buf[32768];
 		size_t off = 0;
 
-#if defined(__MINGW64__) || defined(_M_AMD64)
-		setenv("MSYSTEM", "MINGW64", 1);
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 		setenv("MSYSTEM", "CLANGARM64", 1);
+#elif defined(__MINGW64__) || defined(_M_AMD64)
+		setenv("MSYSTEM", "MINGW64", 1);
 #else
 		setenv("MSYSTEM", "MINGW32", 1);
 #endif


### PR DESCRIPTION
Apparently my tests of https://github.com/git-for-windows/git/pull/5586 had been incomplete. This here patch is needed to let t0060.221 pass (where it verifies that `git.exe` sets `MSYSTEM` correctly if that environment variable has not yet been set): Simply reverse the order of the tests whether to set `MINGW64` or `CLANGARM64` to avoid using the former on Windows/ARM64 by mistake.