### PR TITLE
Fix `vcpkg_install.bat`

### DIFF
--- a/compat/vcbuild/vcpkg_install.bat
+++ b/compat/vcbuild/vcpkg_install.bat
@@ -127,5 +127,5 @@ set features=
 goto :EOF
 
 :curl_features
-set features=[core,openssl,schannel]
+set features=[core,ssl]
 goto :EOF


### PR DESCRIPTION
While researching a build failure in `shears/seen`, I noticed that the `vcpkg` Pipeline [has been broken since August last year](https://dev.azure.com/git/git/_build?definitionId=9&_a=summary) 🤦. The reason is that the `schannel` feature of `curl` was removed, as part of https://github.com/microsoft/vcpkg/pull/46459. This PR did not remove _Secure Channel support_, it merely removed the ability to specify it _as a feature_. Let's accommodate for that.