### PR TITLE
monitor-components: stop looking for mimalloc updates

### DIFF
--- a/.github/workflows/monitor-components.yml
+++ b/.github/workflows/monitor-components.yml
@@ -77,9 +77,6 @@ jobs:
             feed: https://github.com/msys2/MINGW-packages/commits/master/mingw-w64-llvm.atom
           - label: innosetup
             feed: https://github.com/jrsoftware/issrc/tags.atom
-          - label: mimalloc
-            feed: https://github.com/microsoft/mimalloc/tags.atom
-            title-pattern: ^(?!v1\.|v3\.[01]\.)
       fail-fast: false
     steps:
       - uses: git-for-windows/rss-to-issues@v0


### PR DESCRIPTION
As of https://github.com/git-for-windows/git/pull/6231, Git for Windows does not use mimalloc anymore (because the system allocator has sprouted comparable performance in the meantime).

So let's not bother looking for new versions of that project, no reaction is needed from Git for Windows' side anymore when those appear.