### PR TITLE
Drop obsolete downstream patches

### DIFF
--- a/t/t5551-http-fetch-smart.sh
+++ b/t/t5551-http-fetch-smart.sh
@@ -413,15 +413,7 @@ test_expect_success CMDLINE_LIMIT \
 	)
 '
 
-# This is a temporary work-around for libcurl v8.10.0 on the macos-* runners;
-# see https://github.com/git-for-windows/git/issues/5159 for full details
-test_lazy_prereq UNBROKEN_HTTP2 '
-	test "$HTTP_PROTO" = HTTP/2 &&
-	test -z "$(brew info -q curl 2>/dev/null |
-		sed -n "/^Installed/{N;s/.*8\\.10\\.0.*/BROKEN HTTP2/p;}")"
-'
-
-test_expect_success UNBROKEN_HTTP2 'large fetch-pack requests can be sent using chunked encoding' '
+test_expect_success 'large fetch-pack requests can be sent using chunked encoding' '
 	GIT_TRACE_CURL=true git -c http.postbuffer=65536 \
 		clone --bare "$HTTPD_URL/smart/repo.git" split.git 2>err &&
 	{


### PR DESCRIPTION
Over time, as upstream Git absorbs fixes and features that originated in or were carried by Git for Windows, downstream patches accumulate that are no longer needed. The steady stream of merged PRs makes this virtually inevitable. This PR collects fixup! commits to drop three such patches during the next autosquash rebase.

The HTTP/2 workaround in `t5551` was a temporary fix for a libcurl v8.10.0 regression on macOS CI runners. The faulty libcurl has long been superseded by fixed versions, making it unnecessary.

The `unix-socket: avoid leak when initialization fails` patch changed `return -1` to `goto fail` in `unix_stream_connect()` so cleanup would run when `unix_sockaddr_init()` failed. Upstream fixed the same leak more surgically in c5fe29f696f4 (unix-socket: fix memory leak when chdir(3p) fails, 2025-01-30) by having `unix_sockaddr_init()` call `FREE_AND_NULL(ctx->orig_dir)` before returning, making the downstream caller-side fix redundant.

The `revision: create mark_trees_uninteresting_dense()` commit was a preparatory patch for the path-walk API. That API has since been upstreamed, and this commit became empty during the merging-rebase because its changes were already in the new base.
