### PR TITLE
Winansi: Drop pre-Vista workaround

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2938,7 +2938,7 @@ repeat:
 	if (supports_file_rename_info_ex) {
 		/*
 		 * Our minimum required Windows version is still set to Windows
-		 * Vista. We thus have to declare required infrastructure for
+		 * 8.1. We thus have to declare required infrastructure for
 		 * FileRenameInfoEx ourselves until we bump _WIN32_WINNT to
 		 * 0x0A00. Furthermore, we have to handle cases where the
 		 * FileRenameInfoEx call isn't supported yet.

--- a/compat/nedmalloc/malloc.c.h
+++ b/compat/nedmalloc/malloc.c.h
@@ -500,7 +500,7 @@ MAX_RELEASE_CHECK_RATE   default: 4095 unless not HAVE_MMAP
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x403
+#define _WIN32_WINNT 0x603
 #endif
 #include <windows.h>
 #define HAVE_MMAP 1

--- a/compat/poll/poll.c
+++ b/compat/poll/poll.c
@@ -20,7 +20,7 @@
 
 #define DISABLE_SIGN_COMPARE_WARNINGS
 
-/* To bump the minimum Windows version to Windows Vista */
+/* To bump the minimum Windows version to Windows 8.1 */
 #include "git-compat-util.h"
 
 /* Tell gcc not to warn about the (nfd < 0) tests, below.  */
@@ -41,7 +41,7 @@
 #if (defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__
 # define WIN32_NATIVE
 # if defined (_MSC_VER) && !defined(_WIN32_WINNT)
-#  define _WIN32_WINNT 0x0502
+#  define _WIN32_WINNT 0x0603
 # endif
 # include <winsock2.h>
 # include <windows.h>

--- a/compat/posix.h
+++ b/compat/posix.h
@@ -78,7 +78,7 @@
 
 #if defined(WIN32) && !defined(__CYGWIN__) /* Both MinGW and MSVC */
 # if !defined(_WIN32_WINNT)
-#  define _WIN32_WINNT 0x0600
+#  define _WIN32_WINNT 0x0603
 # endif
 #define WIN32_LEAN_AND_MEAN  /* stops windows.h including winsock.h */
 #include <winsock2.h>

--- a/compat/win32/flush.c
+++ b/compat/win32/flush.c
@@ -6,7 +6,9 @@ int win32_fsync_no_flush(int fd)
 {
        IO_STATUS_BLOCK io_status;
 
+#ifndef FLUSH_FLAGS_FILE_DATA_ONLY
 #define FLUSH_FLAGS_FILE_DATA_ONLY 1
+#endif
 
        DECLARE_PROC_ADDR(ntdll.dll, NTSTATUS, NTAPI, NtFlushBuffersFileEx,
 			 HANDLE FileHandle, ULONG Flags, PVOID Parameters, ULONG ParameterSize,

--- a/compat/winansi.c
+++ b/compat/winansi.c
@@ -32,47 +32,18 @@ static int non_ascii_used = 0;
 static HANDLE hthread, hread, hwrite;
 static HANDLE hconsole1, hconsole2;
 
-#ifdef __MINGW32__
-#if !defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 5
-typedef struct _CONSOLE_FONT_INFOEX {
-	ULONG cbSize;
-	DWORD nFont;
-	COORD dwFontSize;
-	UINT FontFamily;
-	UINT FontWeight;
-	WCHAR FaceName[LF_FACESIZE];
-} CONSOLE_FONT_INFOEX, *PCONSOLE_FONT_INFOEX;
-#endif
-#endif
-
 static void warn_if_raster_font(void)
 {
 	DWORD fontFamily = 0;
-	DECLARE_PROC_ADDR(kernel32.dll, BOOL, WINAPI,
-			GetCurrentConsoleFontEx, HANDLE, BOOL,
-			PCONSOLE_FONT_INFOEX);
+	CONSOLE_FONT_INFOEX cfi;
 
 	/* don't bother if output was ascii only */
 	if (!non_ascii_used)
 		return;
 
-	/* GetCurrentConsoleFontEx is available since Vista */
-	if (INIT_PROC_ADDR(GetCurrentConsoleFontEx)) {
-		CONSOLE_FONT_INFOEX cfi;
-		cfi.cbSize = sizeof(cfi);
-		if (GetCurrentConsoleFontEx(console, 0, &cfi))
-			fontFamily = cfi.FontFamily;
-	} else {
-		/* pre-Vista: check default console font in registry */
-		HKEY hkey;
-		if (ERROR_SUCCESS == RegOpenKeyExA(HKEY_CURRENT_USER, "Console",
-				0, KEY_READ, &hkey)) {
-			DWORD size = sizeof(fontFamily);
-			RegQueryValueExA(hkey, "FontFamily", NULL, NULL,
-					(LPVOID) &fontFamily, &size);
-			RegCloseKey(hkey);
-		}
-	}
+	cfi.cbSize = sizeof(cfi);
+	if (GetCurrentConsoleFontEx(console, 0, &cfi))
+		fontFamily = cfi.FontFamily;
 
 	if (!(fontFamily & TMPF_TRUETYPE)) {
 		const wchar_t *msg = L"\nWarning: Your console font probably "


### PR DESCRIPTION
https://github.com/git-for-windows/git/commit/1edeb9abf5828e317999b4ebe8b7472c494341f2 (Win32: warn if the console font doesn't support Unicode,
2014-06-10) introduced both code to detect the current console font on
Windows Vista and newer and a fallback for older systems to detect the
default console font and issue a warning if that font doesn't support
unicode.

Since we haven't supported any Windows older than Vista in almost a
decade, we don't need to keep the workaround.

This more or less fell out of #6108, but didn't quite fit into that PR.

There are also some other version specific hacks and workarounds I considered dropping, but decided against:

* https://github.com/git-for-windows/git/commit/492f70913e11de19bc4cb197b1fe195c645b89c9
  *  I'm unsure if this regression has ever been fixed or just become the new normal.
* #5042
  * So far this hasn't been an issue on Windows 8.1, but officially Go 1.21 and newer only support Windows 10 and newer. So this might become a problem at any point.