### PR TITLE
Don't traverse mount points in `remove_dir_recurse()`

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -3457,6 +3457,13 @@ static int remove_dir_recurse(struct strbuf *path, int flag, int *kept_up)
 		return 0;
 	}
 
+	if (is_mount_point(path)) {
+		/* Do not descend and nuke a mount point or junction. */
+		if (kept_up)
+			*kept_up = 1;
+		return 0;
+	}
+
 	flag &= ~REMOVE_DIR_KEEP_TOPLEVEL;
 	dir = opendir(path->buf);
 	if (!dir) {

--- a/t/t2403-worktree-move.sh
+++ b/t/t2403-worktree-move.sh
@@ -271,4 +271,13 @@ test_expect_success 'move worktree with relative path to absolute path' '
 	test_cmp expect .git/worktrees/absolute/gitdir
 '
 
+test_expect_success MINGW 'worktree remove does not traverse mount points' '
+	mkdir target &&
+	>target/dont-remove-me &&
+	git worktree add --detach wt-junction &&
+	cmd //c "mklink /j wt-junction\\mnt target" &&
+	git worktree remove --force wt-junction &&
+	test_path_is_file target/dont-remove-me
+'
+
 test_done


### PR DESCRIPTION
`remove_dir_recurse()` in `dir.c` doesn't check for mount points, even though this check was already added for `git clean` in #2268. So `git worktree remove` (or anything else that calls it) will traverse NTFS junctions and delete whatever is there. Similar to #607.

This extends the same check from #2268 but for anything that calls `remove_dir_recurse()`. 