### PR TITLE
mingw: use strftime() directly in UCRT builds

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1509,6 +1509,9 @@ revert_attrs:
 size_t mingw_strftime(char *s, size_t max,
 		      const char *format, const struct tm *tm)
 {
+#ifdef _UCRT
+	size_t ret = strftime(s, max, format, tm);
+#else
 	/* a pointer to the original strftime in case we can't find the UCRT version */
 	static size_t (*fallback)(char *, size_t, const char *, const struct tm *) = strftime;
 	size_t ret;
@@ -1519,6 +1522,7 @@ size_t mingw_strftime(char *s, size_t max,
 		ret = strftime(s, max, format, tm);
 	else
 		ret = fallback(s, max, format, tm);
+#endif
 
 	if (!ret && errno == EINVAL)
 		die("invalid strftime format: '%s'", format);


### PR DESCRIPTION
Currently, Git for Windows is built off of the MINGW64 tool chain. But this will have to change because [the MSYS2 project deprecated this tool chain in favor of UCRT64](https://www.msys2.org/news/#2026-03-15-deprecating-the-mingw64-environment). Of course, that's only possible because they dropped support for Windows 8.1, which Git for Windows will probably have to do relatively soon. The best time to do that is probably [the Git 3.0 inflection point](https://github.com/git-for-windows/git/discussions/6018) when we already promised to drop support for older Windows versions.

To prepare for such a huge change, I investigated what needs to be changed in Git for Windows' source code. And the good news is there's actually not very much. This here patch seems to be the only change that's necessary, and not even _strictly_ necessary: the `mingw_strftime()` wrapper would still do the right thing. It would just uselessly load the same function that's already loaded, dynamically, again.

- The `strerror()` override [is guarded by an `#ifndef _UCRT`](https://github.com/git-for-windows/git/blob/v2.53.0.windows.2/compat/mingw-posix.h#L294-L296),
- `PRIuMAX` resolves to standard `"llu"` [via `<inttypes.h>`](https://github.com/git-for-windows/git/blob/v2.53.0.windows.2/compat/mingw-posix.h#L449-L454) (note that `__MINGW64_VERSION_MAJOR` is defined both in MINGW64 and UCRT64, by virtue of using the `mingw-w64-headers`),
- [`__USE_MINGW_ANSI_STDIO=0`](https://github.com/git-for-windows/git/blob/v2.53.0.windows.2/config.mak.uname#L751C19-L751C33) is irrelevant because [`_UCRT` short-circuits it](https://github.com/git-for-windows/git-sdk-64/blob/08933e673c79b5db48419917a2b02746b390afc4/mingw64/include/inttypes.h#L33), and
- `SNPRINTF_RETURNS_BOGUS` hasn't been set for Git for Windows' builds since ec47a33fd2c3b679c3d8cbd440752414adb56ce9, i.e. for a _really_ long time.