### PR TITLE
path.c: translate WSL and Cygwin paths when resolving worktrees

### DIFF
--- a/path.c
+++ b/path.c
@@ -18,6 +18,45 @@
 #include "lockfile.h"
 #include "exec-cmd.h"
 
+void translate_wsl_path(char *path)
+{
+#ifdef GIT_WINDOWS_NATIVE
+	static const struct {
+		const char *prefix;
+		size_t      prefix_len;
+	} posix_prefixes[] = {
+		{ "/mnt/",      5 },
+		{ "/cygdrive/", 10 },
+	};
+	size_t i, len;
+
+	if (!path || !path[0])
+		return;
+	len = strlen(path);
+
+	for (i = 0; i < ARRAY_SIZE(posix_prefixes); i++) {
+		size_t pl = posix_prefixes[i].prefix_len;
+		char drive;
+
+		if (len < pl + 1)
+			continue;
+		if (memcmp(path, posix_prefixes[i].prefix, pl) != 0)
+			continue;
+		drive = path[pl];
+		if (!isalpha((unsigned char)drive))
+			continue;
+		if (len > pl + 1 && path[pl + 1] != '/' && path[pl + 1] != '\\')
+			continue;
+
+		/* In-place rewrite to "<drive>:" + tail. Result is shorter. */
+		path[0] = drive;
+		path[1] = ':';
+		memmove(path + 2, path + pl + 1, len - pl);
+		return;
+	}
+#endif
+}
+
 static int get_st_mode_bits(const char *path, int *mode)
 {
 	struct stat st;

--- a/path.h
+++ b/path.h
@@ -7,6 +7,15 @@ struct string_list;
 struct worktree;
 
 /*
+ * Translate POSIX-style drive paths produced by Git running under WSL2
+ * (`/mnt/<x>/...`) or Cygwin/MSYS (`/cygdrive/<x>/...`) into Windows
+ * drive-letter form (`<x>:/...`). Edits `path` in place; the result is
+ * never longer than the input. No-op on non-Windows platforms, where
+ * these prefixes may name real directories on the host filesystem.
+ */
+void translate_wsl_path(char *path);
+
+/*
  * The result to all functions which return statically allocated memory may be
  * overwritten by another call to _any_ one of these functions. Consider using
  * the safer variants which operate on strbufs or return allocated memory.

--- a/setup.c
+++ b/setup.c
@@ -336,6 +336,7 @@ int get_common_dir_noenv(struct strbuf *sb, const char *gitdir)
 			data.len--;
 		data.buf[data.len] = '\0';
 		strbuf_reset(&path);
+		translate_wsl_path(data.buf);
 		if (!is_absolute_path(data.buf))
 			strbuf_addf(&path, "%s/", gitdir);
 		strbuf_addbuf(&path, &data);
@@ -1008,6 +1009,8 @@ const char *read_gitfile_gently(const char *path, int *return_error_code)
 	}
 	buf[len] = '\0';
 	dir = buf + 8;
+
+	translate_wsl_path(dir);
 
 	if (!is_absolute_path(dir) && (slash = strrchr(path, '/'))) {
 		size_t pathlen = slash+1 - path;

--- a/t/t0042-wsl-mnt-path.sh
+++ b/t/t0042-wsl-mnt-path.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+
+test_description='translate WSL/Cygwin /mnt/<x>/ paths in worktree gitfiles
+
+Verify that `git worktree add` artefacts written from inside WSL2 or
+Cygwin/MSYS - which use POSIX-mounted paths like `/mnt/c/...` or
+`/cygdrive/c/...` - are still resolvable when read back from native
+Windows git.
+'
+
+GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=main
+export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME
+
+. ./test-lib.sh
+
+# Convert any drive-prefixed path Windows git might emit to the named
+# POSIX-mount form. Handles MSYS form (/c/foo) and Windows forms
+# (C:/foo and C:\foo). MINGW-only.
+mount_form () {
+	prefix=$1 ;# /mnt or /cygdrive
+	path=$2
+	case "$path" in
+	/[A-Za-z]/*)
+		echo "$path" | sed -E "s|^/([A-Za-z])/|$prefix/\\L\\1/|"
+		;;
+	[A-Za-z]:/*)
+		echo "$path" | sed -E "s|^([A-Za-z]):/|$prefix/\\L\\1/|"
+		;;
+	[A-Za-z]:'\'*)
+		echo "$path" | sed -E "s|^([A-Za-z]):.|$prefix/\\L\\1/|; s|\\\\|/|g"
+		;;
+	*)
+		echo "$path"
+		;;
+	esac
+}
+
+to_mnt () {
+	mount_form /mnt "$1"
+}
+
+to_cygdrive () {
+	mount_form /cygdrive "$1"
+}
+
+test_expect_success MINGW 'setup main repo' '
+	git init repo &&
+	test_commit -C repo init
+'
+
+test_expect_success MINGW 'read_gitfile_gently translates /mnt/<x>/ gitdir' '
+	test_when_finished "rm -rf wtlink actual" &&
+	REAL=$(cd repo/.git && pwd) &&
+	MNT=$(to_mnt "$REAL") &&
+
+	# Sanity: the path must actually start with /mnt/ - if it does not,
+	# the host shell did not give us a path with a drive prefix and the
+	# rest of the test would be silently meaningless.
+	case "$MNT" in
+	/mnt/*) : ok ;;
+	*) BUG "to_mnt produced $MNT from $REAL" ;;
+	esac &&
+
+	mkdir wtlink &&
+	printf "gitdir: %s\n" "$MNT" >wtlink/.git &&
+
+	(cd wtlink && git rev-parse --git-dir) >actual &&
+	test_path_is_dir "$(cat actual)"
+'
+
+test_expect_success MINGW 'read_gitfile_gently translates /cygdrive/<x>/ gitdir' '
+	test_when_finished "rm -rf wtlink actual" &&
+	REAL=$(cd repo/.git && pwd) &&
+	CYG=$(to_cygdrive "$REAL") &&
+
+	mkdir wtlink &&
+	printf "gitdir: %s\n" "$CYG" >wtlink/.git &&
+
+	(cd wtlink && git rev-parse --git-dir) >actual &&
+	test_path_is_dir "$(cat actual)"
+'
+
+test_expect_success MINGW 'read_gitfile_gently leaves /mnt/<multichar>/ alone' '
+	test_when_finished "rm -rf wtlink" &&
+	mkdir wtlink &&
+	# "storage" is not a single drive letter, so this must not be
+	# translated. The path does not exist on Windows, so the open fails.
+	echo "gitdir: /mnt/storage/no/such/repo" >wtlink/.git &&
+
+	test_must_fail git -C wtlink rev-parse --git-dir 2>err &&
+	test_grep "not a git repository" err
+'
+
+test_expect_success MINGW 'get_linked_worktree finds worktree recorded with /mnt/<x>/ path' '
+	test_when_finished "rm -rf repo/wt repo/.git/worktrees/wt" &&
+
+	git -C repo worktree add --detach wt &&
+	WT_REAL=$(cd repo/wt && pwd) &&
+	WT_MNT=$(to_mnt "$WT_REAL") &&
+
+	# Overwrite the recorded worktree path with the WSL form, mimicking
+	# what `git worktree add` writes when run from inside WSL.
+	printf "%s/.git\n" "$WT_MNT" >repo/.git/worktrees/wt/gitdir &&
+
+	# `git worktree list` reads that file via get_linked_worktree.
+	# After translation the worktree must still be reachable: it must
+	# NOT be flagged prunable, and a git operation inside the worktree
+	# directory must succeed.
+	git -C repo worktree list --porcelain >list &&
+	! grep -q "^prunable" list &&
+	(cd "$WT_REAL" && git rev-parse --is-inside-work-tree)
+'
+
+test_expect_success MINGW 'get_common_dir_noenv translates /mnt/<x>/ commondir' '
+	test_when_finished "rm -rf wtdir wt actual" &&
+
+	REAL=$(cd repo/.git && pwd) &&
+	MNT=$(to_mnt "$REAL") &&
+
+	# Build a synthetic linked-worktree gitdir that points at the main
+	# repo via a /mnt/<x>/ commondir record.
+	mkdir wtdir &&
+	echo "$(cd repo && git rev-parse HEAD)" >wtdir/HEAD &&
+	echo "$MNT" >wtdir/commondir &&
+	printf "%s/.git\n" "$(pwd)" >wtdir/gitdir &&
+
+	# rev-parse --git-common-dir on a checkout that points here should
+	# resolve through the translated commondir.
+	mkdir wt &&
+	printf "gitdir: %s\n" "$(pwd)/wtdir" >wt/.git &&
+	(cd wt && git rev-parse --git-common-dir) >actual &&
+	test_path_is_dir "$(cat actual)"
+'
+
+test_done

--- a/worktree.c
+++ b/worktree.c
@@ -155,6 +155,9 @@ struct worktree *get_linked_worktree(const char *id,
 	strbuf_rtrim(&worktree_path);
 	strbuf_strip_suffix(&worktree_path, "/.git");
 
+	/* Worktree path may have been recorded under WSL/Cygwin. */
+	translate_wsl_path(worktree_path.buf);
+
 	if (!is_absolute_path(worktree_path.buf)) {
 		strbuf_strip_suffix(&path, "gitdir");
 		strbuf_addbuf(&path, &worktree_path);
@@ -992,6 +995,8 @@ int should_prune_worktree(const char *id, struct strbuf *reason, char **wtpath, 
 		goto done;
 	}
 	path[len] = '\0';
+	/* Worktree path may have been recorded under WSL/Cygwin. */
+	translate_wsl_path(path);
 	if (is_absolute_path(path)) {
 		strbuf_addstr(&dotgit, path);
 	} else {


### PR DESCRIPTION
Fixes https://github.com/git-for-windows/git/issues/6187

### The Problem

If I create a git worktree from within WSL, then Windows Git cannot resolve it, because the `gitdir` specifier will be a POSIX-style path `/mnt/c/repo...` rather than Windows-style `C:\repo\...`

(I use a hybrid Windows and WSL Ubuntu setup on the same machine; it works nearly perfectly except for the above issue, specifically with worktrees.)

### Related PRs

- I've raised a PR for the vice-versa issue--accessing Windows-originated paths from WSL Linux git--here: https://github.com/gitgitgadget/git/pull/2107
- TortoiseGit support: https://gitlab.com/tortoisegit/tortoisegit/-/merge_requests/263

### The Root Cause

Worktrees use a bi-directional link that include absolute paths in the `gitdir` value to point from the main repo to the worktree repo, and vice versa. It is specifically this `gitdir` value that needs Windows-to-POSIX path translation handling. (Nothing else besides this path requires additional logic for worktrees to work across WSL and Windows native.)

```
  <main-repo>/   ← e.g. C:\workspace\myrepo (or /mnt/c/workspace/myrepo from WSL)
  └── .git/
      └── worktrees/
          └── <name>/
              ├── gitdir      ← file. content: "<worktree>/.git\n"
              ├── commondir   ← file (sometimes). content: relative or absolute path back to main .git
              ├── HEAD
              ├── index
              └── config.worktree

  <worktree>/    ← e.g. C:\workspace\myrepo-wt
  └── .git       ← FILE (not a dir). content: "gitdir: <main-repo>/.git/worktrees/<name>\n"
```

When `git worktree add` is run from **inside WSL2 (or Cygwin/MSYS)**, git records each worktree's path in a `gitdir` file using the POSIX-mounted path of the Windows filesystem - e.g. `/mnt/c/repo/.git/worktrees/wt` or `/cygdrive/c/repo/.git/worktrees/wt`. Reading those files back from native-Windows git fails because the paths are not the expected Windows path format `C:\repo\...`, so the worktree appears broken even though it is actually reachable from Windows.

### The Solution

This PR adds a small helper `translate_wsl_path()` that rewrites the recognised POSIX-drive prefixes into Windows drive-letter form in place, and call it at the three places where Windows-native git reads a recorded worktree-related path back from disk:

  * `read_gitfile_gently()` - the `gitdir:` line in a worktree's `.git` file.
  * `get_common_dir_noenv()` - the `commondir` file inside a worktree's git directory, which points at the main repo.
  * `get_linked_worktree()` - the `gitdir` file inside `<commondir>/worktrees/<id>/`, which points at the worktree's `.git` link.

### Why this is Safe

This PR is safe because:
- The logic is **Windows-only:** the helper compiles to a no-op outside `GIT_WINDOWS_NATIVE`, so a `/mnt/c/...` path on a Linux host - where it might really exist - is still treated literally.
- The logic is **read-only:** it only affects how POSIX-style paths are read from Windows native, it does NOT mutate how the paths are stored in .git's definitions.
- **Path traversal safety:** the path translation only happens for the left-anchored part of the string `/mnt/<x>/` and `/cygdrive/<x>/` where `<x>` is a single ASCII letter and the next character is either a separator or end-of-string. Anything else (e.g. `/mnt/storage`) is left alone. The helper also doesn't evaluate/collapse relative paths, so it doesn't introduce any path-traversal vectors that aren't existing today.
