### PR TITLE
t5410: avoid hangs in CI runs in the win+Meson test jobs

### DIFF
--- a/Documentation/RelNotes/2.50.0.adoc
+++ b/Documentation/RelNotes/2.50.0.adoc
@@ -300,7 +300,7 @@ Fixes since v2.49
    (merge e7ef4be7c2 mh/left-right-limited later to maint).
 
  * Document the convention to disable hooks altogether by setting the
-   hooksPath configuration variable to /dev/nulll
+   hooksPath configuration variable to /dev/null.
    (merge 1b2eee94f1 ds/doc-disable-hooks later to maint).
 
  * Make sure outage of third-party sites that supply P4, Git-LFS, and
@@ -318,6 +318,7 @@ Fixes since v2.49
 
  * Update to arm64 Windows port.
    (merge 436a42215e js/windows-arm64 later to maint).
+
  * hashmap API clean-up to ensure hashmap_clear() leaves a cleared map
    in a reusable state.
    (merge 9481877de3 en/hashmap-clear-fix later to maint).
@@ -351,7 +352,7 @@ Fixes since v2.49
    (merge 5dbaec628d pw/sequencer-reflog-use-after-free later to maint).
 
  * win+Meson CI pipeline, unlike other pipelines for Windows,
-   used to build artifacts in develper mode, which has been changed to
+   used to build artifacts in developer mode, which has been changed to
    build them in release mode for consistency.
    (merge 184abdcf05 js/ci-build-win-in-release-mode later to maint).
 
@@ -378,6 +379,15 @@ Fixes since v2.49
  * "git apply --index/--cached" when applying a deletion patch in
    reverse failed to give the mode bits of the path "removed" by the
    patch to the file it creates, which has been corrected.
+
+ * "git verify-refs" (and hence "git fsck --reference") started
+   erroring out in a repository in which secondary worktrees were
+   prepared with Git 2.43 or lower.
+   (merge d5b3c38b8a sj/ref-contents-check-fix later to maint).
+
+ * Update total_ram() functrion on BSD variants.
+
+ * Update online_cpus() functrion on BSD variants.
 
  * Other code cleanup, docfix, build fix, etc.
    (merge 227c4f33a0 ja/doc-block-delimiter-markup-fix later to maint).

--- a/GIT-VERSION-GEN
+++ b/GIT-VERSION-GEN
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DEF_VER=v2.50.0-rc0
+DEF_VER=v2.50.0-rc1
 
 LF='
 '

--- a/t/t5410-receive-pack.sh
+++ b/t/t5410-receive-pack.sh
@@ -41,7 +41,19 @@ test_expect_success 'with core.alternateRefsPrefixes' '
 	test_cmp expect actual.haves
 '
 
-test_expect_success 'receive-pack missing objects fails connectivity check' '
+# The `tee.exe` shipped in Git for Windows v2.49.0 is known to hang frequently
+# when spawned from `git.exe` and piping its output to `git.exe`. This seems
+# related to MSYS2 runtime bug fixes regarding the signal handling; Let's just
+# skip the tests that need to exercise this when the faulty MSYS2 runtime is
+# detected; The test cases are exercised enough in other matrix jobs of the CI
+# runs.
+test_lazy_prereq TEE_DOES_NOT_HANG '
+	test_have_prereq !MINGW &&
+	case "$(uname -a)" in *3.5.7-463ebcdc.x86_64*) false;; esac
+'
+
+test_expect_success TEE_DOES_NOT_HANG \
+	'receive-pack missing objects fails connectivity check' '
 	test_when_finished rm -rf repo remote.git setup.git &&
 
 	git init repo &&
@@ -62,7 +74,8 @@ test_expect_success 'receive-pack missing objects fails connectivity check' '
 	test_must_fail git -C remote.git cat-file -e $(git -C repo rev-parse HEAD)
 '
 
-test_expect_success 'receive-pack missing objects bypasses connectivity check' '
+test_expect_success TEE_DOES_NOT_HANG \
+	'receive-pack missing objects bypasses connectivity check' '
 	test_when_finished rm -rf repo remote.git setup.git &&
 
 	git init repo &&


### PR DESCRIPTION
This is a backport of https://github.com/gitgitgadget/git/pull/1932.