### PR TITLE
Fix Coverity builds

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -149,7 +149,11 @@ jobs:
         run: |
           export PATH="$PATH:$(cygpath -au "$RUNNER_TEMP")/cov-analysis/bin" &&
           cov-configure --gcc &&
-          cov-build --dir cov-int make
+          if ! cov-build --dir cov-int make
+          then
+            cat cov-int/build-log.txt
+            exit 1
+          fi
       - name: package the build
         run: tar -czvf cov-int.tgz cov-int
       - name: submit the build to Coverity Scan

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -147,7 +147,7 @@ jobs:
           key: cov-build-${{ env.COVERITY_LANGUAGE }}-${{ env.COVERITY_PLATFORM }}-${{ steps.lookup.outputs.hash }}
       - name: build with cov-build
         run: |
-          export PATH="$RUNNER_TEMP/cov-analysis/bin:$PATH" &&
+          export PATH="$PATH:$(cygpath -au "$RUNNER_TEMP")/cov-analysis/bin" &&
           cov-configure --gcc &&
           cov-build --dir cov-int make
       - name: package the build


### PR DESCRIPTION
As of three months ago, Git for Windows' [Coverity builds fail](https://github.com/git-for-windows/git/actions/workflows/coverity.yml?query=branch%3Amain):

![Screen Shot 2025-06-11 at 14 10 59](https://github.com/user-attachments/assets/e76edace-4ea0-4a29-83be-af5178299ba8)

The reason is most likely the most recent release, 2025.3. Its [release notes](https://documentation.blackduck.com/bundle/coverity-docs/page/webhelp-files/relnotes_latest.html) do not shed any light into the issue (and does not mention that they bundle JDK20 and JDK22 in addition to JRE, because what's better than a single Java installation: three, right?).

My investigation turned up `.dll` files that are located in Coverity's `bin/` directory which have the same name as `.dll` files in Git for Windows' SDK. As a consequence, the former override the latter and throw off MSYS2's logic to find the MSYS2 root directory given the location of certain `.dll` files.

This PR fixes this issue, and while at it, enhances the Coverity workflow to print out the build log in case of failure.