### PR TITLE
Some amendments for the `hashliteral_t` size fixes

### DIFF
--- a/odb/source-files.c
+++ b/odb/source-files.c
@@ -159,7 +159,7 @@ static int odb_source_files_freshen_object(struct odb_source *source,
 }
 
 static int odb_source_files_write_object(struct odb_source *source,
-					 const void *buf, unsigned long len,
+					 const void *buf, size_t len,
 					 enum object_type type,
 					 struct object_id *oid,
 					 struct object_id *compat_oid,

--- a/odb/source-inmemory.c
+++ b/odb/source-inmemory.c
@@ -227,7 +227,7 @@ static int odb_source_inmemory_count_objects(struct odb_source *source,
 }
 
 static int odb_source_inmemory_write_object(struct odb_source *source,
-					    const void *buf, unsigned long len,
+					    const void *buf, size_t len,
 					    enum object_type type,
 					    struct object_id *oid,
 					    struct object_id *compat_oid UNUSED,

--- a/odb/source-loose.c
+++ b/odb/source-loose.c
@@ -583,7 +583,7 @@ static int odb_source_loose_freshen_object(struct odb_source *source,
 }
 
 static int odb_source_loose_write_object(struct odb_source *source,
-					 const void *buf, unsigned long len,
+					 const void *buf, size_t len,
 					 enum object_type type, struct object_id *oid,
 					 struct object_id *compat_oid_in,
 					 enum odb_write_object_flags flags)

--- a/odb/source.h
+++ b/odb/source.h
@@ -199,7 +199,7 @@ struct odb_source {
 	 * return 0 on success, a negative error code otherwise.
 	 */
 	int (*write_object)(struct odb_source *source,
-			    const void *buf, unsigned long len,
+			    const void *buf, size_t len,
 			    enum object_type type,
 			    struct object_id *oid,
 			    struct object_id *compat_oid,

--- a/t/t1007-hash-object.sh
+++ b/t/t1007-hash-object.sh
@@ -277,7 +277,7 @@ test_expect_success EXPENSIVE,SIZE_T_IS_64BIT \
 	test_cmp expect actual
 '
 
-test_expect_success EXPENSIVE,SIZE_T_IS_64BIT,!LONG_IS_64BIT \
+test_expect_success EXPENSIVE,SIZE_T_IS_64BIT \
 		'files over 4GB hash correctly' '
 	{ test -f big || test-tool genzeros $((5*1024*1024*1024)) >big; } &&
 	test_oid large5GB >expect &&

--- a/t/t1007-hash-object.sh
+++ b/t/t1007-hash-object.sh
@@ -269,7 +269,7 @@ test_expect_success EXPENSIVE,SIZE_T_IS_64BIT \
 	test_cmp expect actual
 '
 
-test_expect_success EXPENSIVE,SIZE_T_IS_64BIT,!LONG_IS_64BIT \
+test_expect_success EXPENSIVE,SIZE_T_IS_64BIT \
 		'files over 4GB hash correctly via --stdin' '
 	{ test -f big || test-tool genzeros $((5*1024*1024*1024)) >big; } &&
 	test_oid large5GB >expect &&

--- a/t/t1007-hash-object.sh
+++ b/t/t1007-hash-object.sh
@@ -287,7 +287,7 @@ test_expect_success EXPENSIVE,SIZE_T_IS_64BIT \
 
 # This clean filter does nothing, other than excercising the interface.
 # We ensure that cleaning doesn't mangle large files on 64-bit Windows.
-test_expect_success EXPENSIVE,SIZE_T_IS_64BIT,!LONG_IS_64BIT \
+test_expect_success EXPENSIVE,SIZE_T_IS_64BIT \
 		'hash filtered files over 4GB correctly' '
 	{ test -f big || test-tool genzeros $((5*1024*1024*1024)) >big; } &&
 	test_oid large5GB >expect &&

--- a/t/t1007-hash-object.sh
+++ b/t/t1007-hash-object.sh
@@ -261,7 +261,7 @@ test_expect_success '--stdin outside of repository (uses default hash)' '
 	test_cmp expect actual
 '
 
-test_expect_success EXPENSIVE,SIZE_T_IS_64BIT,!LONG_IS_64BIT \
+test_expect_success EXPENSIVE,SIZE_T_IS_64BIT \
 		'files over 4GB hash literally' '
 	test-tool genzeros $((5*1024*1024*1024)) >big &&
 	test_oid large5GB >expect &&


### PR DESCRIPTION
While upstreaming those patches, I've been asked to adjust them. This backports those fixes.

Of course, the _real_ reason to do this _now_ is that I need _some_ PR to make a new Git for Windows release (to address [the NTLM](https://github.com/git-for-windows/git/issues/6308) issue).