### PR TITLE
ci(vs-build): adapt to Visual Studio 2026 default on windows-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,7 +199,9 @@ jobs:
         cmake `pwd`/contrib/buildsystems/ -DCMAKE_PREFIX_PATH=`pwd`/compat/vcbuild/vcpkg/installed/${{ matrix.arch }}-windows \
         -DNO_GETTEXT=YesPlease -DPERL_TESTS=OFF -DPYTHON_TESTS=OFF -DCURL_NO_CURL_CMAKE=ON -DCMAKE_GENERATOR_PLATFORM=${{ matrix.arch }} -DVCPKG_ARCH=${{ matrix.arch }}-windows -DHOST_CPU=${{ matrix.arch }}
     - name: MSBuild
-      run: msbuild git.sln -property:Configuration=Release -property:Platform=${{ matrix.arch }} -maxCpuCount:4 -property:PlatformToolset=v142
+      run: |
+        $sln = if (Test-Path git.slnx) { 'git.slnx' } else { 'git.sln' }
+        msbuild $sln -property:Configuration=Release -property:Platform=${{ matrix.arch }} -maxCpuCount:4
     - name: bundle artifact tar
       shell: bash
       env:


### PR DESCRIPTION
The `windows-latest` runner image migration that began on June 8, 2026 and completes by June 15, 2026 swaps Visual Studio 2022 for Visual Studio 2026 by default (see [actions/runner-images#14017](https://github.com/actions/runner-images/issues/14017)). That, in turn, leaves the `vs-build` job broken because of two independent things baked into the workflow.

First, CMake 4.x now picks up the `Visual Studio 18 2026` generator on this image, and that generator writes a `.slnx` (XML solution) file rather than the classic `.sln`. The behavior is explicit in [`cmGlobalVisualStudioGenerator::GetSLNFile`](https://github.com/Kitware/CMake/blob/v4.3.2/Source/cmGlobalVisualStudioGenerator.cxx#L1147-L1159), which appends `"x"` to the filename whenever the generator version is `VS18` or newer. The MSBuild step then trips over the missing `git.sln`:

```
MSBUILD : error MSB1009: Project file does not exist.
Switch: git.sln
```

A representative failure is [actions run 27264770241](https://github.com/git-for-windows/git/actions/runs/27264770241/job/80556419519).

Second, the step has been pinning `-property:PlatformToolset=v142` since [889cacb6](https://github.com/git-for-windows/git/commit/889cacb6) (2020), when the job was first wired up for Visual Studio 2019. The new VS 2026 image only ships the v144 toolset plus a v143 compatibility component (`Microsoft.VisualStudio.Component.VC.14.44.17.14.x86.x64`); v142 is simply not installed any more, so even after the `.slnx` rename the pin would fail in its own right.

This PR therefore changes the MSBuild invocation to reference `git.slnx` and drops the v142 toolset pin, letting MSBuild use whatever toolset CMake chose during configuration (v144 on the current image). MSBuild 18, which the new image ships, understands `.slnx` natively, so no further plumbing is needed.
