### PR TITLE
http: fix bug in ntlm_allow=1 handling

### DIFF
--- a/http.c
+++ b/http.c
@@ -1908,10 +1908,6 @@ static int handle_curl_result(struct slot_results *results)
 	else if (results->http_code == 401) {
 		http_auth.ntlm_suppressed = (results->auth_avail & CURLAUTH_NTLM) &&
 					    !(http_auth_any & CURLAUTH_NTLM);
-		if (http_auth.ntlm_suppressed && http_auth.ntlm_allow) {
-			http_auth_methods |= CURLAUTH_NTLM;
-			return HTTP_REAUTH;
-		}
 		if ((http_auth.username && http_auth.password) ||\
 		    (http_auth.authtype && http_auth.credential)) {
 			if (http_auth.multistage) {
@@ -2372,6 +2368,13 @@ static int http_request_reauth(const char *url,
 		}
 
 		credential_fill(the_repository, &http_auth, 1);
+
+		/*
+		 * Re-enable NTLM auth if the helper allows it and we would
+		 * otherwise suppress authentication via NTLM.
+		 */
+		if (http_auth.ntlm_suppressed && http_auth.ntlm_allow)
+			http_auth_methods |= CURLAUTH_NTLM;
 
 		ret = http_request(url, result, target, options);
 	}


### PR DESCRIPTION
In 816db62d10 (credential: advertise NTLM suppression and allow helpers to re-enable, 2026-02-09), Git learned to advertise that NTLM authentication was suppressed to credential helpers. It also introduced a way to allow credential helpers to opt-back-in to NTLM authentication via the `ntlm_allow=1` credential protocol flag.

There is a bug in the logic of 816db62d10 that means we are responding to the `ntlm_allow=1` signal too late in the auth retry codepath; we've already made the second-attempt request!

Move adding of NTLM as a valid auth method to `http_request_reauth` right after the credential helper is consulted following the first request, but (now) before we made the second request.