### PR TITLE
Re-enable expensive tests in Windows CI

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -321,7 +321,7 @@ export SKIP_DASHED_BUILT_INS=YesPlease
 # enable the long tests for pushes to the integration branches as well.
 test -z "$MSYSTEM" ||
 case "$GITHUB_EVENT_NAME,$CI_BRANCH" in
-pull_request,*|push,*next*|push,*master*|push,*maint*)
+pull_request,*|push,*next*|push,*master*|push,*main*|push,*maint*)
 	export GIT_TEST_LONG=YesPlease
 	;;
 esac


### PR DESCRIPTION
When -rc0 was pressing and I had too many things breaking (after having a _beautifully_ passing CI of the branch thicket rebased on top of upstream's `master` [mere hours before -rc0 merged tons of big stuff](https://github.com/dscho/git/actions/runs/27341075463)), I tried to disable the expensive tests that break e.g. macOS CI jobs (because of inadequate timeouts, at least in one instance).

In my frustration, I forgot to revert a change Copilot had suggested (to skip this on pushes to `main`). Since -rc0 was tested in a PR (#6278), that bug didn't matter, but it's still better to fix that bug than to leave it in place.