### PR TITLE
mingw: support Windows Server 2016 again

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2916,7 +2916,9 @@ repeat:
 		 * current system doesn't support FileRenameInfoEx. Keep us
 		 * from using it in future calls and retry.
 		 */
-		if (gle == ERROR_INVALID_PARAMETER || gle == ERROR_NOT_SUPPORTED) {
+		if (gle == ERROR_INVALID_PARAMETER ||
+		    gle == ERROR_NOT_SUPPORTED ||
+		    gle == ERROR_INVALID_FUNCTION) {
 			supports_file_rename_info_ex = 0;
 			goto repeat;
 		}


### PR DESCRIPTION
It was [reported](https://github.com/git-for-windows/git/issues/5695) to the Git for Windows project that a simple `git init` fails on Windows Server 2016:

```console
D:\Dev\test> git init
error: could not write config file D:/Dev/test/.git/config: Function not implemented
fatal: could not set 'core.repositoryformatversion' to '0'
```

According to https://endoflife.date/windows-server, Windows Server 2016 is officially supported for another one-and-a-half years as of time of writing, so this is not good.

The culprit is the `mingw_rename()` changes that try to use POSIX semantics when available, but fail to fall back properly on Windows Server 2016.

This fixes https://github.com/git-for-windows/git/issues/5695.