### PR TITLE
AGENTS.md: document non-interactive builds (MSYSTEM, NO_RUST)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,27 @@ On Windows (in a Git for Windows SDK shell):
 make -j15
 ```
 
+When driving the build non-interactively (for example from PowerShell, or
+from an automation agent, rather than an interactive SDK shell), do not use
+a login shell. A login shell (`bash -l` / `bash --login`) re-runs the
+profile scripts and is unnecessary once `MSYSTEM` and `PATH` are set
+explicitly. Instead set `MSYSTEM` and prepend the SDK's binary directories
+to `PATH`, then invoke a non-login `bash -c` (replace `C:\git-sdk-64` with
+your SDK root):
+
+```powershell
+$env:MSYSTEM = "MINGW64"
+$env:PATH = "C:\git-sdk-64\mingw64\bin;C:\git-sdk-64\usr\bin;" + $env:PATH
+& C:\git-sdk-64\usr\bin\bash.exe -c "make -j15"
+```
+
+If the link step fails to find `target/release/libgitcore.a` (the optional
+Rust component), pass `NO_RUST=1` to skip the cargo step:
+
+```powershell
+& C:\git-sdk-64\usr\bin\bash.exe -c "make -j15 NO_RUST=1"
+```
+
 ### Run Specific Tests
 
 ```bash


### PR DESCRIPTION
This is a small documentation improvement to `AGENTS.md`. The current "Building and Testing" section only shows `make -j15` "in a Git for Windows SDK shell" and says nothing about how to drive the build when you are not sitting in an interactive SDK shell, for example from PowerShell or from an automation agent. These are two things that are easy to get wrong in that situation, so let's write them down.

The first is that a login shell is the wrong tool: `bash -l` / `bash --login` re-runs the profile scripts and is unnecessary once `MSYSTEM` and `PATH` are set explicitly. Setting `MSYSTEM=MINGW64` and prepending the SDK's `mingw64\bin` and `usr\bin` directories to `PATH`, then invoking a non-login `bash -c`, is enough to get a working build environment. The second is that when the optional Rust component fails to link (`cannot find target/release/libgitcore.a`), passing `NO_RUST=1` skips the cargo step.

This is expressed as a `fixup!` for the commit that introduced `AGENTS.md`, so that it autosquashes into that commit during the next merging-rebase rather than adding a separate entry to the branch thicket.
