### PR TITLE
t/t5571-prep-push-hook.sh: Add test with writing to stderr

### DIFF
--- a/t/t5571-pre-push-hook.sh
+++ b/t/t5571-pre-push-hook.sh
@@ -138,4 +138,16 @@ test_expect_success 'sigpipe does not cause pre-push hook failure' '
 	git push parent1 "refs/heads/b/*:refs/heads/b/*"
 '
 
+test_expect_success 'can write to stderr' '
+	test_hook --clobber pre-push <<-\EOF &&
+	echo foo >/dev/stderr &&
+	exit 0
+	EOF
+
+	test_commit third &&
+	echo foo >expect &&
+	git push --quiet parent1 HEAD 2>actual &&
+	test_cmp expect actual
+'
+
 test_done


### PR DESCRIPTION
Git v2.53.0-rc0 included f406b895529 (Merge branch 'ar/run-command-hook', 2026-01-06), which caused a regression on Windows. While this merge was reverted for independent reasons in a3d1f391d35 (Revert "Merge branch 'ar/run-command-hook'", 2026-01-15), it seems worthwhile to ensure that writing to standard error from a `pre-push` hook remains unbroken.

The symptom, when running this regression test case against v2.53.0-rc0.windows.1 is that the `git push` fails, with this message printed to standard error:

   .git/hooks/pre-push: line 2: /dev/stderr: No such file or direct[61/1940]
   error: failed to push some refs to 'repo1'

When that hook runs, `/dev/stderr` is a symlink to `/proc/self/fd/2`, as always, but `ls -l /proc/self/fd/` shows this in the failing run

  total 0
  lrwxrwxrwx 1 me 4096 0 Jan 27 14:34 0 -> pipe:[0]
  lrwxrwxrwx 1 me 4096 0 Jan 27 14:34 1 -> pipe:[0]
  lrwxrwxrwx 1 me 4096 0 Jan 27 14:34 2 -> pipe:[0]

instead of the expected contents (which are shown when running this against v2.53.0-rc1.windows.1):

  total 0
  lrwxrwxrwx 1 me 4096 0 Jan 27 14:53 0 -> 'pipe:[0]'
  lrwxrwxrwx 1 me 4096 0 Jan 27 14:53 1 -> /dev/cons1
  lrwxrwxrwx 1 me 4096 0 Jan 27 14:53 2 -> '/path/to/git/t/trash directory.t5571-pre-push-hook/actual'

This suggests that the underlying reason might be that `stdout` has an exclusive handle to that pipe, and opening `stderr` (which points to the same pipe) fails because of that exclusively-opened `stdout` handle.

This closes https://github.com/git-for-windows/git/issues/6053.