### PR TITLE
Stop monitoring GPG and GPG specific dependencies

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -60,17 +60,6 @@ jobs:
           - label: curl
             feed: https://github.com/curl/curl/tags.atom
             title-pattern: ^(?!rc-)
-          - label: libgpg-error
-            feed: https://github.com/gpg/libgpg-error/releases.atom
-            title-pattern: ^libgpg-error-[0-9\.]*$
-          - label: libgcrypt
-            feed: https://github.com/gpg/libgcrypt/releases.atom
-            title-pattern: ^libgcrypt-[0-9\.]*$
-          - label: gpg
-            feed: https://github.com/gpg/gnupg/releases.atom
-            # As per https://gnupg.org/download/index.html#sec-1-1, the stable
-            # versions are the one with an even minor version number.
-            title-pattern: ^gnupg-\d+\.\d*[02468]\.
           - label: mintty
             feed: https://github.com/mintty/mintty/releases.atom
           - label: 7-zip


### PR DESCRIPTION
Stop monitoring GPG and GPG specific dependencies, now that we [unshadowed the MSYS2 packages for these](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/17854940203/job/50771724937).
