### PR TITLE
run-command: avoid NULL dereference for missing Windows shell

### DIFF
--- a/run-command.c
+++ b/run-command.c
@@ -280,6 +280,8 @@ char *git_shell_path(void)
 	return xstrdup(SHELL_PATH);
 #else
 	char *p = locate_in_PATH("sh");
+	if (!p)
+		die(_("cannot find 'sh' in PATH"));
 	convert_slashes(p);
 	return p;
 #endif

--- a/t/helper/test-run-command.c
+++ b/t/helper/test-run-command.c
@@ -103,6 +103,16 @@ static int test_stdin_pipe_feed(int hook_stdin_fd, void *cb UNUSED, void *task_c
 	return !(*lines_remaining);
 }
 
+static int shell_path_without_path(void)
+{
+	char *path;
+
+	unsetenv("PATH");
+	path = git_shell_path();
+	free(path);
+	return 0;
+}
+
 struct testsuite {
 	struct string_list tests, failed;
 	int next;
@@ -450,6 +460,8 @@ int cmd__run_command(int argc, const char **argv)
 
 	if (argc > 1 && !strcmp(argv[1], "testsuite"))
 		return testsuite(argc - 1, argv + 1);
+	if (argc > 1 && !strcmp(argv[1], "shell-path-without-path"))
+		return shell_path_without_path();
 	if (!strcmp(argv[1], "inherited-handle"))
 		return inherit_handle(argv[0]);
 	if (!strcmp(argv[1], "inherited-handle-child"))

--- a/t/t0061-run-command.sh
+++ b/t/t0061-run-command.sh
@@ -16,6 +16,11 @@ test_expect_success MINGW 'subprocess inherits only std handles' '
 	test-tool run-command inherited-handle
 '
 
+test_expect_success MINGW 'missing shell path is reported' '
+	test_must_fail test-tool run-command shell-path-without-path 2>err &&
+	test_grep "cannot find .sh. in PATH" err
+'
+
 test_expect_success 'start_command reports ENOENT (slash)' '
 	test-tool run-command start-command-ENOENT ./does-not-exist 2>err &&
 	test_grep "\./does-not-exist" err


### PR DESCRIPTION
## Summary

On native Windows, `git_shell_path()` assumes that `locate_in_PATH("sh")`
always succeeds and passes its result directly to `convert_slashes()`. If
`sh` is absent from `PATH`, the lookup returns `NULL` and Git terminates
with an access violation.

Check the lookup result and report a fatal error instead:

```
fatal: cannot find 'sh' in PATH
```

This prevents the NULL dereference. It does not add a shell fallback, so
commands requiring a shell still fail when no shell is available.

## Crash analysis

The failure was reproduced in `git-remote-https.exe` from Git for Windows
2.55.0.windows.3. ProcDump captured the unhandled exception:

```text
Process:               git-remote-https.exe (97196)
Process image:         C:\Program Files\Git\mingw64\libexec\git-core\git-remote-https.exe
Exception monitor:     Unhandled

[21:32:43]Exception: C0000005.ACCESS_VIOLATION
[21:32:43]Unhandled: C0000005.ACCESS_VIOLATION
[21:32:43]Dump 1 initiated: D:\Libraries\Downloads\git-remote-https-crash.dmp
[21:32:44]Dump 1 writing: Estimated dump file size is 47 MB.
[21:32:44]Dump 1 complete: 47 MB written in 0.6 seconds
```

The dump confirms that the faulting instruction attempted to read through
`RAX` while `RAX` was zero:

```text
C0000005.ACCESS_VIOLATION
RAX=0000000000000000
movzx edx, byte ptr [rax]
```

Correlation of the surrounding disassembly with the source shows it
loading `"sh"`, performing the PATH lookup, and then entering the slash
conversion. This matches the native Windows implementation:

```c
char *p = locate_in_PATH("sh");
convert_slashes(p);
```

The reproduced missing-`sh` condition therefore leaves `p` as `NULL`,
which is dereferenced by `convert_slashes()`.

## Regression test

Add a MINGW-only regression test that clears `PATH` inside
`test-tool run-command`, calls `git_shell_path()`, and verifies that Git
reports the controlled fatal diagnostic instead of crashing.

The helper clears `PATH` after process startup, making the missing-shell
condition deterministic without depending on Windows startup PATH
reconstruction.

## Testing

Passed:

- `git diff --check`
- Shell syntax check for `t/t0061-run-command.sh`
- Added-line formatting and commit-message checks

The native Windows test suite was not run locally because a Git for
Windows SDK/compiler was unavailable in the test environment. Windows CI
is expected to build the change and run `t0061-run-command.sh`.
<img width="500" height="230" alt="codex-clipboard-d4f6fbaa-5f73-4e36-8923-acc0596047db" src="https://github.com/user-attachments/assets/ffe18c92-32c0-4dd7-96fc-d7bc59d2a3b4" />
