### PR TITLE
monitor-components: skip curl prereleases

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -59,6 +59,7 @@ jobs:
             feed: https://github.com/petervanderdoes/gitflow-avh/tags.atom
           - label: curl
             feed: https://github.com/curl/curl/tags.atom
+            title-pattern: ^(?!rc-)
           - label: libgpg-error
             feed: https://github.com/gpg/libgpg-error/releases.atom
             title-pattern: ^libgpg-error-[0-9\.]*$


### PR DESCRIPTION
curl recently started releasing rc versions, but we don't want to act on them, so there is no need to open issues about every rc version.
