### PR TITLE
Detect number of cores better on multi-socket systems

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2938,7 +2938,7 @@ repeat:
 	if (supports_file_rename_info_ex) {
 		/*
 		 * Our minimum required Windows version is still set to Windows
-		 * Vista. We thus have to declare required infrastructure for
+		 * 8.1. We thus have to declare required infrastructure for
 		 * FileRenameInfoEx ourselves until we bump _WIN32_WINNT to
 		 * 0x0A00. Furthermore, we have to handle cases where the
 		 * FileRenameInfoEx call isn't supported yet.

--- a/compat/nedmalloc/malloc.c.h
+++ b/compat/nedmalloc/malloc.c.h
@@ -500,7 +500,7 @@ MAX_RELEASE_CHECK_RATE   default: 4095 unless not HAVE_MMAP
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x403
+#define _WIN32_WINNT 0x603
 #endif
 #include <windows.h>
 #define HAVE_MMAP 1

--- a/compat/poll/poll.c
+++ b/compat/poll/poll.c
@@ -20,7 +20,7 @@
 
 #define DISABLE_SIGN_COMPARE_WARNINGS
 
-/* To bump the minimum Windows version to Windows Vista */
+/* To bump the minimum Windows version to Windows 8.1 */
 #include "git-compat-util.h"
 
 /* Tell gcc not to warn about the (nfd < 0) tests, below.  */
@@ -41,7 +41,7 @@
 #if (defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__
 # define WIN32_NATIVE
 # if defined (_MSC_VER) && !defined(_WIN32_WINNT)
-#  define _WIN32_WINNT 0x0502
+#  define _WIN32_WINNT 0x0603
 # endif
 # include <winsock2.h>
 # include <windows.h>

--- a/compat/posix.h
+++ b/compat/posix.h
@@ -78,7 +78,7 @@
 
 #if defined(WIN32) && !defined(__CYGWIN__) /* Both MinGW and MSVC */
 # if !defined(_WIN32_WINNT)
-#  define _WIN32_WINNT 0x0600
+#  define _WIN32_WINNT 0x0603
 # endif
 #define WIN32_LEAN_AND_MEAN  /* stops windows.h including winsock.h */
 #include <winsock2.h>

--- a/compat/win32/flush.c
+++ b/compat/win32/flush.c
@@ -6,7 +6,9 @@ int win32_fsync_no_flush(int fd)
 {
        IO_STATUS_BLOCK io_status;
 
+#ifndef FLUSH_FLAGS_FILE_DATA_ONLY
 #define FLUSH_FLAGS_FILE_DATA_ONLY 1
+#endif
 
        DECLARE_PROC_ADDR(ntdll.dll, NTSTATUS, NTAPI, NtFlushBuffersFileEx,
 			 HANDLE FileHandle, ULONG Flags, PVOID Parameters, ULONG ParameterSize,

--- a/thread-utils.c
+++ b/thread-utils.c
@@ -28,11 +28,28 @@ int online_cpus(void)
 #endif
 
 #ifdef GIT_WINDOWS_NATIVE
-	SYSTEM_INFO info;
-	GetSystemInfo(&info);
-
-	if ((int)info.dwNumberOfProcessors > 0)
-		return (int)info.dwNumberOfProcessors;
+	DWORD len = 0;
+	if (!GetLogicalProcessorInformationEx(RelationProcessorCore, NULL, &len) && GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+		uint8_t *buf = malloc(len);
+		if (buf) {
+			if (GetLogicalProcessorInformationEx(RelationProcessorCore, (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) buf, &len)) {
+				DWORD offset = 0;
+				int n_cores = 0;
+				while (offset < len) {
+					PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX info = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) (buf + offset);
+					offset += info->Size;
+					/* The threads within a core always share a single group. We need to count the bits in the mask to get a thread count. */
+					for (KAFFINITY mask = info->Processor.GroupMask[0].Mask; mask; mask >>= 1)
+						n_cores += mask &1;
+				}
+				if (n_cores) {
+					free(buf);
+					return n_cores;
+				}
+			}
+			free(buf);
+		}
+	}
 #elif defined(hpux) || defined(__hpux) || defined(_hpux)
 	struct pst_dynamic psd;
 


### PR DESCRIPTION
While the currently used way to detect the number of CPU cores ond
Windows is nice and straight-forward, GetSystemInfo() only [gives us
access to the number of processors within the current group.](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info#members)

While that is usually fine for systems with a single physical CPU,
separate physical sockets are typically separate groups.

Switch to using GetLogicalProcessorInformationEx() to handle multi-socket
systems better.

I've tested this on a physical single-socket x86-64 and a physical dual-socket x86-64 system, and on a virtual single-socket ARM64 system. Physical [multi-socket ARM64 systems seem to exist](https://cloudbase.it/ampere-altra-industry-leading-arm64-server/), but I don't have access to such hardware and the hypervisor I use apparently can't emulate that either.  