### PR TITLE
parallel-checkout: fix stack buffer overflow in Windows poll() with many workers

### DIFF
--- a/Documentation/config/checkout.adoc
+++ b/Documentation/config/checkout.adoc
@@ -30,6 +30,11 @@ commands or functionality in the future.
 	all commands that perform checkout. E.g. checkout, clone, reset,
 	sparse-checkout, etc.
 +
+On Windows the number of workers is capped at 62, because the `poll()`
+emulation cannot wait on more worker pipes than that. A higher configured
+value, including the logical core count on a machine with many cores, is
+silently reduced to the cap.
++
 NOTE: Parallel checkout usually delivers better performance for repositories
 located on SSDs or over NFS. For repositories on spinning disks and/or machines
 with a small number of cores, the default sequential checkout often performs

--- a/Makefile
+++ b/Makefile
@@ -1540,6 +1540,7 @@ CLAR_TEST_SUITES += u-odb-inmemory
 CLAR_TEST_SUITES += u-oid-array
 CLAR_TEST_SUITES += u-oidmap
 CLAR_TEST_SUITES += u-oidtree
+CLAR_TEST_SUITES += u-poll
 CLAR_TEST_SUITES += u-prio-queue
 CLAR_TEST_SUITES += u-reftable-basics
 CLAR_TEST_SUITES += u-reftable-block

--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -2313,6 +2313,7 @@ static int fetch_multiple(struct string_list *list, int max_children,
 			.tr2_label = "parallel/fetch",
 
 			.processes = max_children,
+			.no_stdin_pipe = 1,
 
 			.get_next_task = &fetch_next_remote,
 			.start_failure = &fetch_failed_to_start,

--- a/builtin/submodule--helper.c
+++ b/builtin/submodule--helper.c
@@ -2914,6 +2914,7 @@ static int update_submodules(struct update_data *update_data)
 		.tr2_label = "parallel/update",
 
 		.processes = update_data->max_jobs,
+		.no_stdin_pipe = 1,
 
 		.get_next_task = update_clone_get_next_task,
 		.start_failure = update_clone_start_failure,

--- a/compat/poll/poll.c
+++ b/compat/poll/poll.c
@@ -303,6 +303,40 @@ compute_revents (int fd, int sought, fd_set *rfds, fd_set *wfds, fd_set *efds)
 }
 #endif /* !MinGW */
 
+#ifdef WIN32_NATIVE
+/* POLL_MAX_DESCRIPTORS descriptors, plus hEvent and the QS_ALLINPUT message
+   queue, must fit in one MsgWaitForMultipleObjects call, and the collected
+   handles plus the NULL sentinel must fit in handle_array.  */
+#if POLL_MAX_DESCRIPTORS + 2 > MAXIMUM_WAIT_OBJECTS
+#error POLL_MAX_DESCRIPTORS exceeds MAXIMUM_WAIT_OBJECTS
+#endif
+#if POLL_MAX_DESCRIPTORS + 2 > FD_SETSIZE + 2
+#error POLL_MAX_DESCRIPTORS does not fit in handle_array
+#endif
+
+/* Undo the WSAEventSelect() calls made for the first NFD descriptors.  */
+static void
+reset_socket_events (struct pollfd *pfd, nfds_t nfd)
+{
+  nfds_t i;
+
+  for (i = 0; i < nfd; i++)
+    {
+      HANDLE h;
+
+      if (pfd[i].fd < 0)
+	continue;
+
+      h = (HANDLE) _get_osfhandle (pfd[i].fd);
+      if (h == NULL || h == INVALID_HANDLE_VALUE)
+	continue;
+
+      if (IsSocketHandle (h))
+	WSAEventSelect ((SOCKET) h, NULL, 0);
+    }
+}
+#endif
+
 int
 poll (struct pollfd *pfd, nfds_t nfd, int timeout)
 {
@@ -504,7 +538,16 @@ restart:
 	     bits for the "wrong" direction. */
 	  pfd[i].revents = win32_compute_revents (h, &sought);
 	  if (sought)
-	    handle_array[nhandles++] = h;
+	    {
+	      /* hEvent occupies handle_array[0].  See POLL_MAX_DESCRIPTORS.  */
+	      if (nhandles > POLL_MAX_DESCRIPTORS)
+		{
+		  reset_socket_events (pfd, i);
+		  errno = EINVAL;
+		  return -1;
+		}
+	      handle_array[nhandles++] = h;
+	    }
 	  if (pfd[i].revents)
 	    timeout = 0;
 	}

--- a/compat/poll/poll.c
+++ b/compat/poll/poll.c
@@ -326,6 +326,9 @@ reset_socket_events (struct pollfd *pfd, nfds_t nfd)
 
       if (pfd[i].fd < 0)
 	continue;
+      if (!(pfd[i].events & (POLLIN | POLLRDNORM | POLLOUT | POLLWRNORM |
+			     POLLWRBAND | POLLPRI | POLLRDBAND)))
+	continue;
 
       h = (HANDLE) _get_osfhandle (pfd[i].fd);
       if (h == NULL || h == INVALID_HANDLE_VALUE)

--- a/compat/poll/poll.h
+++ b/compat/poll/poll.h
@@ -59,6 +59,20 @@ typedef unsigned long nfds_t;
 
 extern int poll (struct pollfd *pfd, nfds_t nfd, int timeout);
 
+/*
+ * This poll() is emulated with MsgWaitForMultipleObjects(), which waits on at
+ * most MAXIMUM_WAIT_OBJECTS (64) objects. Two of those are never available for
+ * polled descriptors: poll() waits on its own event object, and QS_ALLINPUT
+ * adds the thread message queue. Sockets do not count, because they are all
+ * multiplexed onto that one event object; every other descriptor takes a wait
+ * slot of its own.
+ *
+ * Callers that poll one or more descriptors per child must keep the number of
+ * simultaneously live descriptors within this limit. Exceeding it fails with
+ * EINVAL.
+ */
+#define POLL_MAX_DESCRIPTORS 62
+
 /* Define INFTIM only if doing so conforms to POSIX.  */
 #if !defined (_POSIX_C_SOURCE) && !defined (_XOPEN_SOURCE)
 #define INFTIM (-1)

--- a/compat/poll/poll.h
+++ b/compat/poll/poll.h
@@ -59,6 +59,7 @@ typedef unsigned long nfds_t;
 
 extern int poll (struct pollfd *pfd, nfds_t nfd, int timeout);
 
+#if (defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__
 /*
  * This poll() is emulated with MsgWaitForMultipleObjects(), which waits on at
  * most MAXIMUM_WAIT_OBJECTS (64) objects. Two of those are never available for
@@ -72,6 +73,7 @@ extern int poll (struct pollfd *pfd, nfds_t nfd, int timeout);
  * EINVAL.
  */
 #define POLL_MAX_DESCRIPTORS 62
+#endif
 
 /* Define INFTIM only if doing so conforms to POSIX.  */
 #if !defined (_POSIX_C_SOURCE) && !defined (_XOPEN_SOURCE)

--- a/compat/posix.h
+++ b/compat/posix.h
@@ -133,6 +133,16 @@
 /* Pull the compat stuff */
 #include <poll.h>
 #endif
+
+/*
+ * compat/poll defines POLL_MAX_DESCRIPTORS to the largest number of
+ * descriptors its poll() emulation can wait on. A native poll() has no such
+ * limit, so callers that fan out one descriptor per child can clamp against
+ * this unconditionally.
+ */
+#ifndef POLL_MAX_DESCRIPTORS
+#define POLL_MAX_DESCRIPTORS INT_MAX
+#endif
 #ifdef HAVE_BSD_SYSCTL
 #include <sys/sysctl.h>
 #endif

--- a/hook.c
+++ b/hook.c
@@ -798,6 +798,7 @@ int run_hooks_opt(struct repository *r, const char *hook_name,
 
 		.processes = jobs,
 		.ungroup = jobs == 1,
+		.no_stdin_pipe = !options->feed_pipe,
 
 		.get_next_task = pick_next_hook,
 		.start_failure = notify_start_failure,

--- a/parallel-checkout.c
+++ b/parallel-checkout.c
@@ -671,6 +671,13 @@ int run_parallel_checkout(struct checkout *state, int num_workers, int threshold
 	if (parallel_checkout.nr < num_workers)
 		num_workers = parallel_checkout.nr;
 
+	/*
+	 * gather_results_from_workers() polls one pipe per worker, so the
+	 * worker count must stay within what poll() can wait on.
+	 */
+	if (num_workers > POLL_MAX_DESCRIPTORS)
+		num_workers = POLL_MAX_DESCRIPTORS;
+
 	if (num_workers <= 1 || parallel_checkout.nr < threshold) {
 		write_items_sequentially(state);
 	} else {

--- a/run-command.c
+++ b/run-command.c
@@ -1893,6 +1893,7 @@ void run_processes_parallel(const struct run_process_parallel_opts *opts)
 	int i, code;
 	int timeout = 100;
 	int spawn_cap = 4;
+	size_t max_live;
 	struct parallel_processes_for_signal pp_sig;
 	struct parallel_processes pp = {
 		.buffered_output = STRBUF_INIT,
@@ -1901,6 +1902,18 @@ void run_processes_parallel(const struct run_process_parallel_opts *opts)
 	const char *tr2_category = opts->tr2_category;
 	const char *tr2_label = opts->tr2_label;
 	const int do_trace2 = tr2_category && tr2_label;
+
+	/*
+	 * Unless the caller handles its own output, pp_buffer_io() polls one
+	 * pipe for each child that is sending output and a second one for each
+	 * child that is being fed on stdin. Limit how many children run at once
+	 * so that the worst case stays within what poll() can wait on. Only
+	 * concurrency is limited; the configured maximum is still honoured for
+	 * the number of tasks that are run in total.
+	 */
+	max_live = opts->processes;
+	if (!opts->ungroup && max_live > POLL_MAX_DESCRIPTORS / 2)
+		max_live = POLL_MAX_DESCRIPTORS / 2;
 
 	if (do_trace2)
 		trace2_region_enter_printf(tr2_category, tr2_label, NULL,
@@ -1923,7 +1936,7 @@ void run_processes_parallel(const struct run_process_parallel_opts *opts)
 	while (1) {
 		for (i = 0;
 		    i < spawn_cap && !pp.shutdown &&
-		    pp.nr_processes < opts->processes;
+		    pp.nr_processes < max_live;
 		    i++) {
 			code = pp_start_one(&pp, opts);
 			if (!code)

--- a/run-command.c
+++ b/run-command.c
@@ -1658,6 +1658,9 @@ static int pp_start_one(struct parallel_processes *pp,
 		}
 		return 1;
 	}
+	if (opts->no_stdin_pipe && pp->children[i].process.in < 0)
+		BUG("get_next_task requested a stdin pipe despite "
+		    "no_stdin_pipe");
 	if (!opts->ungroup) {
 		pp->children[i].process.err = -1;
 		pp->children[i].process.stdout_to_stderr = 1;
@@ -1905,15 +1908,17 @@ void run_processes_parallel(const struct run_process_parallel_opts *opts)
 
 	/*
 	 * Unless the caller handles its own output, pp_buffer_io() polls one
-	 * pipe for each child that is sending output and a second one for each
-	 * child that is being fed on stdin. Limit how many children run at once
-	 * so that the worst case stays within what poll() can wait on. Only
-	 * concurrency is limited; the configured maximum is still honoured for
-	 * the number of tasks that are run in total.
+	 * output pipe per child and, unless excluded by no_stdin_pipe, may also
+	 * poll an input pipe. Limit the number of live children so that all of
+	 * their descriptors fit in one poll() call.
 	 */
 	max_live = opts->processes;
-	if (!opts->ungroup && max_live > POLL_MAX_DESCRIPTORS / 2)
-		max_live = POLL_MAX_DESCRIPTORS / 2;
+	if (!opts->ungroup) {
+		size_t fds_per_process = opts->no_stdin_pipe ? 1 : 2;
+
+		if (max_live > POLL_MAX_DESCRIPTORS / fds_per_process)
+			max_live = POLL_MAX_DESCRIPTORS / fds_per_process;
+	}
 
 	if (do_trace2)
 		trace2_region_enter_printf(tr2_category, tr2_label, NULL,

--- a/run-command.h
+++ b/run-command.h
@@ -489,6 +489,12 @@ struct run_process_parallel_opts
 	unsigned int ungroup:1;
 
 	/**
+	 * no_stdin_pipe: set if get_next_task will never request a pipe by
+	 * setting child_process.in to -1.
+	 */
+	unsigned int no_stdin_pipe:1;
+
+	/**
 	 * get_next_task: See get_next_task_fn() above. This must be
 	 * specified.
 	 */

--- a/submodule.c
+++ b/submodule.c
@@ -1835,6 +1835,7 @@ int fetch_submodules(struct repository *r,
 		.tr2_label = "parallel/fetch",
 
 		.processes = max_parallel_jobs,
+		.no_stdin_pipe = 1,
 
 		.get_next_task = get_next_submodule,
 		.start_failure = fetch_start_failure,

--- a/t/helper/test-run-command.c
+++ b/t/helper/test-run-command.c
@@ -20,13 +20,14 @@
 #include "wildmatch.h"
 
 static int number_callbacks;
+static int max_callbacks = 4;
 static int parallel_next(struct child_process *cp,
 			 struct strbuf *err,
 			 void *cb,
 			 void **task_cb)
 {
 	struct child_process *d = cb;
-	if (number_callbacks >= 4)
+	if (number_callbacks >= max_callbacks)
 		return 0;
 
 	strvec_pushv(&cp->args, d->args.v);
@@ -195,6 +196,7 @@ static int testsuite(int argc, const char **argv)
 		OPT_END()
 	};
 	struct run_process_parallel_opts opts = {
+		.no_stdin_pipe = 1,
 		.get_next_task = next_test,
 		.start_failure = test_failed,
 		.feed_pipe = test_stdin_pipe_feed,
@@ -442,6 +444,16 @@ static int inherit_handle_child(void)
 int cmd__run_command(int argc, const char **argv)
 {
 	struct child_process proc = CHILD_PROCESS_INIT;
+	const char * const parallel_usage[] = {
+		"test-tool run-command <parallel-mode> [<options>] "
+		"<jobs> <command> [<args>...]",
+		NULL
+	};
+	struct option parallel_options[] = {
+		OPT_INTEGER_F(0, "tasks", &max_callbacks,
+			      "number of tasks to generate", PARSE_OPT_NONEG),
+		OPT_END()
+	};
 	int jobs;
 	int ret;
 	struct run_process_parallel_opts opts = {
@@ -495,17 +507,28 @@ int cmd__run_command(int argc, const char **argv)
 		opts.ungroup = 1;
 	}
 
+	argc = parse_options(argc - 1, argv + 1, NULL, parallel_options,
+			     parallel_usage, PARSE_OPT_STOP_AT_NON_OPTION |
+			     PARSE_OPT_KEEP_ARGV0);
+	if (argc < 3)
+		usage_with_options(parallel_usage, parallel_options);
+	if (max_callbacks < 0)
+		die("--tasks cannot be negative");
+
 	jobs = atoi(argv[2]);
 	strvec_clear(&proc.args);
 	strvec_pushv(&proc.args, (const char **)argv + 3);
 
 	if (!strcmp(argv[1], "run-command-parallel")) {
+		opts.no_stdin_pipe = 1;
 		opts.get_next_task = parallel_next;
 		opts.task_finished = task_finished_quiet;
 	} else if (!strcmp(argv[1], "run-command-abort")) {
+		opts.no_stdin_pipe = 1;
 		opts.get_next_task = parallel_next;
 		opts.task_finished = task_finished;
 	} else if (!strcmp(argv[1], "run-command-no-jobs")) {
+		opts.no_stdin_pipe = 1;
 		opts.get_next_task = no_job;
 		opts.task_finished = task_finished;
 	} else if (!strcmp(argv[1], "run-command-stdin")) {

--- a/t/meson.build
+++ b/t/meson.build
@@ -11,6 +11,7 @@ clar_test_suites = [
   'unit-tests/u-oid-array.c',
   'unit-tests/u-oidmap.c',
   'unit-tests/u-oidtree.c',
+  'unit-tests/u-poll.c',
   'unit-tests/u-prio-queue.c',
   'unit-tests/u-reftable-basics.c',
   'unit-tests/u-reftable-block.c',

--- a/t/t0061-run-command.sh
+++ b/t/t0061-run-command.sh
@@ -164,6 +164,77 @@ test_expect_success 'run_command runs ungrouped in parallel with more tasks than
 	test_line_count = 4 err
 '
 
+wait_for_line_count () {
+	expected=$1 &&
+	file=$2 &&
+
+	for i in $(test_seq 1 100)
+	do
+		if test "$(wc -l <"$file")" -eq "$expected"
+		then
+			return 0
+		fi &&
+		sleep 0.1
+	done &&
+	return 1
+}
+
+cleanup_parallel () {
+	touch release
+	if test -n "$parallel_pid"
+	then
+		wait "$parallel_pid"
+	fi
+}
+
+test_expect_success MINGW 'setup poll descriptor limit test' '
+	write_script wait-for-release <<-\EOF
+	echo started >>"$1"
+	if test "$3" = stdin
+	then
+		while read line
+		do
+			:
+		done
+	fi
+	while ! test -e "$2"
+	do
+		sleep 0.1
+	done
+	EOF
+'
+
+test_expect_success MINGW 'run_command uses full poll limit without stdin' '
+	: >started &&
+	rm -f release &&
+	test-tool run-command run-command-parallel --tasks=40 40 \
+		./wait-for-release "$PWD/started" "$PWD/release" \
+		>out 2>err &
+	parallel_pid=$! &&
+	test_when_finished cleanup_parallel &&
+	wait_for_line_count 40 started &&
+	touch release &&
+	wait "$parallel_pid" &&
+	parallel_pid=
+'
+
+test_expect_success MINGW 'run_command limits children with stdin pipes' '
+	: >started &&
+	rm -f release &&
+	test-tool run-command run-command-stdin --tasks=40 40 \
+		./wait-for-release "$PWD/started" "$PWD/release" stdin \
+		>out 2>err &
+	parallel_pid=$! &&
+	test_when_finished cleanup_parallel &&
+	wait_for_line_count 31 started &&
+	sleep 1 &&
+	test_line_count = 31 started &&
+	touch release &&
+	wait "$parallel_pid" &&
+	parallel_pid= &&
+	test_line_count = 40 started
+'
+
 test_expect_success 'run_command listens to stdin' '
 	cat >expect <<-\EOF &&
 	preloaded output of a child

--- a/t/t2080-parallel-checkout-basics.sh
+++ b/t/t2080-parallel-checkout-basics.sh
@@ -319,5 +319,41 @@ test_expect_success MINGW 'parallel checkout with fscache does not fail on new d
 		test_cmp expect2 sub/deep/dir/file2.txt
 	)
 '
+# Windows has no native poll(). compat/poll emulates it with
+# MsgWaitForMultipleObjects(), which cannot wait on more than
+# MAXIMUM_WAIT_OBJECTS objects, so run_parallel_checkout() caps the worker
+# count at MAXIMUM_WAIT_OBJECTS - 2. Without that cap, compat/poll collected
+# one wait handle per polled worker pipe in a fixed-size stack array and
+# smashed the stack.
+#
+# MAXIMUM_WAIT_OBJECTS is 64, hence the expected 62 below. The test is
+# MINGW-only because the cap only exists there; on other platforms the
+# requested 200 workers are used as-is.
+test_expect_success MINGW 'checkout caps workers at the poll limit' '
+	test_when_finished "rm -rf many-workers" &&
+	git init many-workers &&
+	(
+		cd many-workers &&
+		mkdir dir &&
+		for i in $(test_seq 1 200)
+		do
+			echo "content $i" >dir/file$i || return 1
+		done &&
+		git add -A &&
+		git commit -q -m base &&
+
+		git checkout -q -b other &&
+		for i in $(test_seq 1 200)
+		do
+			echo "changed $i" >dir/file$i || return 1
+		done &&
+		git commit -q -a -m changed &&
+		git checkout -q -
+	) &&
+
+	set_checkout_config 200 1 &&
+	test_checkout_workers 62 git -C many-workers checkout other &&
+	verify_checkout many-workers
+'
 
 test_done

--- a/t/unit-tests/u-poll.c
+++ b/t/unit-tests/u-poll.c
@@ -1,0 +1,163 @@
+#include "unit-test.h"
+
+#ifdef GIT_WINDOWS_NATIVE
+static struct {
+	int pipes[POLL_MAX_DESCRIPTORS + 1][2];
+	size_t nr_pipes;
+	int listener;
+	int sockets[2];
+	WSAEVENT event;
+	int event_selected;
+} poll_test;
+
+static void open_pipes(struct pollfd *fds, size_t nr)
+{
+	size_t i;
+
+	cl_assert(nr <= ARRAY_SIZE(poll_test.pipes));
+	for (i = 0; i < nr; i++) {
+		int *pipefd = poll_test.pipes[poll_test.nr_pipes];
+
+		cl_assert_equal_i(pipe(pipefd), 0);
+		poll_test.nr_pipes++;
+		fds[i].fd = pipefd[0];
+		fds[i].events = POLLIN;
+	}
+}
+
+static void create_socket_pair(void)
+{
+	struct sockaddr_in address = {
+		.sin_family = AF_INET,
+		.sin_addr.s_addr = htonl(INADDR_LOOPBACK),
+	};
+	socklen_t address_length = sizeof(address);
+
+	poll_test.listener = socket(AF_INET, SOCK_STREAM, 0);
+	cl_assert(poll_test.listener >= 0);
+	cl_assert_equal_i(bind(poll_test.listener,
+			       (struct sockaddr *)&address,
+			       sizeof(address)), 0);
+	cl_assert_equal_i(getsockname(
+				  (SOCKET)_get_osfhandle(poll_test.listener),
+				  (struct sockaddr *)&address,
+				  &address_length), 0);
+	cl_assert_equal_i(listen(poll_test.listener, 1), 0);
+
+	poll_test.sockets[0] = socket(AF_INET, SOCK_STREAM, 0);
+	cl_assert(poll_test.sockets[0] >= 0);
+	cl_assert_equal_i(connect(poll_test.sockets[0],
+				  (struct sockaddr *)&address,
+				  sizeof(address)), 0);
+
+	poll_test.sockets[1] = accept(poll_test.listener, NULL, NULL);
+	cl_assert(poll_test.sockets[1] >= 0);
+	close(poll_test.listener);
+	poll_test.listener = -1;
+}
+#endif
+
+void test_poll__initialize(void)
+{
+#ifdef GIT_WINDOWS_NATIVE
+	memset(&poll_test, 0, sizeof(poll_test));
+	poll_test.listener = -1;
+	poll_test.sockets[0] = -1;
+	poll_test.sockets[1] = -1;
+	poll_test.event = WSA_INVALID_EVENT;
+#endif
+}
+
+void test_poll__cleanup(void)
+{
+#ifdef GIT_WINDOWS_NATIVE
+	size_t i;
+
+	if (poll_test.event_selected && poll_test.sockets[0] >= 0)
+		WSAEventSelect(
+			(SOCKET)_get_osfhandle(poll_test.sockets[0]), NULL, 0);
+	if (poll_test.event != WSA_INVALID_EVENT)
+		WSACloseEvent(poll_test.event);
+	if (poll_test.listener >= 0)
+		close(poll_test.listener);
+	for (i = 0; i < ARRAY_SIZE(poll_test.sockets); i++)
+		if (poll_test.sockets[i] >= 0)
+			close(poll_test.sockets[i]);
+	for (i = 0; i < poll_test.nr_pipes; i++) {
+		close(poll_test.pipes[i][0]);
+		close(poll_test.pipes[i][1]);
+	}
+#endif
+}
+
+void test_poll__limit(void)
+{
+#ifdef GIT_WINDOWS_NATIVE
+	struct pollfd fds[POLL_MAX_DESCRIPTORS + 1] = { 0 };
+
+	open_pipes(fds, ARRAY_SIZE(fds));
+	cl_assert_equal_i(poll(fds, POLL_MAX_DESCRIPTORS, 0), 0);
+
+	errno = 0;
+	cl_assert_equal_i(poll(fds, ARRAY_SIZE(fds), 0), -1);
+	cl_assert_equal_i(errno, EINVAL);
+#else
+	cl_skip();
+#endif
+}
+
+void test_poll__sparse(void)
+{
+#ifdef GIT_WINDOWS_NATIVE
+	struct pollfd fds[2 * POLL_MAX_DESCRIPTORS + 1] = { 0 };
+	size_t i;
+
+	open_pipes(fds, POLL_MAX_DESCRIPTORS);
+	create_socket_pair();
+
+	for (i = POLL_MAX_DESCRIPTORS; i > 0; i--) {
+		fds[2 * i - 1] = fds[i - 1];
+		fds[2 * i - 2].fd = -1;
+	}
+	fds[2 * POLL_MAX_DESCRIPTORS].fd = poll_test.sockets[0];
+	fds[2 * POLL_MAX_DESCRIPTORS].events = POLLIN;
+
+	cl_assert_equal_i(poll(fds, ARRAY_SIZE(fds), 0), 0);
+#else
+	cl_skip();
+#endif
+}
+
+void test_poll__socket_cleanup(void)
+{
+#ifdef GIT_WINDOWS_NATIVE
+	struct pollfd fds[POLL_MAX_DESCRIPTORS + 2] = { 0 };
+	WSANETWORKEVENTS events;
+	SOCKET socket_handle;
+
+	create_socket_pair();
+	socket_handle = (SOCKET)_get_osfhandle(poll_test.sockets[0]);
+	poll_test.event = WSACreateEvent();
+	cl_assert(poll_test.event != WSA_INVALID_EVENT);
+	cl_assert_equal_i(WSAEventSelect(socket_handle, poll_test.event,
+					FD_READ), 0);
+	poll_test.event_selected = 1;
+
+	fds[0].fd = poll_test.sockets[0];
+	open_pipes(fds + 1, POLL_MAX_DESCRIPTORS + 1);
+
+	errno = 0;
+	cl_assert_equal_i(poll(fds, ARRAY_SIZE(fds), 0), -1);
+	cl_assert_equal_i(errno, EINVAL);
+
+	cl_assert_equal_i(send(
+				  (SOCKET)_get_osfhandle(poll_test.sockets[1]),
+				  "x", 1, 0), 1);
+	cl_assert_equal_i(WaitForSingleObject(poll_test.event, 1000),
+			  WAIT_OBJECT_0);
+	cl_assert_equal_i(WSAEnumNetworkEvents(socket_handle, poll_test.event,
+					      &events), 0);
+#else
+	cl_skip();
+#endif
+}


### PR DESCRIPTION
### Symptom

On Windows, `git checkout` and `git reset --hard` can abort with

```
*** stack smashing detected ***: terminated
```

and exit code `0xC0000409` (`STATUS_STACK_BUFFER_OVERRUN`). This is memory
corruption, not a normal error. The process dies before Trace2 writes its log,
so nothing shows up in a trace. A `.git/index.lock` is left behind.

It happens when `checkout.workers` is large, or when it is `0` (meaning "use
`online_cpus()`") on a machine with many logical processors.

### Mechanism

`gather_results_from_workers()` in `parallel-checkout.c` polls one pipe per
checkout worker:

```c
CALLOC_ARRAY(pfds, num_workers);
...
poll(pfds, num_workers, -1);
```

Windows has no native `poll()`, so `compat/poll/poll.c` emulates it with
`MsgWaitForMultipleObjects()`. It collects one handle per polled descriptor in a
fixed stack array:

```c
HANDLE h, handle_array[FD_SETSIZE + 2];   /* 64 + 2 = 66 entries */
...
handle_array[nhandles++] = h;             /* no bounds check */
...
handle_array[nhandles] = NULL;            /* sentinel, no bounds check */
```

`FD_SETSIZE` is the Winsock default 64, and nothing in the build overrides it.
`run_parallel_checkout()` clamps `num_workers` only against the number of files,
never against the array size or the Windows wait limit. A high worker count
therefore writes past the end of the array and smashes the stack.

Sockets are not involved: they are multiplexed onto a single event through
`WSAEventSelect`, so only non-socket descriptors consume a slot.

### Why 62, and where the limit lives

Two of the wait slots are never available for descriptors:

* `compat/poll` uses index 0 for its own event object.
* `QS_ALLINPUT` adds the thread message queue as an implicit wait object. The
  code confirms this, because it reports the message queue as
  `WAIT_OBJECT_0 + nhandles`.

So `nhandles + 1 <= MAXIMUM_WAIT_OBJECTS`, which gives at most
`MAXIMUM_WAIT_OBJECTS - 2` = 62 descriptors.

That value is defined once, as `POLL_MAX_DESCRIPTORS` in `compat/poll/poll.h`
alongside the `poll()` declaration it constrains, and both callers clamp against
it. `compat/posix.h` defines it to `INT_MAX` where a native `poll()` is used, so
the callers need no `#ifdef`.

### Why the array cannot simply be enlarged

`MAXIMUM_WAIT_OBJECTS` is a kernel limit, not a header convenience. Passing more
handles fails with `ERROR_INVALID_PARAMETER`. Growing the array would only turn
memory corruption into a functional failure. Support for more descriptors needs
a wait tree (helper threads each waiting on at most 62 handles) or completion
ports, which is out of scope here.

### Why it surfaced in 2.54

`parallel-checkout.c` and `compat/poll/poll.c` are unchanged between 2.53 and
2.54. Only `online_cpus()` changed:

| Version | API | Result |
| --- | --- | --- |
| 2.53 | `GetSystemInfo()` | processors in the current processor group only; a group holds at most 64 |
| 2.54+ | `GetLogicalProcessorInformationEx()` | true system-wide logical processor count |

The old API could never report more than 64, so the array always fit. That
ceiling was accidental, not deliberate. The `online_cpus()` change is correct and
must stay; it only exposed a latent bug.

### The changes

1. **`compat/poll: do not collect more handles than the wait supports`** — defines
   `POLL_MAX_DESCRIPTORS` (62) next to the `poll()` declaration and refuses to
   collect beyond it, returning `EINVAL` instead of appending past the end of the
   array. Two preprocessor assertions tie the constant to `MAXIMUM_WAIT_OBJECTS`
   and to the size of `handle_array`, so they cannot drift apart. `poll()` is now
   memory-safe for every input.

   The error path also undoes the `WSAEventSelect()` registrations made earlier in
   the same call. The loop that normally does that runs after the wait, so
   returning early would otherwise leave those sockets bound to `poll()`'s static
   event object and let later socket activity disturb an unrelated `poll()`.

   The limit is on the handles actually collected, **not** on `nfd`. Those are
   different: a descriptor only takes a handle when it is non-negative, is not a
   socket, and has no events pending yet. Callers routinely pass sparse arrays —
   `run_processes_parallel()` sizes its `pollfd` array to the configured job count
   and leaves the unused slots at `fd = -1`. An earlier revision of this PR
   rejected a large `nfd` instead, which broke `t7406` (`submodule.fetchJobs 67`,
   with only a handful of live pipes) with `fatal: poll: Invalid argument`.

   On platforms with a native `poll()` there is no such limit, so
   `POLL_MAX_DESCRIPTORS` is `INT_MAX` and callers can clamp against it
   unconditionally.

2. **`parallel-checkout: limit worker count to what poll() can wait on`** — clamps
   `num_workers` to `POLL_MAX_DESCRIPTORS` in `run_parallel_checkout()`, the single
   choke point before the workers start. The clamp is silent: fewer workers is
   correct, and a warning would fire on every checkout on a large machine. Also
   documents the cap, since `checkout.workers` was described as using one worker
   per logical core with no upper bound.

3. **`run-command: limit concurrent children to what poll() can wait on`** — the
   same limit applied to the other `poll()` fan-out. `pp_buffer_io()` polls one
   pipe per child sending output and a second per child being fed on stdin, and
   `fetch.parallel` / `submodule.fetchJobs` / `hook.jobs` all accept a high value
   (or `0`, meaning `online_cpus()`). Without this, change 1 would convert the old
   stack smash on that path into a hard `die_errno("poll")`. Only *concurrency* is
   limited; the configured maximum still sizes the arrays and is still reported by
   the trace, so the total number of tasks run is unchanged.

### Reproduction

No clone, no special hardware, about 10 seconds. A many-core machine is not
required: a positive `checkout.workers` is used verbatim, and `online_cpus()` is
consulted only when the value is `0` or less.

```powershell
# Use a NEW directory every attempt (see the note on timing below).
$repo = "C:\tmp\poll-repro-$(Get-Random)"
New-Item -ItemType Directory -Force -Path $repo | Out-Null
Set-Location $repo

git init -q -b main .
git config user.email repro@example.com
git config user.name  repro
git config checkout.workers 200
git config checkout.thresholdForParallelism 1

New-Item -ItemType Directory -Force -Path dir | Out-Null
1..400 | ForEach-Object { Set-Content -Path "dir\f$_.txt" -Value "base $_" -NoNewline }
git add -A; git commit -qm base

git checkout -qb other
1..400 | ForEach-Object { Set-Content -Path "dir\f$_.txt" -Value "changed $_ padding padding padding" -NoNewline }
git commit -qam changed

git checkout -q main
Write-Host "exit=$LASTEXITCODE"
```

Before the fix, on a 12-core machine, this crashed 3 out of 3 runs with
`exit=-1073740791` (`0xC0000409`) and left `.git/index.lock` behind. After the
fix it exits 0 on 3 out of 3 runs, with the files correctly updated. A
`checkout.workers 16` checkout still works, as before.

### The crash is not deterministic

`poll()` only appends a descriptor when the worker's pipe has no data ready yet,
so `nhandles` reflects the workers pending at that instant, not the workers
spawned. On warm cache, pipes answer immediately and few workers stay pending.
Measured before the fix:

| workers | result |
| --- | --- |
| 16, 64, 65, 70, 72, 74, 76, 78 | pass |
| 80 | crashed once, then passed 3 times |
| 200, repeated checkouts in the same repo | passed 4 times |
| 200, fresh repository each run | crashed 3 of 3 |

The first out-of-bounds write happens at 65 descriptors by arithmetic, but the
corruption does not reliably reach the stack cookie until well past that. The
corruption is real from 65 onward whether or not it crashes. That is why the fix
targets the contract (62), not the observed crash point.

For the same reason, the added test asserts the **effective worker count** rather
than a crash. `test_checkout_workers` counts the workers actually spawned from a
TRACE2 log, so the test verifies the clamp took effect (62) instead of merely
checking that the checkout did not crash. It is `MINGW`-gated, because that is the
only platform where the cap applies.

### Testing

* New test in `t/t2080-parallel-checkout-basics.sh`. `t2080`, `t2081`, `t2082`,
  `t0061`, `t5526` and `t7406` all pass on Windows.
* Manual verification with the reproduction above, plus a low-worker-count
  regression check.

### Workaround for affected users

```
git config checkout.workers 16
```

Any value at or below 62 avoids the overflow. No downgrade is needed.
