### PR TITLE
fix for false error when processing > 4GB stream

### DIFF
--- a/git-zlib.h
+++ b/git-zlib.h
@@ -7,8 +7,8 @@ typedef struct git_zstream {
 	struct z_stream_s z;
 	unsigned long avail_in;
 	unsigned long avail_out;
-	unsigned long total_in;
-	unsigned long total_out;
+	size_t total_in;
+	size_t total_out;
 	unsigned char *next_in;
 	unsigned char *next_out;
 } git_zstream;


### PR DESCRIPTION
Addressed a bug that caused erroneous error reporting when data stream sizes exceeded 4GB.

Another teaspoon of 4GB fixes.
Together with https://github.com/git-for-windows/git/pull/6069 this allows to clone/fetch/pool my 67GB repository containig 2GB+ files without error, but resulting >4GB file is 0 size on disk.

The main idea that we operate in "modulo 32bit space" keeping the 32bit stream "happy" , while counting in 64 bit