### PR TITLE
git-svn: mark it as unsupported by the Git for Windows project

### DIFF
--- a/Documentation/git-svn.adoc
+++ b/Documentation/git-svn.adoc
@@ -9,6 +9,7 @@ SYNOPSIS
 --------
 [verse]
 'git svn' <command> [<options>] [<arguments>]
+(UNSUPPORTED!)
 
 DESCRIPTION
 -----------

--- a/git-svn.perl
+++ b/git-svn.perl
@@ -305,6 +305,19 @@ sub term_init {
 			: new Term::ReadLine 'git-svn';
 }
 
+sub deprecated_warning {
+    my @lines = @_;
+    if (-t STDERR) {
+        @lines = map { "\e[33m$_\e[0m" } @lines;
+    }
+    warn join("\n", @lines), "\n";
+}
+
+deprecated_warning(
+	"WARNING: \`git svn\` is no longer supported by the Git for Windows project.",
+	"See https://github.com/git-for-windows/git/issues/5405 for details."
+);
+
 my $cmd;
 for (my $i = 0; $i < @ARGV; $i++) {
 	if (defined $cmd{$ARGV[$i]}) {

--- a/t/t9108-git-svn-glob.sh
+++ b/t/t9108-git-svn-glob.sh
@@ -110,7 +110,8 @@ test_expect_success 'test disallow multi-globs' '
 		svn_cmd commit -m "try to try"
 	) &&
 	test_must_fail git svn fetch three 2> stderr.three &&
-	test_cmp expect.three stderr.three
+	sed "/^WARNING.*no.* supported/{N;d}" <stderr.three >stderr.three.clean &&
+	test_cmp expect.three stderr.three.clean
 	'
 
 test_done

--- a/t/t9109-git-svn-multi-glob.sh
+++ b/t/t9109-git-svn-multi-glob.sh
@@ -161,7 +161,8 @@ test_expect_success 'test disallow multiple globs' '
 		svn_cmd commit -m "try to try"
 	) &&
 	test_must_fail git svn fetch three 2> stderr.three &&
-	test_cmp expect.three stderr.three
+	sed "/^WARNING.*no.* supported/{N;d}" <stderr.three >stderr.three.clean &&
+	test_cmp expect.three stderr.three.clean
 	'
 
 test_done

--- a/t/t9168-git-svn-partially-globbed-names.sh
+++ b/t/t9168-git-svn-partially-globbed-names.sh
@@ -155,7 +155,8 @@ test_expect_success 'test disallow prefixed multi-globs' '
 		svn_cmd commit -m "try to try"
 	) &&
 	test_must_fail git svn fetch four 2>stderr.four &&
-	test_cmp expect.four stderr.four &&
+	sed "/^WARNING.*no.* supported/{N;d}" <stderr.four >stderr.four.clean &&
+	test_cmp expect.four stderr.four.clean &&
 	git config --unset svn-remote.four.branches &&
 	git config --unset svn-remote.four.tags
 	'
@@ -223,7 +224,8 @@ test_expect_success 'test disallow multiple asterisks in one word' '
 		svn_cmd commit -m "try to try"
 	) &&
 	test_must_fail git svn fetch six 2>stderr.six &&
-	test_cmp expect.six stderr.six
+	sed "/^WARNING.*no.* supported/{N;d}" <stderr.six >stderr.six.clean &&
+	test_cmp expect.six stderr.six.clean
 	'
 
 test_done


### PR DESCRIPTION
There have been too many challenges supporting `git svn`, including lack of participation in developing/maintaining the required stack.

See https://github.com/git-for-windows/git/issues/5405 for full details.