### PR TITLE
Add completion for short options

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -3916,6 +3916,16 @@ __git_main ()
 			--help
 			"
 			;;
+		-*)
+			__gitcomp "
+			-C
+			-P
+			-c
+			-h
+			-p
+			-v
+			"
+			;;
 		*)
 			if test -n "${GIT_TESTING_PORCELAIN_COMMAND_LIST-}"
 			then


### PR DESCRIPTION
Git provided completion for long options but not the short ones

Thanks for taking the time to contribute to Git!

Those seeking to contribute to the Git for Windows fork should see
http://gitforwindows.org/#contribute on how to contribute Windows specific
enhancements.

If your contribution is for the core Git functions and documentation
please be aware that the Git community does not use the github.com issues
or pull request mechanism for their contributions.

Instead, we use the Git mailing list (git@vger.kernel.org) for code and
documentation submissions, code reviews, and bug reports. The
mailing list is plain text only (anything with HTML is sent directly
to the spam folder).

Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

For a single-commit pull request, please *leave the pull request description
empty*: your commit message itself should describe your changes.

Please read the "guidelines for contributing" linked above!

Signed-off-by: Wiktor Mis <mwiktor023@gmail.com>