### PR TITLE
`git svn`: remove deprecation note (since it is no longer included in Git for Windows, anyway)

### DIFF
--- a/Documentation/git-svn.adoc
+++ b/Documentation/git-svn.adoc
@@ -9,7 +9,6 @@ SYNOPSIS
 --------
 [verse]
 'git svn' <command> [<options>] [<arguments>]
-(UNSUPPORTED!)
 
 DESCRIPTION
 -----------

--- a/git-svn.perl
+++ b/git-svn.perl
@@ -305,19 +305,6 @@ sub term_init {
 			: new Term::ReadLine 'git-svn';
 }
 
-sub deprecated_warning {
-    my @lines = @_;
-    if (-t STDERR) {
-        @lines = map { "\e[33m$_\e[0m" } @lines;
-    }
-    warn join("\n", @lines), "\n";
-}
-
-deprecated_warning(
-	"WARNING: \`git svn\` is no longer supported by the Git for Windows project.",
-	"See https://github.com/git-for-windows/git/issues/5405 for details."
-);
-
 my $cmd;
 for (my $i = 0; $i < @ARGV; $i++) {
 	if (defined $cmd{$ARGV[$i]}) {

--- a/t/t9108-git-svn-glob.sh
+++ b/t/t9108-git-svn-glob.sh
@@ -110,8 +110,7 @@ test_expect_success 'test disallow multi-globs' '
 		svn_cmd commit -m "try to try"
 	) &&
 	test_must_fail git svn fetch three 2> stderr.three &&
-	sed "/^WARNING.*no.* supported/{N;d}" <stderr.three >stderr.three.clean &&
-	test_cmp expect.three stderr.three.clean
+	test_cmp expect.three stderr.three
 	'
 
 test_done

--- a/t/t9109-git-svn-multi-glob.sh
+++ b/t/t9109-git-svn-multi-glob.sh
@@ -161,8 +161,7 @@ test_expect_success 'test disallow multiple globs' '
 		svn_cmd commit -m "try to try"
 	) &&
 	test_must_fail git svn fetch three 2> stderr.three &&
-	sed "/^WARNING.*no.* supported/{N;d}" <stderr.three >stderr.three.clean &&
-	test_cmp expect.three stderr.three.clean
+	test_cmp expect.three stderr.three
 	'
 
 test_done

--- a/t/t9168-git-svn-partially-globbed-names.sh
+++ b/t/t9168-git-svn-partially-globbed-names.sh
@@ -155,8 +155,7 @@ test_expect_success 'test disallow prefixed multi-globs' '
 		svn_cmd commit -m "try to try"
 	) &&
 	test_must_fail git svn fetch four 2>stderr.four &&
-	sed "/^WARNING.*no.* supported/{N;d}" <stderr.four >stderr.four.clean &&
-	test_cmp expect.four stderr.four.clean &&
+	test_cmp expect.four stderr.four &&
 	git config --unset svn-remote.four.branches &&
 	git config --unset svn-remote.four.tags
 	'
@@ -224,8 +223,7 @@ test_expect_success 'test disallow multiple asterisks in one word' '
 		svn_cmd commit -m "try to try"
 	) &&
 	test_must_fail git svn fetch six 2>stderr.six &&
-	sed "/^WARNING.*no.* supported/{N;d}" <stderr.six >stderr.six.clean &&
-	test_cmp expect.six stderr.six.clean
+	test_cmp expect.six stderr.six
 	'
 
 test_done


### PR DESCRIPTION
As of https://github.com/git-for-windows/MINGW-packages/pull/187, Git for Windows no longer includes `git svn` in its installers and portable Git editions.

As a consequence, the deprecation note is no longer necessary.

Even worse: Since the recommendation for users who want (or at least need) to continue using `git svn` is to use the MSYS2 package instead, and that MSYS2 package is built from Git for Windows' source code, they would now be bothered by a note that they do not need.

So let's drop that deprecation note.