### PR TITLE
ci(macos): skip the `git p4` tests

### DIFF
--- a/ci/install-dependencies.sh
+++ b/ci/install-dependencies.sh
@@ -108,11 +108,12 @@ macos-*)
 	# brew install gnu-time
 	brew link --force gettext
 
-	mkdir -p "$CUSTOM_PATH"
-	wget -q "$P4WHENCE/bin.macosx1015x86_64/helix-core-server.tgz" &&
-	tar -xf helix-core-server.tgz -C "$CUSTOM_PATH" p4 p4d &&
-	sudo xattr -d com.apple.quarantine "$CUSTOM_PATH/p4" "$CUSTOM_PATH/p4d" 2>/dev/null || true
-	rm helix-core-server.tgz
+	# Uncomment this block if you want to run `git p4` tests:
+	# mkdir -p "$CUSTOM_PATH"
+	# wget -q "$P4WHENCE/bin.macosx1015x86_64/helix-core-server.tgz" &&
+	# tar -xf helix-core-server.tgz -C "$CUSTOM_PATH" p4 p4d &&
+	# sudo xattr -d com.apple.quarantine "$CUSTOM_PATH/p4" "$CUSTOM_PATH/p4d" 2>/dev/null || true
+	# rm helix-core-server.tgz
 
 	case "$jobname" in
 	osx-meson)


### PR DESCRIPTION
Historically, the macOS jobs have always been among the longest-running ones, and recently the `git p4` tests became another liability: They started to fail much more often (maybe as of the switch away from the `macos-13` pool?), requiring re-runs of the jobs that already were responsible for long CI build times.

Of the 35 test scripts that exercise `git p4`, 32 are actually run on macOS (3 are skipped for reasons like case-sensitivee filesystem), and they take an accumulated runtime of over half an hour.

Furthermore, the `git p4` command is not really affected by Git for Windows' patches, at least not as far as macOS is concerned, therefore it is not only causing developer friction to have these long-running, frequently failing tests, it is also quite wasteful: There has not been a single instance so far where any `git p4` test failure in Git for Windows had demonstrated an actionable bug.

So let's just disable those tests in the CI runs, at least on macOS.