### PR TITLE
CONTRIBUTING.md: fix PuTTY URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,7 +261,7 @@ There are many virtual machine alternatives available, if you do not have such a
   network if shut down incorrectly).
 * Provide as many cores to your VM as you can (for parallel builds).
 * Restart your VM, but do not connect.
-* Use `ssh` in Git Bash, download [PuTTY](http://www.putty.org/), or use your favorite SSH client to connect to the VM through SSH.
+* Use `ssh` in Git Bash, download [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/), or use your favorite SSH client to connect to the VM through SSH.
 
 In order to build and use `git`, you will need the following libraries via `apt-get`:
 


### PR DESCRIPTION
Already in c2a2fd57402e (CONTRIBUTING.md: add guide for first-time contributors, 2018-03-01) there were _two_ links added for PuTTY, one being the correct, official one, and the other an official-looking one owned by a third-party. Let's only use the official one.

Original-patch-by: @jsoref in https://github.com/microsoft/git/pull/774